### PR TITLE
fix: v0.8.4 — tabs crash, State<T> Copy, ContainerStyle Copy, docs.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.8.4] — 2026-03-15
+
+### Bug Fixes
+- **Tabs empty labels crash**: guard modulo-by-zero when `TabsState::new(vec![])` — no longer panics
+- **Sparkline div-by-zero**: already guarded (verified, no change needed)
+
+### Improvements
+- **`State<T>`**: now `Copy + Clone + Debug + PartialEq + Eq` — pass by value, no `&` needed
+- **`ContainerStyle`**: now `Copy` — eliminates unnecessary `.clone()` calls
+- **`ContainerStyle`**: added `min_h()`, `max_h()`, `w_pct()`, `h_pct()` builder methods
+- **`full` feature flag**: `features = ["full"]` enables async + serde + image
+- **docs.rs metadata**: `all-features = true` — async/serde/image APIs now visible on docs.rs
+
 ## [0.8.3] — 2026-03-15
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "superlighttui"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
  "criterion",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "superlighttui"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"
@@ -31,6 +31,11 @@ insta = "1"
 async = ["dep:tokio"]
 serde = ["dep:serde"]
 image = ["dep:image"]
+full = ["async", "serde", "image"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [[example]]
 name = "hello"

--- a/src/context.rs
+++ b/src/context.rs
@@ -33,6 +33,7 @@ fn slt_warn(msg: &str) {
 fn slt_warn(_msg: &str) {}
 
 /// Handle to state created by `use_state()`. Access via `.get(ui)` / `.get_mut(ui)`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct State<T> {
     idx: usize,
     _marker: std::marker::PhantomData<T>,
@@ -4716,7 +4717,9 @@ impl Context {
                             consumed_indices.push(i);
                         }
                         KeyCode::Right => {
-                            state.selected = (state.selected + 1) % state.labels.len();
+                            if !state.labels.is_empty() {
+                                state.selected = (state.selected + 1) % state.labels.len();
+                            }
                             consumed_indices.push(i);
                         }
                         _ => {}

--- a/src/style.rs
+++ b/src/style.rs
@@ -1220,7 +1220,7 @@ impl Style {
 /// ui.container().apply(&CARD).col(|ui| { ... });
 /// ui.container().apply(&CARD).apply(&DANGER).col(|ui| { ... });
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct ContainerStyle {
     pub border: Option<Border>,
     pub border_sides: Option<BorderSides>,
@@ -1400,6 +1400,30 @@ impl ContainerStyle {
     /// Set main-axis justification.
     pub const fn justify(mut self, value: Justify) -> Self {
         self.justify = Some(value);
+        self
+    }
+
+    /// Set minimum height.
+    pub const fn min_h(mut self, value: u32) -> Self {
+        self.min_h = Some(value);
+        self
+    }
+
+    /// Set maximum height.
+    pub const fn max_h(mut self, value: u32) -> Self {
+        self.max_h = Some(value);
+        self
+    }
+
+    /// Set width as percentage of parent (1-100).
+    pub const fn w_pct(mut self, value: u8) -> Self {
+        self.w_pct = Some(value);
+        self
+    }
+
+    /// Set height as percentage of parent (1-100).
+    pub const fn h_pct(mut self, value: u8) -> Self {
+        self.h_pct = Some(value);
         self
     }
 }


### PR DESCRIPTION
## Summary
- **Fix**: Tabs empty labels no longer panics (modulo-by-zero guard)
- **State<T>**: now Copy + Clone + Debug + PartialEq + Eq
- **ContainerStyle**: now Copy + added min_h/max_h/w_pct/h_pct methods
- **full feature**: `features = ["full"]` enables async + serde + image
- **docs.rs**: all-features = true — async/serde/image APIs visible