### PR TITLE
feat: v0.10.0 — error_boundary fix, Theme::light(), consume_key API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "superlighttui"
-version = "0.9.5"
+version = "0.10.0"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ ui.scrollable(&mut scroll).col(|ui| { });    // scroll container
 ui.toast(&mut toasts);                       // notifications
 ui.separator();                              // horizontal line
 ui.help(&[("q", "quit"), ("Tab", "focus")]); // key hints
-ui.link("Docs", "https://docs.rs/slt");      // clickable hyperlink (OSC 8)
+ui.link("Docs", "https://docs.rs/superlighttui");      // clickable hyperlink (OSC 8)
 ui.modal(|ui| { ui.text("overlay"); });      // modal with dim backdrop
 ui.overlay(|ui| { ui.text("floating"); });   // overlay without backdrop
 ui.command_palette(&mut palette);            // searchable command palette
@@ -215,7 +215,7 @@ Focus, events, theming, layout — all accessible through `Context`. One trait, 
 ui.text("styled").bold().italic().underline().fg(Color::Cyan).bg(Color::Black);
 ```
 
-16 named colors · 256-color palette · 24-bit RGB · 6 modifiers · 4 border styles
+16 named colors · 256-color palette · 24-bit RGB · 6 modifiers · 6 border styles
 
 </details>
 
@@ -564,7 +564,6 @@ Press **F12** in any SLT app to toggle the layout debugger overlay. Shows contai
 | demo_ime | `cargo run --example demo_ime` | Korean/CJK IME input |
 | inline | `cargo run --example inline` | Inline mode |
 | anim | `cargo run --example anim` | Tween + Spring + Keyframes |
-| demo_v050 | `cargo run --example demo_v050` | v0.5.0 features |
 | demo_infoviz | `cargo run --example demo_infoviz` | Data visualization |
 | async_demo | `cargo run --example async_demo --features async` | Background tasks |
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -688,13 +688,13 @@ fn render_advanced(
 
             ui.line(|ui| {
                 ui.text("Status: ");
-                ui.text("Online").bold().fg(Color::Green);
+                ui.text("Online").bold().fg(theme.success);
                 ui.text(" · ");
                 ui.text("3 tasks").fg(theme.accent);
             });
 
             ui.line(|ui| {
-                ui.text("Error: ").fg(Color::Red);
+                ui.text("Error: ").fg(theme.error);
                 ui.text("file ").fg(theme.surface_text);
                 ui.text("config.toml").bold().fg(theme.primary);
                 ui.text(" not found").fg(theme.surface_text);
@@ -710,7 +710,7 @@ fn render_advanced(
                         ui.text("This ");
                         ui.text("wraps ").bold();
                         ui.text("across lines while keeping ");
-                        ui.text("styles").fg(Color::Cyan).bold();
+                        ui.text("styles").fg(theme.primary).bold();
                         ui.text(" on each segment.");
                     });
                 });
@@ -1014,7 +1014,7 @@ fn render_v080(
     v8_anim_done: &mut bool,
     tick: u64,
 ) {
-    let _theme = *ui.theme();
+    let theme = *ui.theme();
     section(ui, "v0.8.0 FEATURES");
 
     section(ui, "STYLE RECIPES");
@@ -1047,7 +1047,7 @@ fn render_v080(
             .p(1)
             .col(|ui| {
                 ui.error_boundary(|ui| {
-                    ui.text("Safe content").fg(Color::Green);
+                    ui.text("Safe content").fg(theme.success);
                 });
             });
         ui.container()
@@ -1060,7 +1060,7 @@ fn render_v080(
                         ui.text("Protected zone");
                     },
                     |ui, _msg| {
-                        ui.text("Caught a panic!").fg(Color::Red);
+                        ui.text("Caught a panic!").fg(theme.error);
                     },
                 );
                 ui.text("error_boundary_with catches panics").dim();
@@ -1200,7 +1200,7 @@ fn render_v080(
         ui.row_gap(1, |ui| {
             ui.text(format!("Value: {:.0}", val));
             if *v8_anim_done {
-                ui.text("✓ on_complete fired!").fg(Color::Green).bold();
+                ui.text("✓ on_complete fired!").fg(theme.success).bold();
             }
             if ui.button("Restart") {
                 v8_tween.reset(tick);
@@ -1236,8 +1236,8 @@ fn render_v080(
         let tripled = *ui.use_memo(&count_val, |c| c * 3);
         ui.row_gap(1, |ui| {
             ui.text(format!("Count: {count_val}"));
-            ui.text(format!("×2 = {doubled}")).fg(Color::Cyan);
-            ui.text(format!("×3 = {tripled}")).fg(Color::Green);
+            ui.text(format!("×2 = {doubled}")).fg(theme.primary);
+            ui.text(format!("×3 = {tripled}")).fg(theme.success);
             if ui.button("+1") {
                 *counter.get_mut(ui) += 1;
             }
@@ -1276,13 +1276,13 @@ fn render_v094(
     section(ui, "v0.9.4 WIDGETS");
     ui.text("");
 
-    if *alert_visible {
-        if ui.alert(
+    if *alert_visible
+        && ui.alert(
             "Deployment successful — all checks passed",
             AlertLevel::Success,
-        ) {
-            *alert_visible = false;
-        }
+        )
+    {
+        *alert_visible = false;
     }
 
     ui.divider_text("Navigation");
@@ -1297,7 +1297,7 @@ fn render_v094(
             ui.stat_trend("Errors", "3", Trend::Down);
         });
         card(ui, |ui| {
-            ui.stat_colored("CPU", "72%", Color::Yellow);
+            ui.stat_colored("CPU", "72%", ui.theme().warning);
         });
         card(ui, |ui| {
             ui.stat("Uptime", "14d 3h");
@@ -1308,9 +1308,9 @@ fn render_v094(
     ui.line(|ui| {
         ui.badge("v0.9.4");
         ui.text(" ");
-        ui.badge_colored("Stable", Color::Green);
+        ui.badge_colored("Stable", ui.theme().success);
         ui.text(" ");
-        ui.badge_colored("Rust", Color::Rgb(222, 165, 91));
+        ui.badge_colored("Rust", ui.theme().accent);
         ui.text("   ");
         ui.key_hint("Ctrl+S");
         ui.text(" save  ");

--- a/examples/demo_cli.rs
+++ b/examples/demo_cli.rs
@@ -308,14 +308,14 @@ fn main() -> std::io::Result<()> {
                                                     ),
                                                 ));
                                             }
-                                            if pkg.status == "installed" || pkg.status == "outdated"
+                                            if (pkg.status == "installed"
+                                                || pkg.status == "outdated")
+                                                && ui.button("Remove")
                                             {
-                                                if ui.button("Remove") {
-                                                    output_lines.push((
-                                                        Color::Red,
-                                                        format!("Removed {}", pkg.name),
-                                                    ));
-                                                }
+                                                output_lines.push((
+                                                    Color::Red,
+                                                    format!("Removed {}", pkg.name),
+                                                ));
                                             }
                                         });
                                     }

--- a/examples/demo_fire.rs
+++ b/examples/demo_fire.rs
@@ -85,7 +85,7 @@ impl Fire {
                 let rand_val = self.next_rand();
                 let decay = (rand_val & 3) as usize;
                 let wind = ((rand_val >> 2) & 1) as usize;
-                let dst_x = if x >= wind { x - wind } else { 0 };
+                let dst_x = x.saturating_sub(wind);
                 let dst = (y - 1) * self.w + dst_x;
                 self.pixels[dst] = self.pixels[src].saturating_sub(decay);
             }

--- a/examples/demo_raw_draw.rs
+++ b/examples/demo_raw_draw.rs
@@ -2,8 +2,6 @@ use slt::{Border, Buffer, Color, Context, KeyCode, Rect, RunConfig, Style};
 use std::time::Duration;
 
 fn main() {
-    let mut tick_offset: u64 = 0;
-
     let _ = slt::run_with(
         RunConfig {
             tick_rate: Duration::from_millis(16),
@@ -16,7 +14,7 @@ fn main() {
                 return;
             }
 
-            tick_offset = ui.tick();
+            let tick_offset = ui.tick();
 
             ui.bordered(Border::Rounded)
                 .title("draw_raw demo")

--- a/examples/demo_website.rs
+++ b/examples/demo_website.rs
@@ -413,9 +413,7 @@ fn render_home(
             ui.row(|ui| {
                 ui.text_input(email);
                 email.validate(|v| {
-                    if v.is_empty() {
-                        Ok(())
-                    } else if v.contains('@') && v.contains('.') {
+                    if v.is_empty() || (v.contains('@') && v.contains('.')) {
                         Ok(())
                     } else {
                         Err("Enter a valid email".into())
@@ -1736,6 +1734,7 @@ fn feature_card(ui: &mut Context, theme: &Theme, title: &str, desc: &str) {
     });
 }
 
+#[allow(clippy::too_many_arguments)]
 fn price_card(
     ui: &mut Context,
     tier: &str,

--- a/src/context.rs
+++ b/src/context.rs
@@ -227,6 +227,7 @@ pub trait Widget {
 /// });
 /// ```
 pub struct Context {
+    // NOTE: If you add a mutable per-frame field, also add it to ContextSnapshot in error_boundary_with
     pub(crate) commands: Vec<Command>,
     pub(crate) events: Vec<Event>,
     pub(crate) consumed: Vec<bool>,
@@ -259,10 +260,63 @@ pub struct Context {
     debug: bool,
     theme: Theme,
     pub(crate) dark_mode: bool,
+    pub(crate) is_real_terminal: bool,
     pub(crate) deferred_draws: Vec<Option<RawDrawCallback>>,
 }
 
 type RawDrawCallback = Box<dyn FnOnce(&mut crate::buffer::Buffer, Rect)>;
+
+struct ContextSnapshot {
+    cmd_count: usize,
+    last_text_idx: Option<usize>,
+    focus_count: usize,
+    interaction_count: usize,
+    scroll_count: usize,
+    group_count: usize,
+    group_stack_len: usize,
+    overlay_depth: usize,
+    modal_active: bool,
+    hook_cursor: usize,
+    hook_states_len: usize,
+    dark_mode: bool,
+    deferred_draws_len: usize,
+}
+
+impl ContextSnapshot {
+    fn capture(ctx: &Context) -> Self {
+        Self {
+            cmd_count: ctx.commands.len(),
+            last_text_idx: ctx.last_text_idx,
+            focus_count: ctx.focus_count,
+            interaction_count: ctx.interaction_count,
+            scroll_count: ctx.scroll_count,
+            group_count: ctx.group_count,
+            group_stack_len: ctx.group_stack.len(),
+            overlay_depth: ctx.overlay_depth,
+            modal_active: ctx.modal_active,
+            hook_cursor: ctx.hook_cursor,
+            hook_states_len: ctx.hook_states.len(),
+            dark_mode: ctx.dark_mode,
+            deferred_draws_len: ctx.deferred_draws.len(),
+        }
+    }
+
+    fn restore(&self, ctx: &mut Context) {
+        ctx.commands.truncate(self.cmd_count);
+        ctx.last_text_idx = self.last_text_idx;
+        ctx.focus_count = self.focus_count;
+        ctx.interaction_count = self.interaction_count;
+        ctx.scroll_count = self.scroll_count;
+        ctx.group_count = self.group_count;
+        ctx.group_stack.truncate(self.group_stack_len);
+        ctx.overlay_depth = self.overlay_depth;
+        ctx.modal_active = self.modal_active;
+        ctx.hook_cursor = self.hook_cursor;
+        ctx.hook_states.truncate(self.hook_states_len);
+        ctx.dark_mode = self.dark_mode;
+        ctx.deferred_draws.truncate(self.deferred_draws_len);
+    }
+}
 
 /// Fluent builder for configuring containers before calling `.col()` or `.row()`.
 ///
@@ -284,7 +338,7 @@ type RawDrawCallback = Box<dyn FnOnce(&mut crate::buffer::Buffer, Rect)>;
 ///     });
 /// # });
 /// ```
-#[must_use = "configure and finalize with .col() or .row()"]
+#[must_use = "ContainerBuilder does nothing until .col(), .row(), .line(), or .draw() is called"]
 pub struct ContainerBuilder<'a> {
     ctx: &'a mut Context,
     gap: u32,
@@ -1773,7 +1827,8 @@ impl Context {
             clipboard_text: None,
             debug: state.debug_mode,
             theme,
-            dark_mode: true,
+            dark_mode: theme.is_dark,
+            is_real_terminal: false,
             deferred_draws: Vec::new(),
         }
     }
