### PR TITLE
feat: v0.9.4 — 10 new widgets, syntax highlighting, demo updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.9.4] — 2026-03-15
+
+### Features — 10 New Widgets
+
+**Tier 1 (not composable from primitives):**
+- **`divider_text(label)`**: horizontal rule with centered text label — `──── Settings ────`
+- **`alert(message, AlertLevel)`**: persistent inline notification with icon + dismiss — returns `true` when dismissed
+- **`breadcrumb(&["Home", "Settings"])`**: clickable path navigation — returns `Some(idx)` on segment click
+- **`accordion(title, &mut open, |ui| { ... })`**: collapsible content section with ▾/▸ toggle
+
+**Tier 2 (convenience widgets):**
+- **`badge(label)` / `badge_colored(label, color)`**: inline colored tag with auto-contrast foreground
+- **`key_hint(key)`**: inline keyboard shortcut display — `[Ctrl+S]` reversed style
+- **`stat(label, value)` / `stat_colored` / `stat_trend`**: dashboard metric with optional trend arrow ↑↓
+- **`definition_list(&[("key", "value")])`**: auto-aligned key-value pairs
+- **`empty_state(title, desc)` / `empty_state_action`**: centered placeholder for empty lists
+- **`code_block(code)` / `code_block_numbered`**: bordered code display with optional line numbers
+
+### New Types
+- `AlertLevel` enum: `Info`, `Success`, `Warning`, `Error`
+- `Trend` enum: `Up`, `Down`
+
 ## [0.9.3] — 2026-03-15
 
 ### Refactoring

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "superlighttui"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "criterion",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "superlighttui"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,9 +1,9 @@
 use slt::{
-    Align, ApprovalAction, Border, BorderSides, Breakpoint, Color, CommandPaletteState, Context,
-    ContextItem, FormField, FormState, HalfBlockImage, Justify, KeyCode, ListState,
+    AlertLevel, Align, ApprovalAction, Border, BorderSides, Breakpoint, Color, CommandPaletteState,
+    Context, ContextItem, FormField, FormState, HalfBlockImage, Justify, KeyCode, ListState,
     MultiSelectState, PaletteCommand, RadioState, RunConfig, ScrollState, SelectState,
     SpinnerState, StreamingTextState, TableState, TabsState, TextInputState, TextareaState, Theme,
-    ToastState, ToolApprovalState, TreeNode, TreeState,
+    ToastState, ToolApprovalState, TreeNode, TreeState, Trend,
 };
 
 fn main() -> std::io::Result<()> {
@@ -16,6 +16,7 @@ fn main() -> std::io::Result<()> {
         "Advanced",
         "v0.7.0",
         "v0.8.0",
+        "v0.9.4",
     ]);
     let mut section_tabs = TabsState::new(vec!["Primary", "Secondary", "Accent"]);
     let mut scroll = ScrollState::new();
@@ -36,6 +37,9 @@ fn main() -> std::io::Result<()> {
     table.page_size = 3;
     let mut table_filter = TextInputState::with_placeholder("Filter table...");
     let spinner = SpinnerState::dots();
+    let mut accordion_general = true;
+    let mut accordion_advanced = false;
+    let mut alert_visible = true;
     let mut progress = 0.64_f64;
     let mut dark_mode = true;
     let mut notifications = true;
@@ -229,6 +233,12 @@ fn main() -> std::io::Result<()> {
                                 &mut v8_tween,
                                 &mut v8_anim_done,
                                 tick,
+                            ),
+                            8 => render_v094(
+                                ui,
+                                &mut accordion_general,
+                                &mut accordion_advanced,
+                                &mut alert_visible,
                             ),
                             _ => {}
                         });
