### PR TITLE
feat: v0.7.1 — multi-token AND filter for TableState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.1] — 2026-03-14
+
+### Changed
+- **Multi-token table filter**: `TableState::set_filter` now splits input by whitespace and matches all tokens (AND logic) across any cell in a row — e.g. `"ERROR deploy"` matches rows where one cell contains "error" and another contains "deploy"
+
 ## [0.7.0] — 2026-03-14
 
 ### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "superlighttui"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -567,16 +567,21 @@ impl TableState {
     fn rebuild_view(&mut self) {
         let mut indices: Vec<usize> = (0..self.rows.len()).collect();
 
-        if !self.filter.is_empty() {
-            let needle = self.filter.to_lowercase();
+        let tokens: Vec<String> = self
+            .filter
+            .split_whitespace()
+            .map(|t| t.to_lowercase())
+            .collect();
+        if !tokens.is_empty() {
             indices.retain(|&idx| {
-                self.rows
-                    .get(idx)
-                    .map(|row| {
-                        row.iter()
-                            .any(|cell| cell.to_lowercase().contains(needle.as_str()))
-                    })
-                    .unwrap_or(false)
+                let row = match self.rows.get(idx) {
+                    Some(r) => r,
+                    None => return false,
+                };
+                tokens.iter().all(|token| {
+                    row.iter()
+                        .any(|cell| cell.to_lowercase().contains(token.as_str()))
+                })
             });
         }
 

--- a/tests/widgets.rs
+++ b/tests/widgets.rs
@@ -339,6 +339,54 @@ fn table_filter_no_match() {
 }
 
 #[test]
+fn table_filter_multi_token_cross_column() {
+    let mut table = TableState::new(
+        vec!["Level", "Message"],
+        vec![
+            vec!["ERROR", "deploy failed"],
+            vec!["INFO", "deploy success"],
+            vec!["ERROR", "health check ok"],
+        ],
+    );
+    table.set_filter("ERROR deploy");
+    assert_eq!(table.visible_indices(), &[0]);
+}
+
+#[test]
+fn table_filter_multi_token_same_column() {
+    let mut table = TableState::new(
+        vec!["Name", "City"],
+        vec![vec!["Alice", "Seoul"], vec!["Bob", "Busan"]],
+    );
+    table.set_filter("Ali ce");
+    assert_eq!(table.visible_indices(), &[0]);
+}
+
+#[test]
+fn table_filter_single_token_unchanged() {
+    let mut table = TableState::new(
+        vec!["Name", "City"],
+        vec![
+            vec!["Alice", "Seoul"],
+            vec!["Bob", "Busan"],
+            vec!["Lila", "Jeju"],
+        ],
+    );
+    table.set_filter("li");
+    assert_eq!(table.visible_indices(), &[0, 2]);
+}
+
+#[test]
+fn table_filter_whitespace_only_shows_all() {
+    let mut table = TableState::new(
+        vec!["Name", "City"],
+        vec![vec!["Alice", "Seoul"], vec!["Bob", "Busan"]],
+    );
+    table.set_filter("   ");
+    assert_eq!(table.visible_indices(), &[0, 1]);
+}
+
+#[test]
 fn table_pagination_basic() {
     let mut table = TableState::new(
         vec!["Name", "Value"],


### PR DESCRIPTION
## Summary

- `TableState::set_filter` now splits input by whitespace and requires **all tokens** to match across any cell in the same row (AND logic)
- e.g. `"ERROR deploy"` matches rows where one cell contains "error" AND another contains "deploy"
- Single-token input and empty/whitespace-only input behave identically to v0.7.0 — **no breaking changes**

## Changes

| File | What |
|------|------|
| `src/widgets.rs` | `rebuild_view` filter: single needle → multi-token `split_whitespace` + `all()` |
| `tests/widgets.rs` | +4 tests: cross-column, same-column, single-token compat, whitespace-only |
| `Cargo.toml` | 0.7.0 → 0.7.1 |
| `CHANGELOG.md` | v0.7.1 entry |