### PR TITLE
Add CI stage to audit Rust dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,10 @@ jobs:
         with:
           components: rustfmt
       - run: cargo fmt -- --check
+
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/audit@v1


### PR DESCRIPTION
This revision includes:
- Add CI stage to audit Rust dependencies
  - https://github.com/RustSec/rustsec/tree/main/cargo-audit
  - https://rustsec.org/advisories/