### PR TITLE
feat: v0.8.2 — IME cursor support + text_input horizontal scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.8.2] — 2026-03-15
+
+### Features
+- **IME cursor always visible**: text_input/textarea cursor no longer blinks — always shown when focused, enabling OS IME popup to anchor correctly for Korean/CJK input
+- **text_input horizontal scroll**: long text scrolls within container bounds instead of overflowing — CJK double-width aware via unicode-width
+
+### Added
+- `demo_ime.rs` example for Korean/CJK input testing
+
 ## [0.8.1] — 2026-03-15
 
 ### Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "superlighttui"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/examples/demo_ime.rs
+++ b/examples/demo_ime.rs
@@ -1,4 +1,4 @@
-use slt::{Border, Context, KeyCode, RunConfig};
+use slt::{Context, KeyCode, RunConfig};
 
 fn main() -> std::io::Result<()> {
     let mut name = slt::TextInputState::with_placeholder("이름을 입력하세요");
@@ -31,6 +31,7 @@ fn main() -> std::io::Result<()> {
             }
 
             let theme = *ui.theme();
+            let term_h = ui.height();
 
             ui.col(|ui| {
                 ui.container().grow(1).gap(1).p(1).col(|ui| {
@@ -40,18 +41,20 @@ fn main() -> std::io::Result<()> {
 
                     ui.row_gap(2, |ui| {
                         ui.container().grow(1).gap(1).col(|ui| {
-                            ui.text("Text Input").bold();
+                            ui.text("Name").bold();
                             ui.text_input(&mut name);
                             if !name.value.is_empty() {
                                 ui.line(|ui| {
-                                    ui.text("입력값: ");
+                                    ui.text("→ ");
                                     ui.text(&name.value).fg(theme.accent);
                                     ui.text(format!(" ({} chars)", name.value.chars().count()))
                                         .dim();
                                 });
                             }
+                        });
 
-                            ui.text("Search (multi-token filter)").bold();
+                        ui.container().grow(1).gap(1).col(|ui| {
+                            ui.text("Search").bold();
                             ui.text_input(&mut search);
 
                             let query = search.value.to_lowercase();
@@ -64,36 +67,20 @@ fn main() -> std::io::Result<()> {
                                 })
                                 .map(|s| s.to_string())
                                 .collect();
-
-                            ui.bordered(Border::Rounded).col(|ui| {
-                                if results.is_empty() {
-                                    ui.text("검색 결과 없음").dim();
-                                } else {
-                                    for item in &results {
-                                        ui.text(item);
-                                    }
-                                }
-                            });
                             ui.text(format!("{}/{} items", results.len(), items.len()))
                                 .dim();
                         });
-
-                        ui.container().grow(1).gap(1).col(|ui| {
-                            ui.text("Textarea (auto word-wrap)").bold();
-                            let half_w = ui.width() / 2;
-                            message.wrap_width = Some(half_w.saturating_sub(4));
-                            ui.textarea(&mut message, 8);
-                            let total: usize =
-                                message.lines.iter().map(|l| l.chars().count()).sum();
-                            ui.text(format!(
-                                "{} lines, {} chars, wrap@{}",
-                                message.lines.len(),
-                                total,
-                                half_w.saturating_sub(4),
-                            ))
-                            .dim();
-                        });
                     });
+
+                    ui.separator();
+
+                    ui.text("Message").bold();
+                    let rows = term_h.saturating_sub(16).max(5);
+                    ui.textarea(&mut message, rows);
+
+                    let total: usize = message.lines.iter().map(|l| l.chars().count()).sum();
+                    ui.text(format!("{} lines, {} chars", message.lines.len(), total,))
+                        .dim();
                 });
 
                 ui.help(&[

--- a/src/context.rs
+++ b/src/context.rs
@@ -2816,6 +2816,7 @@ impl Context {
             }
         }
 
+        let visible_width = self.area_width.saturating_sub(4) as usize;
         let input_text = if state.value.is_empty() {
             if state.placeholder.len() > 100 {
                 slt_warn(
@@ -2828,22 +2829,48 @@ impl Context {
             }
             ph
         } else {
+            let chars: Vec<char> = state.value.chars().collect();
+            let display_chars: Vec<char> = if state.masked {
+                vec!['•'; chars.len()]
+            } else {
+                chars.clone()
+            };
+
+            let cursor_display_pos: usize = display_chars[..state.cursor.min(display_chars.len())]
+                .iter()
+                .map(|c| UnicodeWidthChar::width(*c).unwrap_or(1))
+                .sum();
+
+            let scroll_offset = if cursor_display_pos >= visible_width {
+                cursor_display_pos - visible_width + 1
+            } else {
+                0
+            };
+
             let mut rendered = String::new();
-            for (idx, ch) in state.value.chars().enumerate() {
+            let mut current_width: usize = 0;
+            for (idx, &ch) in display_chars.iter().enumerate() {
+                let cw = UnicodeWidthChar::width(ch).unwrap_or(1);
+                if current_width + cw <= scroll_offset {
+                    current_width += cw;
+                    continue;
+                }
+                if current_width - scroll_offset >= visible_width {
+                    break;
+                }
                 if focused && idx == state.cursor {
                     rendered.push('▎');
                 }
-                rendered.push(if state.masked { '•' } else { ch });
+                rendered.push(ch);
+                current_width += cw;
             }
-            if focused && state.cursor >= state.value.chars().count() {
+            if focused && state.cursor >= display_chars.len() {
                 rendered.push('▎');
             }
             rendered
         };
         let input_style = if state.value.is_empty() && !focused {
             Style::new().dim().fg(self.theme.text_dim)
-        } else if state.value.is_empty() {
-            Style::new().fg(self.theme.text)
         } else {
             Style::new().fg(self.theme.text)
         };
@@ -3179,15 +3206,15 @@ impl Context {
                 Style::new().fg(self.theme.text)
             };
 
-            if is_cursor_line {
+            if is_cursor_line && focused {
                 rendered.clear();
                 for (idx, ch) in seg_text.chars().enumerate() {
-                    if focused && idx == cursor_vcol {
+                    if idx == cursor_vcol {
                         rendered.push('▎');
                     }
                     rendered.push(ch);
                 }
-                if focused && cursor_vcol >= seg_text.chars().count() {
+                if cursor_vcol >= seg_text.chars().count() {
                     rendered.push('▎');
                 }
                 style = Style::new().fg(self.theme.text);


### PR DESCRIPTION
## Summary

- **IME cursor always visible**: cursor no longer blinks when focused — OS IME popup anchors correctly for Korean/CJK
- **text_input horizontal scroll**: long text scrolls within container bounds (CJK double-width aware)
- **demo_ime.rs**: Korean/CJK input testing example