### PR TITLE
perf: v0.10.1 — CompactString cells, inline diff+flush

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
       - run: cargo check --all-features
 
   check-msrv:
-    name: Check (MSRV 1.74)
+    name: Check (MSRV 1.81)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.74"
+          toolchain: "1.81"
       - uses: Swatinem/rust-cache@v2
       - run: cargo generate-lockfile
       - run: cargo check --features async,serde

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,13 @@ jobs:
       - run: cargo fmt -- --check
 
   ci-msrv:
-    name: CI Gate (MSRV 1.74)
+    name: CI Gate (MSRV 1.81)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.74"
+          toolchain: "1.81"
       - uses: Swatinem/rust-cache@v2
       - run: cargo generate-lockfile
       - run: cargo check --features async,serde

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.10.1] — 2026-03-16
+
+### Performance
+- **Cell.symbol**: `String` → `CompactString` — eliminates heap allocation for ≤24-byte symbols (99%+ of terminal cells). Same approach as ratatui.
+- **Cell.hyperlink**: `Option<String>` → `Option<CompactString>` — reduces per-cell overhead for hyperlinks.
+- **diff+flush inline**: Removed intermediate `Vec<(u32, u32, &Cell)>` allocation in `Terminal::flush()`. Now diffs and writes to stdout in a single pass.
+- **reset_with_bg()**: Theme background applied during buffer reset instead of a separate O(w×h) loop per frame.
+
+### Changes
+- **MSRV**: 1.74 → 1.81 (required by `compact_str` 0.9)
+- **New dependency**: `compact_str` 0.9 (no-default-features) — adds 4 small transitive deps (castaway, ryu, static_assertions, rustversion)
+
 ## [0.10.0] — 2026-03-15
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +137,20 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "console"
@@ -735,6 +758,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,9 +877,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "superlighttui"
-version = "0.9.5"
+version = "0.10.1"
 dependencies = [
+ "compact_str",
  "criterion",
  "crossterm",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "superlighttui"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/superlighttui"
 readme = "README.md"
 keywords = ["tui", "terminal", "cli", "ui", "immediate-mode"]
 categories = ["command-line-interface"]
-rust-version = "1.74"
+rust-version = "1.81"
 exclude = ["examples/", ".github/"]
 
 [lib]
@@ -22,6 +22,7 @@ unicode-width = "0.2"
 tokio = { version = "1", features = ["rt", "sync", "macros", "time"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 image = { version = "0.25", optional = true, default-features = false, features = ["png", "jpeg"] }
+compact_str = { version = "0.9.0", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -159,7 +159,7 @@ impl Buffer {
             return;
         }
         let clip = self.effective_clip().copied();
-        let link = Some(url.to_string());
+        let link = Some(compact_str::CompactString::new(url));
         for ch in s.chars() {
             if x >= self.area.right() {
                 break;
@@ -246,6 +246,15 @@ impl Buffer {
     pub fn reset(&mut self) {
         for cell in &mut self.content {
             cell.reset();
+        }
+        self.clip_stack.clear();
+    }
+
+    /// Reset every cell and apply a background color to all cells.
+    pub fn reset_with_bg(&mut self, bg: crate::style::Color) {
+        for cell in &mut self.content {
+            cell.reset();
+            cell.style.bg = Some(bg);
         }
         self.clip_stack.clear();
     }

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,28 +1,30 @@
 //! Single terminal cell — the smallest unit of the render buffer.
 
+use compact_str::CompactString;
+
 use crate::style::Style;
 
 /// A single terminal cell containing a character and style.
 ///
-/// Each cell holds one grapheme cluster (stored as a `String` to support
-/// multi-byte Unicode) and the [`Style`] to render it with. Wide characters
-/// (e.g., CJK) occupy two adjacent cells; the second cell's `symbol` is left
-/// empty by the buffer layer.
+/// Each cell holds one grapheme cluster (stored as a [`CompactString`] for
+/// inline storage of short strings — no heap allocation for ≤24 bytes).
+/// Wide characters (e.g., CJK) occupy two adjacent cells; the second cell's
+/// `symbol` is left empty by the buffer layer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Cell {
     /// The grapheme cluster displayed in this cell. Defaults to a single space.
-    pub symbol: String,
+    pub symbol: CompactString,
     /// The visual style (colors and modifiers) for this cell.
     pub style: Style,
     /// Optional OSC 8 hyperlink URL. When set, the terminal renders this cell
     /// as a clickable link.
-    pub hyperlink: Option<String>,
+    pub hyperlink: Option<CompactString>,
 }
 
 impl Default for Cell {
     fn default() -> Self {
         Self {
-            symbol: " ".into(),
+            symbol: CompactString::const_new(" "),
             style: Style::new(),
             hyperlink: None,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,9 @@ pub fn run_with(config: RunConfig, mut f: impl FnMut(&mut Context)) -> io::Resul
     install_panic_hook();
     let color_depth = config.color_depth.unwrap_or_else(ColorDepth::detect);
     let mut term = Terminal::new(config.mouse, config.kitty_keyboard, color_depth)?;
+    if config.theme.bg != Color::Reset {
+        term.theme_bg = Some(config.theme.bg);
+    }
     let mut events: Vec<Event> = Vec::new();
     let mut state = FrameState::default();
 
@@ -410,6 +413,9 @@ fn run_async_loop<M: Send + 'static>(
     install_panic_hook();
     let color_depth = config.color_depth.unwrap_or_else(ColorDepth::detect);
     let mut term = Terminal::new(config.mouse, config.kitty_keyboard, color_depth)?;
+    if config.theme.bg != Color::Reset {
+        term.theme_bg = Some(config.theme.bg);
+    }
     let mut events: Vec<Event> = Vec::new();
     let mut state = FrameState::default();
 
@@ -629,20 +635,6 @@ fn run_frame<T: TerminalBackend>(
     state.prev_content_map = fd.content_areas;
     state.prev_focus_rects = fd.focus_rects;
     state.prev_focus_groups = fd.focus_groups;
-    {
-        let buf = term.buffer_mut();
-        let bg = config.theme.bg;
-        if bg != Color::Reset {
-            for y in 0..buf.area.height {
-                for x in 0..buf.area.width {
-                    let cell = buf.get_mut(x, y);
-                    if cell.style.bg.is_none() {
-                        cell.style.bg = Some(bg);
-                    }
-                }
-            }
-        }
-    }
     layout::render(&tree, term.buffer_mut());
     let raw_rects = layout::collect_raw_draw_rects(&tree);
     for (draw_id, rect) in raw_rects {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -25,6 +25,7 @@ pub(crate) struct Terminal {
     cursor_visible: bool,
     kitty_keyboard: bool,
     color_depth: ColorDepth,
+    pub(crate) theme_bg: Option<Color>,
 }
 
 pub(crate) struct InlineTerminal {
@@ -81,6 +82,7 @@ impl Terminal {
             cursor_visible: false,
             kitty_keyboard,
             color_depth,
+            theme_bg: None,
         })
     }
 
@@ -93,42 +95,48 @@ impl Terminal {
     }
 
     pub fn flush(&mut self) -> io::Result<()> {
-        let updates = self.current.diff(&self.previous);
         queue!(self.stdout, BeginSynchronizedUpdate)?;
 
-        if !updates.is_empty() {
-            let mut last_style = Style::new();
-            let mut first_style = true;
-            let mut last_pos: Option<(u32, u32)> = None;
-            let mut active_link: Option<&str> = None;
+        let mut last_style = Style::new();
+        let mut first_style = true;
+        let mut last_pos: Option<(u32, u32)> = None;
+        let mut active_link: Option<&str> = None;
+        let mut has_updates = false;
 
-            for &(x, y, cell) in &updates {
-                if cell.symbol.is_empty() {
+        for y in self.current.area.y..self.current.area.bottom() {
+            for x in self.current.area.x..self.current.area.right() {
+                let cur = self.current.get(x, y);
+                let prev = self.previous.get(x, y);
+                if cur == prev {
                     continue;
                 }
+                if cur.symbol.is_empty() {
+                    continue;
+                }
+                has_updates = true;
 
                 let need_move = last_pos.map_or(true, |(lx, ly)| ly != y || lx != x);
                 if need_move {
                     queue!(self.stdout, cursor::MoveTo(x as u16, y as u16))?;
                 }
 
-                if cell.style != last_style {
+                if cur.style != last_style {
                     if first_style {
                         queue!(self.stdout, ResetColor, SetAttribute(Attribute::Reset))?;
-                        apply_style(&mut self.stdout, &cell.style, self.color_depth)?;
+                        apply_style(&mut self.stdout, &cur.style, self.color_depth)?;
                         first_style = false;
                     } else {
                         apply_style_delta(
                             &mut self.stdout,
                             &last_style,
-                            &cell.style,
+                            &cur.style,
                             self.color_depth,
                         )?;
                     }
-                    last_style = cell.style;
+                    last_style = cur.style;
                 }
 
-                let cell_link = cell.hyperlink.as_deref();
+                let cell_link = cur.hyperlink.as_deref();
                 if cell_link != active_link {
                     if let Some(url) = cell_link {
                         queue!(self.stdout, Print(format!("\x1b]8;;{url}\x07")))?;
@@ -138,11 +146,13 @@ impl Terminal {
                     active_link = cell_link;
                 }
 
-                queue!(self.stdout, Print(&cell.symbol))?;
-                let char_width = UnicodeWidthStr::width(cell.symbol.as_str()).max(1) as u32;
+                queue!(self.stdout, Print(&*cur.symbol))?;
+                let char_width = UnicodeWidthStr::width(cur.symbol.as_str()).max(1) as u32;
                 last_pos = Some((x + char_width, y));
             }
+        }
 
+        if has_updates {
             if active_link.is_some() {
                 queue!(self.stdout, Print("\x1b]8;;\x07"))?;
             }
@@ -171,7 +181,11 @@ impl Terminal {
         self.stdout.flush()?;
 
         std::mem::swap(&mut self.current, &mut self.previous);
-        self.current.reset();
+        if let Some(bg) = self.theme_bg {
+            self.current.reset_with_bg(bg);
+        } else {
+            self.current.reset();
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Performance improvements targeting the hot path (per-frame allocations):

- **Cell.symbol**: `String` → `CompactString` — zero heap allocation for ≤24-byte symbols (covers 99%+ of terminal cells)
- **Cell.hyperlink**: `Option<String>` → `Option<CompactString>` — same inline optimization for hyperlink URLs
- **diff+flush inline**: removed intermediate `Vec<(u32, u32, &Cell)>` in `Terminal::flush()` — now diffs and writes in a single pass
- **reset_with_bg()**: theme background applied during buffer reset instead of separate O(w×h) loop

## Breaking Changes

- **MSRV**: 1.74 → 1.81 (required by `compact_str` 0.9)
- **New dependency**: `compact_str` 0.9 (`no-default-features`) — adds 4 small transitive deps

## Changed Files (6 files, +95/-41)

| File | Change |
|------|--------|
| `Cargo.toml` | compact_str dep, version bump, MSRV 1.81 |
| `src/cell.rs` | String → CompactString for symbol + hyperlink |
| `src/buffer.rs` | CompactString in set_string_linked, add reset_with_bg() |
| `src/terminal.rs` | Inline diff+flush, theme_bg field, reset_with_bg usage |
| `src/lib.rs` | Set theme_bg on Terminal, remove per-frame bg fill loop |
| `.github/workflows/` | MSRV 1.74 → 1.81 in CI + release configs |