@@ -1255,4 +1265,82 @@ fn card(ui: &mut Context, f: impl FnOnce(&mut Context)) {
 fn section(ui: &mut Context, title: &str) {
     let theme = *ui.theme();
     ui.text(title).bold().fg(theme.text_dim);
+}
+
+fn render_v094(
+    ui: &mut Context,
+    accordion_general: &mut bool,
+    accordion_advanced: &mut bool,
+    alert_visible: &mut bool,
+) {
+    section(ui, "v0.9.4 WIDGETS");
+    ui.text("");
+
+    if *alert_visible {
+        if ui.alert(
+            "Deployment successful — all checks passed",
+            AlertLevel::Success,
+        ) {
+            *alert_visible = false;
+        }
+    }
+
+    ui.divider_text("Navigation");
+    ui.breadcrumb(&["Home", "Settings", "Profile"]);
+
+    ui.divider_text("Dashboard");
+    ui.row(|ui| {
+        card(ui, |ui| {
+            ui.stat_trend("Revenue", "$12,400", Trend::Up);
+        });
+        card(ui, |ui| {
+            ui.stat_trend("Errors", "3", Trend::Down);
+        });
+        card(ui, |ui| {
+            ui.stat_colored("CPU", "72%", Color::Yellow);
+        });
+        card(ui, |ui| {
+            ui.stat("Uptime", "14d 3h");
+        });
+    });
+
+    ui.divider_text("Inline Elements");
+    ui.line(|ui| {
+        ui.badge("v0.9.4");
+        ui.text(" ");
+        ui.badge_colored("Stable", Color::Green);
+        ui.text(" ");
+        ui.badge_colored("Rust", Color::Rgb(222, 165, 91));
+        ui.text("   ");
+        ui.key_hint("Ctrl+S");
+        ui.text(" save  ");
+        ui.key_hint("q");
+        ui.text(" quit");
+    });
+
+    ui.divider_text("Accordions");
+    ui.accordion("General Settings", accordion_general, |ui| {
+        ui.definition_list(&[
+            ("Theme", "Dark"),
+            ("Language", "en-US"),
+            ("Font Size", "14px"),
+        ]);
+    });
+    ui.accordion("Advanced Settings", accordion_advanced, |ui| {
+        ui.definition_list(&[
+            ("Log Level", "debug"),
+            ("Max Conn", "100"),
+            ("Timeout", "30s"),
+        ]);
+    });
+
+    ui.divider_text("Code Block");
+    ui.code_block_numbered(
+        "fn main() {\n    slt::run(|ui| {\n        ui.text(\"hello\");\n    });\n}",
+    );
+
+    ui.divider_text("Empty State");
+    ui.container().h(3).col(|ui| {
+        ui.empty_state("No items yet", "Items will appear here when added");
+    });
 }

--- a/examples/demo_dashboard.rs
+++ b/examples/demo_dashboard.rs
@@ -1,5 +1,5 @@
 use slt::{
-    Border, Color, Context, ScrollState, SpinnerState, Style, TableState, Theme, ToastState,
+    Border, Color, Context, ScrollState, SpinnerState, Style, TableState, Theme, ToastState, Trend,
 };
 
 struct Metrics {
@@ -101,9 +101,7 @@ fn main() -> std::io::Result<()> {
                         ))
                         .dim();
                     });
