### PR TITLE
feat: v0.8.3 — ContainerStyle, markdown CJK fix, rustdoc examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.8.3] — 2026-03-15
+
+### Features
+- **ContainerStyle**: reusable composable style recipes — `const CARD: ContainerStyle = ContainerStyle::new().border(Border::Rounded).p(1)` + `ui.container().apply(&CARD)`
+- **Rustdoc examples**: added `/// # Example` sections to `modal`, `group`, `use_state`, `use_memo`, `apply`
+
+### Bug Fixes
+- **Markdown Korean panic**: `parse_inline_segments` used byte indices on char-indexed positions — panicked on multi-byte CJK text (`**bold**` with Korean). Now uses char-based string operations
+- **Example warnings**: removed unused variables and dead code in demo, demo_cli
+
 ## [0.8.2] — 2026-03-15
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "superlighttui"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "criterion",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "superlighttui"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1004,7 +1004,7 @@ fn render_v080(
     v8_anim_done: &mut bool,
     tick: u64,
 ) {
-    let theme = *ui.theme();
+    let _theme = *ui.theme();
     section(ui, "v0.8.0 FEATURES");
 
     section(ui, "DARK MODE");
@@ -1099,7 +1099,7 @@ fn render_v080(
         ];
         let idx_state = ui.use_state(|| 0usize);
         let idx = *idx_state.get(ui);
-        let (name, ref custom) = presets[idx % presets.len()];
+        let (_name, ref custom) = presets[idx % presets.len()];
 
         ui.row_gap(1, |ui| {
             for (i, (label, _)) in presets.iter().enumerate() {

--- a/examples/demo_cli.rs
+++ b/examples/demo_cli.rs
@@ -347,7 +347,3 @@ fn main() -> std::io::Result<()> {
         },
     )
 }
-
-fn search_focused(search: &TextInputState) -> bool {
-    !search.value.is_empty()
-}

--- a/src/context.rs
+++ b/src/context.rs
@@ -2397,6 +2397,13 @@ impl Context {
     }
 
     /// Render content in a modal overlay with dimmed background.
+    ///
+    /// ```ignore
+    /// ui.modal(|ui| {
+    ///     ui.text("Are you sure?");
+    ///     if ui.button("OK") { show = false; }
+    /// });
+    /// ```
     pub fn modal(&mut self, f: impl FnOnce(&mut Context)) {
         self.commands.push(Command::BeginOverlay { modal: true });
         self.overlay_depth += 1;
@@ -2418,6 +2425,12 @@ impl Context {
     }
 
     /// Create a named group container for shared hover/focus styling.
+    ///
+    /// ```ignore
+    /// ui.group("card").border(Border::Rounded)
+    ///     .group_hover_bg(Color::Indexed(238))
+    ///     .col(|ui| { ui.text("Hover anywhere"); });
+    /// ```
     pub fn group(&mut self, name: &str) -> ContainerBuilder<'_> {
         self.group_count = self.group_count.saturating_add(1);
         self.group_stack.push(name.to_string());
@@ -5944,12 +5957,15 @@ impl Context {
         let mut i = 0;
         while i < chars.len() {
             if i + 1 < chars.len() && chars[i] == '*' && chars[i + 1] == '*' {
-                if let Some(end) = text[i + 2..].find("**") {
+                let rest: String = chars[i + 2..].iter().collect();
+                if let Some(end) = rest.find("**") {
                     if !current.is_empty() {
                         segments.push((std::mem::take(&mut current), base));
                     }
-                    segments.push((text[i + 2..i + 2 + end].to_string(), bold));
-                    i += 4 + end;
+                    let inner: String = rest[..end].to_string();
+                    let char_count = inner.chars().count();
+                    segments.push((inner, bold));
+                    i += 2 + char_count + 2;
                     continue;
                 }
             }
@@ -5957,22 +5973,28 @@ impl Context {
                 && (i + 1 >= chars.len() || chars[i + 1] != '*')
                 && (i == 0 || chars[i - 1] != '*')
             {
-                if let Some(end) = text[i + 1..].find('*') {
+                let rest: String = chars[i + 1..].iter().collect();
+                if let Some(end) = rest.find('*') {
                     if !current.is_empty() {
                         segments.push((std::mem::take(&mut current), base));
                     }
-                    segments.push((text[i + 1..i + 1 + end].to_string(), base.italic()));
-                    i += 2 + end;
+                    let inner: String = rest[..end].to_string();
+                    let char_count = inner.chars().count();
+                    segments.push((inner, base.italic()));
+                    i += 1 + char_count + 1;
                     continue;
                 }
             }
             if chars[i] == '`' {
-                if let Some(end) = text[i + 1..].find('`') {
+                let rest: String = chars[i + 1..].iter().collect();
+                if let Some(end) = rest.find('`') {
                     if !current.is_empty() {
                         segments.push((std::mem::take(&mut current), base));
                     }
-                    segments.push((text[i + 1..i + 1 + end].to_string(), code));
-                    i += 2 + end;
+                    let inner: String = rest[..end].to_string();
+                    let char_count = inner.chars().count();
+                    segments.push((inner, code));
+                    i += 1 + char_count + 1;
                     continue;
                 }
             }


### PR DESCRIPTION
## Summary

- **ContainerStyle + apply()**: reusable composable style recipes — define `const CARD` once, `apply(&CARD)` anywhere
- **Fix**: markdown `parse_inline_segments` panicked on Korean text (byte index on multi-byte chars)
- **Rustdoc**: examples added to `modal`, `group`, `use_state`, `use_memo`, `apply`
- **Warnings**: all example warnings fixed (demo, demo_cli)
- **README**: Style Recipes section added