@@ -1859,8 +1914,7 @@ impl Context {
         f: impl FnOnce(&mut Context),
         fallback: impl FnOnce(&mut Context, String),
     ) {
-        let cmd_count = self.commands.len();
-        let last_text_idx = self.last_text_idx;
+        let snapshot = ContextSnapshot::capture(self);
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             f(self);
@@ -1869,8 +1923,15 @@ impl Context {
         match result {
             Ok(()) => {}
             Err(panic_info) => {
-                self.commands.truncate(cmd_count);
-                self.last_text_idx = last_text_idx;
+                if self.is_real_terminal {
+                    let _ = crossterm::terminal::enable_raw_mode();
+                    let _ = crossterm::execute!(
+                        std::io::stdout(),
+                        crossterm::terminal::EnterAlternateScreen
+                    );
+                }
+
+                snapshot.restore(self);
 
                 let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
                     (*s).to_string()

--- a/src/context/widgets_display.rs
+++ b/src/context/widgets_display.rs
@@ -17,7 +17,7 @@ impl Context {
         let content = s.into();
         self.commands.push(Command::Text {
             content,
-            style: Style::new(),
+            style: Style::new().fg(self.theme.text),
             grow: 0,
             align: Align::Start,
             wrap: false,
@@ -93,7 +93,7 @@ impl Context {
         let content = s.into();
         self.commands.push(Command::Text {
             content,
-            style: Style::new(),
+            style: Style::new().fg(self.theme.text),
             grow: 0,
             align: Align::Start,
             wrap: true,

--- a/src/context/widgets_interactive.rs
+++ b/src/context/widgets_interactive.rs
@@ -1947,6 +1947,57 @@ impl Context {
         })
     }
 
+    /// Check for a character key press and consume the event, preventing other
+    /// handlers from seeing it.
+    ///
+    /// Returns `true` if the key was found unconsumed and is now consumed.
+    /// Unlike [`key()`](Self::key) which peeks without consuming, this claims
+    /// exclusive ownership of the event.
+    ///
+    /// Call **after** widgets if you want widgets to have priority over your
+    /// handler, or **before** widgets to intercept first.
+    pub fn consume_key(&mut self, c: char) -> bool {
+        if (self.modal_active || self.prev_modal_active) && self.overlay_depth == 0 {
+            return false;
+        }
+        for (i, event) in self.events.iter().enumerate() {
+            if self.consumed[i] {
+                continue;
+            }
+            if matches!(event, Event::Key(k) if k.kind == KeyEventKind::Press && k.code == KeyCode::Char(c))
+            {
+                self.consumed[i] = true;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Check for a special key press and consume the event, preventing other
+    /// handlers from seeing it.
+    ///
+    /// Returns `true` if the key was found unconsumed and is now consumed.
+    /// Unlike [`key_code()`](Self::key_code) which peeks without consuming,
+    /// this claims exclusive ownership of the event.
+    ///
+    /// Call **after** widgets if you want widgets to have priority over your
+    /// handler, or **before** widgets to intercept first.
+    pub fn consume_key_code(&mut self, code: KeyCode) -> bool {
+        if (self.modal_active || self.prev_modal_active) && self.overlay_depth == 0 {
+            return false;
+        }
+        for (i, event) in self.events.iter().enumerate() {
+            if self.consumed[i] {
+                continue;
+            }
+            if matches!(event, Event::Key(k) if k.kind == KeyEventKind::Press && k.code == code) {
+                self.consumed[i] = true;
+                return true;
+            }
+        }
+        false
+    }
+
     /// Check if a character key with specific modifiers was pressed this frame.
     ///
     /// Returns `true` if the key event has not been consumed by another widget.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ fn install_panic_hook() {
 /// Configuration for a TUI run loop.
 ///
 /// Pass to [`run_with`] or [`run_inline_with`] to customize behavior.
-/// Use [`Default::default()`] for sensible defaults (100ms tick, no mouse, dark theme).
+/// Use [`Default::default()`] for sensible defaults (16ms tick / 60fps, no mouse, dark theme).
 ///
 /// # Example
 ///
@@ -150,7 +150,7 @@ pub struct RunConfig {
     /// How long to wait for input before triggering a tick with no events.
     ///
     /// Lower values give smoother animations at the cost of more CPU usage.
-    /// Defaults to 100ms.
+    /// Defaults to 16ms (60fps).
     pub tick_rate: Duration,
     /// Whether to enable mouse event reporting.
     ///
@@ -582,6 +582,7 @@ fn run_frame<T: TerminalBackend>(
     let frame_start = Instant::now();
     let (w, h) = term.size();
     let mut ctx = Context::new(events.to_vec(), w, h, state, config.theme);
+    ctx.is_real_terminal = true;
     ctx.process_focus_keys();
 
     f(&mut ctx);
@@ -628,6 +629,20 @@ fn run_frame<T: TerminalBackend>(
     state.prev_content_map = fd.content_areas;
     state.prev_focus_rects = fd.focus_rects;
     state.prev_focus_groups = fd.focus_groups;
+    {
+        let buf = term.buffer_mut();
+        let bg = config.theme.bg;
+        if bg != Color::Reset {
+            for y in 0..buf.area.height {
+                for x in 0..buf.area.width {
+                    let cell = buf.get_mut(x, y);
+                    if cell.style.bg.is_none() {
+                        cell.style.bg = Some(bg);
+                    }
+                }
+            }
+        }
+    }
     layout::render(&tree, term.buffer_mut());
     let raw_rects = layout::collect_raw_draw_rects(&tree);
     for (draw_id, rect) in raw_rects {

--- a/src/style/theme.rs
+++ b/src/style/theme.rs
@@ -45,6 +45,8 @@ pub struct Theme {
     /// containers. `text_dim` is tuned for the main `bg`; on `surface` it
     /// may lack contrast.
     pub surface_text: Color,
+    /// Whether this theme is a dark theme. Used to initialize dark mode in Context.
+    pub is_dark: bool,
 }
 
 impl Theme {
@@ -66,27 +68,29 @@ impl Theme {
             surface: Color::Indexed(236),
             surface_hover: Color::Indexed(238),
             surface_text: Color::Indexed(250),
+            is_dark: true,
         }
     }
 
-    /// Create a light theme with blue primary and black text.
+    /// Create a light theme with high-contrast dark text on light backgrounds.
     pub fn light() -> Self {
         Self {
-            primary: Color::Blue,
-            secondary: Color::Cyan,
-            accent: Color::Magenta,
-            text: Color::Black,
-            text_dim: Color::Indexed(240),
-            border: Color::Indexed(245),
-            bg: Color::Reset,
-            success: Color::Green,
-            warning: Color::Yellow,
-            error: Color::Red,
-            selected_bg: Color::Blue,
+            primary: Color::Rgb(37, 99, 235),
+            secondary: Color::Rgb(14, 116, 144),
+            accent: Color::Rgb(147, 51, 234),
+            text: Color::Rgb(15, 23, 42),
+            text_dim: Color::Rgb(100, 116, 139),
+            border: Color::Rgb(203, 213, 225),
+            bg: Color::Rgb(248, 250, 252),
+            success: Color::Rgb(22, 163, 74),
+            warning: Color::Rgb(202, 138, 4),
+            error: Color::Rgb(220, 38, 38),
+            selected_bg: Color::Rgb(37, 99, 235),
             selected_fg: Color::White,
-            surface: Color::Indexed(254),
-            surface_hover: Color::Indexed(252),
-            surface_text: Color::Indexed(238),
+            surface: Color::Rgb(241, 245, 249),
+            surface_hover: Color::Rgb(226, 232, 240),
+            surface_text: Color::Rgb(51, 65, 85),
+            is_dark: false,
         }
     }
 
@@ -119,6 +123,7 @@ impl Theme {
             surface: None,
             surface_hover: None,
             surface_text: None,
+            is_dark: None,
         }
     }
 
@@ -140,6 +145,7 @@ impl Theme {
             surface: Color::Rgb(68, 71, 90),
             surface_hover: Color::Rgb(98, 100, 120),
             surface_text: Color::Rgb(191, 194, 210),
+            is_dark: true,
         }
     }
 
@@ -161,6 +167,7 @@ impl Theme {
             surface: Color::Rgb(49, 50, 68),
             surface_hover: Color::Rgb(69, 71, 90),
             surface_text: Color::Rgb(166, 173, 200),
+            is_dark: true,
         }
     }
 
@@ -182,6 +189,7 @@ impl Theme {
             surface: Color::Rgb(59, 66, 82),
             surface_hover: Color::Rgb(67, 76, 94),
             surface_text: Color::Rgb(216, 222, 233),
+            is_dark: true,
         }
     }
 
@@ -203,6 +211,7 @@ impl Theme {
             surface: Color::Rgb(7, 54, 66),
             surface_hover: Color::Rgb(23, 72, 85),
             surface_text: Color::Rgb(147, 161, 161),
+            is_dark: true,
         }
     }
 
@@ -224,6 +233,7 @@ impl Theme {
             surface: Color::Rgb(36, 40, 59),
             surface_hover: Color::Rgb(41, 46, 66),
             surface_text: Color::Rgb(192, 202, 245),
+            is_dark: true,
         }
     }
 }
@@ -245,6 +255,7 @@ pub struct ThemeBuilder {
     surface: Option<Color>,
     surface_hover: Option<Color>,
     surface_text: Option<Color>,
+    is_dark: Option<bool>,
 }
 
 impl ThemeBuilder {
@@ -323,6 +334,11 @@ impl ThemeBuilder {
         self
     }
 
+    pub fn is_dark(mut self, is_dark: bool) -> Self {
+        self.is_dark = Some(is_dark);
+        self
+    }
+
     pub fn build(self) -> Theme {
         let defaults = Theme::dark();
         Theme {
@@ -341,6 +357,7 @@ impl ThemeBuilder {
             surface: self.surface.unwrap_or(defaults.surface),
             surface_hover: self.surface_hover.unwrap_or(defaults.surface_hover),
             surface_text: self.surface_text.unwrap_or(defaults.surface_text),
+            is_dark: self.is_dark.unwrap_or(defaults.is_dark),
         }
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -679,10 +679,12 @@ mod tests {
     #[test]
     fn selection_state_drag_activates() {
         let hit_map = vec![pair(Rect::new(0, 0, 80, 24))];
-        let mut sel = SelectionState::default();
-        sel.anchor = Some((10, 5));
-        sel.current = Some((10, 5));
-        sel.widget_rect = Some(Rect::new(0, 0, 80, 24));
+        let mut sel = SelectionState {
+            anchor: Some((10, 5)),
+            current: Some((10, 5)),
+            widget_rect: Some(Rect::new(0, 0, 80, 24)),
+            ..Default::default()
+        };
         sel.mouse_drag(10, 5, &hit_map);
         assert!(!sel.active, "no movement = not active");
         sel.mouse_drag(11, 5, &hit_map);
@@ -694,10 +696,12 @@ mod tests {
     #[test]
     fn selection_state_drag_vertical_activates() {
         let hit_map = vec![pair(Rect::new(0, 0, 80, 24))];
-        let mut sel = SelectionState::default();
-        sel.anchor = Some((10, 5));
-        sel.current = Some((10, 5));
-        sel.widget_rect = Some(Rect::new(0, 0, 80, 24));
+        let mut sel = SelectionState {
+            anchor: Some((10, 5)),
+            current: Some((10, 5)),
+            widget_rect: Some(Rect::new(0, 0, 80, 24)),
+            ..Default::default()
+        };
         sel.mouse_drag(10, 6, &hit_map);
         assert!(sel.active, "any vertical movement = active");
     }
@@ -709,10 +713,12 @@ mod tests {
             pair(Rect::new(5, 2, 30, 10)),
             pair(Rect::new(5, 2, 30, 3)),
         ];
-        let mut sel = SelectionState::default();
-        sel.anchor = Some((10, 3));
-        sel.current = Some((10, 3));
-        sel.widget_rect = Some(Rect::new(5, 2, 30, 3));
+        let mut sel = SelectionState {
+            anchor: Some((10, 3)),
+            current: Some((10, 3)),
+            widget_rect: Some(Rect::new(5, 2, 30, 3)),
+            ..Default::default()
+        };
         sel.mouse_drag(10, 6, &hit_map);
         assert_eq!(sel.widget_rect, Some(Rect::new(5, 2, 30, 10)));
     }

--- a/tests/render_check.rs
+++ b/tests/render_check.rs
@@ -6,8 +6,6 @@ fn render_demo_basic_layout() {
     let mut tb = TestBackend::new(80, 24);
     let mut input = TextInputState::with_placeholder("Type here...");
     let spinner = SpinnerState::dots();
-    let mut dark = true;
-    let mut notif = true;
 
     tb.render(|ui| {
         ui.bordered(Border::Rounded)

--- a/tests/widgets.rs
+++ b/tests/widgets.rs
@@ -926,7 +926,7 @@ fn histogram_renders() {
         ui.histogram(&data, 40, 10);
     });
     let line0 = tb.line(0);
-    assert!(line0.contains("█") || line0.contains("▁") || line0.len() > 0);
+    assert!(line0.contains("█") || line0.contains("▁") || !line0.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **error_boundary terminal recovery**: Re-enter raw mode after panic hook fires inside `error_boundary_with()`. Expand rollback scope from 2 fields to 13 via `ContextSnapshot`.
- **Theme::light() redesign**: Tailwind slate-based high-contrast palette. Default text fg follows `theme.text`. Root background filled with `theme.bg`.
- **consume_key() / consume_key_code()**: New public API for explicit event consumption (vs peek-only `key()`).
- **DX**: Improved `#[must_use]` messages, documentation drift fixes, clippy clean across all targets.
- **Demo**: Theme-aware colors instead of hardcoded `Color::*` values.

## Changed Files (14 files, +219/-75)

### Bug Fixes
- `src/context.rs` — `is_real_terminal` + `ContextSnapshot` (13-field rollback) + re-enter raw mode
- `src/style/theme.rs` — `is_dark: bool` field, redesigned `light()` palette
- `src/context.rs` — `dark_mode: theme.is_dark` instead of hardcoded `true`

### New API
- `src/context/widgets_interactive.rs` — `consume_key()`, `consume_key_code()`

### Theme-Aware Rendering
- `src/context/widgets_display.rs` — `text()` default fg = `theme.text`
- `src/lib.rs` — Fill root bg with `theme.bg` when not `Color::Reset`

### Docs & Clippy
- `src/lib.rs` — RunConfig docs: 100ms → 16ms
- `README.md` — docs.rs link, border count, dead example
- `examples/*.rs` — clippy fixes + theme-aware demo colors
- `src/terminal.rs`, `tests/` — clippy clean