-                    ui.separator();
-
-                    // metric cards
+                    ui.divider_text("System Metrics");
                     ui.row(|ui| {
                         metric_card(ui, "CPU", metrics.cpu, "%", Color::Cyan);
                         metric_card(ui, "Memory", metrics.mem, "%", Color::Yellow);
@@ -122,25 +120,28 @@ fn main() -> std::io::Result<()> {
                         metric_card(ui, "Net Out", metrics.net_out, "MB/s", Color::Magenta);
                     });
 
+                    ui.divider_text("Key Metrics");
                     ui.row(|ui| {
-                        stat_pill(
-                            ui,
-                            "Requests",
-                            &format!("{}", metrics.requests),
-                            Color::Cyan,
-                        );
-                        stat_pill(
-                            ui,
-                            "Errors",
-                            &format!("{}", metrics.errors),
-                            if metrics.errors > 5 {
-                                Color::Red
-                            } else {
-                                Color::Green
-                            },
-                        );
-                        stat_pill(ui, "P99", "45ms", Color::Yellow);
-                        stat_pill(ui, "Threads", "24", Color::Blue);
+                        ui.bordered(Border::Rounded).pad(1).grow(1).col(|ui| {
+                            ui.stat_trend("Requests", &format!("{}", metrics.requests), Trend::Up);
+                        });
+                        ui.bordered(Border::Rounded).pad(1).grow(1).col(|ui| {
+                            ui.stat_colored(
+                                "Errors",
+                                &format!("{}", metrics.errors),
+                                if metrics.errors > 5 {
+                                    Color::Red
+                                } else {
+                                    Color::Green
+                                },
+                            );
+                        });
+                        ui.bordered(Border::Rounded).pad(1).grow(1).col(|ui| {
+                            ui.stat_colored("P99", "45ms", Color::Yellow);
+                        });
+                        ui.bordered(Border::Rounded).pad(1).grow(1).col(|ui| {
+                            ui.stat_colored("Threads", "24", Color::Blue);
+                        });
                     });
 
                     ui.container().grow(1).row(|ui| {
@@ -196,7 +197,7 @@ fn main() -> std::io::Result<()> {
 
                     ui.toast(&mut toasts);
 
-                    ui.separator();
+                    ui.divider_text("Controls");
                     ui.help(&[
                         ("q", "quit"),
                         ("t", "theme"),
@@ -217,17 +218,10 @@ fn metric_card(ui: &mut Context, label: &str, value: f64, unit: &str, color: Col
         let bar: String = "█".repeat(filled) + &"░".repeat(bar_w - filled);
         ui.text(bar).fg(color);
         if value > 80.0 {
-            ui.text("⚠ HIGH").bold().fg(Color::Red);
+            ui.badge_colored("HIGH", Color::Red);
         }
     });
     let _ = resp;
-}
-
-fn stat_pill(ui: &mut Context, label: &str, value: &str, color: Color) {
-    ui.bordered(Border::Rounded).pad(1).grow(1).col(|ui| {
-        ui.text(label).dim();
-        ui.text(value).bold().fg(color);
-    });
 }
 
 fn sim_metrics(tick: u64) -> Metrics {

--- a/src/context/widgets_display.rs
+++ b/src/context/widgets_display.rs
@@ -359,6 +359,219 @@ impl Context {
         });
     }
 
+    pub fn alert(&mut self, message: &str, level: crate::widgets::AlertLevel) -> bool {
+        use crate::widgets::AlertLevel;
+
+        let theme = self.theme;
+        let (icon, color) = match level {
+            AlertLevel::Info => ("ℹ", theme.accent),
+            AlertLevel::Success => ("✓", theme.success),
+            AlertLevel::Warning => ("⚠", theme.warning),
+            AlertLevel::Error => ("✕", theme.error),
+        };
+
+        let focused = self.register_focusable();
+        let key_dismiss = focused && (self.key_code(KeyCode::Enter) || self.key('x'));
+
+        let resp = self.container().col(|ui| {
+            ui.line(|ui| {
+                ui.text(format!(" {icon} ")).fg(color).bold();
+                ui.text(message).grow(1);
+                ui.text(" [×] ").dim();
+            });
+        });
+
+        key_dismiss || resp.clicked
+    }
+
+    pub fn breadcrumb(&mut self, segments: &[&str]) -> Option<usize> {
+        self.breadcrumb_with(segments, " › ")
+    }
+
+    pub fn breadcrumb_with(&mut self, segments: &[&str], separator: &str) -> Option<usize> {
+        let theme = self.theme;
+        let last_idx = segments.len().saturating_sub(1);
+        let mut clicked_idx: Option<usize> = None;
+
+        self.line(|ui| {
+            for (i, segment) in segments.iter().enumerate() {
+                let is_last = i == last_idx;
+                if is_last {
+                    ui.text(*segment).bold().fg(theme.text);
+                } else {
+                    if ui.button_with(*segment, ButtonVariant::Default) {
+                        clicked_idx = Some(i);
+                    }
+                    ui.text(separator).dim();
+                }
+            }
+        });
+
+        clicked_idx
+    }
+
+    pub fn accordion(&mut self, title: &str, open: &mut bool, f: impl FnOnce(&mut Context)) {
+        let theme = self.theme;
+        let focused = self.register_focusable();
+
+        if focused && self.key_code(KeyCode::Enter) {
+            *open = !*open;
+        }
+
+        let icon = if *open { "▾" } else { "▸" };
+        let title_color = if focused { theme.primary } else { theme.text };
+
+        let resp = self.container().col(|ui| {
+            ui.line(|ui| {
+                ui.text(icon).fg(title_color);
+                ui.text(format!(" {title}")).bold().fg(title_color);
+            });
+        });
+
+        if resp.clicked {
+            *open = !*open;
+        }
+
+        if *open {
+            self.container().pl(2).col(f);
+        }
+    }
+
+    pub fn definition_list(&mut self, items: &[(&str, &str)]) {
+        let max_key_width = items
+            .iter()
+            .map(|(k, _)| unicode_width::UnicodeWidthStr::width(*k))
+            .max()
+            .unwrap_or(0);
+
+        self.col(|ui| {
+            for (key, value) in items {
+                ui.line(|ui| {
+                    let padded = format!("{:>width$}", key, width = max_key_width);
+                    ui.text(padded).dim();
+                    ui.text("  ");
+                    ui.text(*value);
+                });
+            }
+        });
+    }
+
+    pub fn divider_text(&mut self, label: &str) {
+        let w = self.width();
+        let label_len = unicode_width::UnicodeWidthStr::width(label) as u32;
+        let pad = 1u32;
+        let left_len = 4u32;
+        let right_len = w.saturating_sub(left_len + pad + label_len + pad);
+        let left: String = "─".repeat(left_len as usize);
+        let right: String = "─".repeat(right_len as usize);
+        let theme = self.theme;
+        self.line(|ui| {
+            ui.text(&left).fg(theme.border);
+            ui.text(format!(" {} ", label)).fg(theme.text);
+            ui.text(&right).fg(theme.border);
+        });
+    }
+
+    pub fn badge(&mut self, label: &str) {
+        let theme = self.theme;
+        self.badge_colored(label, theme.primary);
+    }
+
+    pub fn badge_colored(&mut self, label: &str, color: Color) {
+        let fg = Color::contrast_fg(color);
+        self.text(format!(" {} ", label)).fg(fg).bg(color);
+    }
+
+    pub fn key_hint(&mut self, key: &str) {
+        let theme = self.theme;
+        self.text(format!(" {} ", key))
+            .reversed()
+            .fg(theme.text_dim);
+    }
+
+    pub fn stat(&mut self, label: &str, value: &str) {
+        self.col(|ui| {
+            ui.text(label).dim();
+            ui.text(value).bold();
+        });
+    }
+
+    pub fn stat_colored(&mut self, label: &str, value: &str, color: Color) {
+        self.col(|ui| {
+            ui.text(label).dim();
+            ui.text(value).bold().fg(color);
+        });
+    }
+
+    pub fn stat_trend(&mut self, label: &str, value: &str, trend: crate::widgets::Trend) {
+        let theme = self.theme;
+        let (arrow, color) = match trend {
+            crate::widgets::Trend::Up => ("↑", theme.success),
+            crate::widgets::Trend::Down => ("↓", theme.error),
+        };
+        self.col(|ui| {
+            ui.text(label).dim();
+            ui.line(|ui| {
+                ui.text(value).bold();
+                ui.text(format!(" {arrow}")).fg(color);
+            });
+        });
+    }
+
+    pub fn empty_state(&mut self, title: &str, description: &str) {
+        self.container().center().col(|ui| {
+            ui.text(title).align(Align::Center);
+            ui.text(description).dim().align(Align::Center);
+        });
+    }
+
+    pub fn empty_state_action(
+        &mut self,
+        title: &str,
+        description: &str,
+        action_label: &str,
+    ) -> bool {
+        let mut clicked = false;
+        self.container().center().col(|ui| {
+            ui.text(title).align(Align::Center);
+            ui.text(description).dim().align(Align::Center);
+            if ui.button(action_label) {
+                clicked = true;
+            }
+        });
+        clicked
+    }
+
+    pub fn code_block(&mut self, code: &str) {
+        let theme = self.theme;
+        self.bordered(Border::Rounded)
+            .bg(theme.surface)
+            .pad(1)
+            .col(|ui| {
+                for line in code.lines() {
+                    render_highlighted_line(ui, line);
+                }
+            });
+    }
+
+    pub fn code_block_numbered(&mut self, code: &str) {
+        let lines: Vec<&str> = code.lines().collect();
+        let gutter_w = format!("{}", lines.len()).len();
+        let theme = self.theme;
+        self.bordered(Border::Rounded)
+            .bg(theme.surface)
+            .pad(1)
+            .col(|ui| {
+                for (i, line) in lines.iter().enumerate() {
+                    ui.line(|ui| {
+                        ui.text(format!("{:>gutter_w$} │ ", i + 1))
+                            .fg(theme.text_dim);
+                        render_highlighted_line(ui, line);
+                    });
+                }
+            });
+    }
+
     /// Enable word-boundary wrapping on the last rendered text element.
     pub fn wrap(&mut self) -> &mut Self {
         if let Some(idx) = self.last_text_idx {
@@ -892,5 +1105,89 @@ impl Context {
     /// Returns `true` when the button is clicked or activated.
     pub fn form_submit(&mut self, label: impl Into<String>) -> bool {
         self.button(label)
+    }
+}
+
+const RUST_KEYWORDS: &[&str] = &[
+    "fn", "let", "mut", "pub", "use", "impl", "struct", "enum", "trait", "type", "const", "static",
+    "if", "else", "match", "for", "while", "loop", "return", "break", "continue", "where", "self",
+    "super", "crate", "mod", "async", "await", "move", "ref", "in", "as", "true", "false", "Some",
+    "None", "Ok", "Err", "Self",
+];
+
+fn render_highlighted_line(ui: &mut Context, line: &str) {
+    let theme = ui.theme;
+    let keyword_color = Color::Rgb(198, 120, 221);
+    let string_color = Color::Rgb(152, 195, 121);
+    let comment_color = theme.text_dim;
+    let number_color = Color::Rgb(209, 154, 102);
+    let fn_color = Color::Rgb(97, 175, 239);
+    let macro_color = Color::Rgb(86, 182, 194);
+
+    let trimmed = line.trim_start();
+    let indent = &line[..line.len() - trimmed.len()];
+    if !indent.is_empty() {
+        ui.text(indent);
+    }
+
+    if trimmed.starts_with("//") {
+        ui.text(trimmed).fg(comment_color).italic();
+        return;
+    }
+
+    let mut pos = 0;
+
+    while pos < trimmed.len() {
+        let ch = trimmed.as_bytes()[pos];
+
+        if ch == b'"' {
+            if let Some(end) = trimmed[pos + 1..].find('"') {
+                let s = &trimmed[pos..pos + end + 2];
+                ui.text(s).fg(string_color);
+                pos += end + 2;
+                continue;
+            }
+        }
+
+        if ch.is_ascii_digit() && (pos == 0 || !trimmed.as_bytes()[pos - 1].is_ascii_alphanumeric())
+        {
+            let end = trimmed[pos..]
+                .find(|c: char| !c.is_ascii_digit() && c != '.' && c != '_')
+                .map_or(trimmed.len(), |e| pos + e);
+            ui.text(&trimmed[pos..end]).fg(number_color);
+            pos = end;
+            continue;
+        }
+
+        if ch.is_ascii_alphabetic() || ch == b'_' {
+            let end = trimmed[pos..]
+                .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+                .map_or(trimmed.len(), |e| pos + e);
+            let word = &trimmed[pos..end];
+
+            if end < trimmed.len() && trimmed.as_bytes()[end] == b'!' {
+                ui.text(&trimmed[pos..end + 1]).fg(macro_color);
+                pos = end + 1;
+            } else if end < trimmed.len()
+                && trimmed.as_bytes()[end] == b'('
+                && !RUST_KEYWORDS.contains(&word)
+            {
+                ui.text(word).fg(fn_color);
+                pos = end;
+            } else if RUST_KEYWORDS.contains(&word) {
+                ui.text(word).fg(keyword_color);
+                pos = end;
+            } else {
+                ui.text(word);
+                pos = end;
+            }
+            continue;
+        }
+
+        let end = trimmed[pos..]
+            .find(|c: char| c.is_ascii_alphanumeric() || c == '_' || c == '"')
+            .map_or(trimmed.len(), |e| pos + e);
+        ui.text(&trimmed[pos..end]);
+        pos = end;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,10 +72,10 @@ pub use style::{
     Justify, Margin, Modifiers, Padding, Style, Theme, ThemeBuilder,
 };
 pub use widgets::{
-    ApprovalAction, ButtonVariant, CommandPaletteState, ContextItem, FormField, FormState,
-    ListState, MultiSelectState, PaletteCommand, RadioState, ScrollState, SelectState,
+    AlertLevel, ApprovalAction, ButtonVariant, CommandPaletteState, ContextItem, FormField,
+    FormState, ListState, MultiSelectState, PaletteCommand, RadioState, ScrollState, SelectState,
     SpinnerState, StreamingTextState, TableState, TabsState, TextInputState, TextareaState,
-    ToastLevel, ToastMessage, ToastState, ToolApprovalState, TreeNode, TreeState,
+    ToastLevel, ToastMessage, ToastState, ToolApprovalState, TreeNode, TreeState, Trend,
 };
 
 static PANIC_HOOK_ONCE: Once = Once::new();

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -199,6 +199,14 @@ pub enum ToastLevel {
     Error,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertLevel {
+    Info,
+    Success,
+    Warning,
+    Error,
+}
+
 impl ToastState {
     /// Create an empty toast state with no messages.
     pub fn new() -> Self {
@@ -792,6 +800,12 @@ pub enum ButtonVariant {
     Danger,
     /// Bordered button without background fill.
     Outline,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Trend {
+    Up,
+    Down,
 }
 
 // ── Select / Dropdown ─────────────────────────────────────────────────


### PR DESCRIPTION
## 10 New Widgets
**Tier 1:** divider_text, alert (with dismiss click), breadcrumb, accordion
**Tier 2:** badge, key_hint, stat/stat_trend, definition_list, empty_state, code_block

## Syntax Highlighting
code_block now renders Rust with One Dark palette — keywords (purple), functions (blue), macros (cyan), strings (green), comments (dim italic), numbers (orange)

## Demo Updates
- Main demo: v0.9.4 tab showcasing all new widgets
- demo_dashboard: separator→divider_text, stat_pill→stat_colored/stat_trend, badge for HIGH alerts

## Verification
- [x] 5 quality gates pass
- [x] User tested demo + demo_dashboard