### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.12.0] — 2026-03-16
+
+### Features
+- **Custom Backend API**: `pub trait Backend { size, buffer_mut, flush }` — implement custom rendering targets (WebGL, egui, SSH, test harnesses). Pair with `AppState` and `slt::frame()` to drive the render loop from external event loops.
+- **`streaming_markdown()`**: New widget combining streaming text with markdown rendering — headings, bold, italic, inline code, bullet lists, code blocks with blinking cursor during streaming.
+
+### Bug Fixes
+- **`confirm()` hook panic on tab switch**: Removed internal `use_state()` from `confirm()` widget — was the only widget using internal hooks, causing panic when conditionally rendered across tab switches. Now uses the `result: &mut bool` parameter directly for selection state.
+
+### Improvements
+- **`parse_inline_segments()` visibility**: Changed from private to `pub(crate)` — enables inline markdown formatting reuse across widget modules.
+- **README architecture section**: Added Custom Backends guide with code example and AI-Native Widgets table.
+
 ## [0.11.0] — 2026-03-16
 
 ### BREAKING: Response Pattern

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "superlighttui"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "compact_str",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "superlighttui"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -628,6 +628,56 @@ Each frame: your closure runs, SLT collects what you described, computes flexbox
 
 Pure Rust. No macros, no code generation, no build scripts.
 
+### Custom Backends
+
+SLT's rendering is abstracted behind the `Backend` trait, enabling custom rendering targets beyond the terminal:
+
+```rust
+use slt::{Backend, AppState, Buffer, Rect, RunConfig, Context, Event};
+
+struct MyBackend { buffer: Buffer }
+
+impl Backend for MyBackend {
+    fn size(&self) -> (u32, u32) {
+        (self.buffer.area.width, self.buffer.area.height)
+    }
+    fn buffer_mut(&mut self) -> &mut Buffer { &mut self.buffer }
+    fn flush(&mut self) -> std::io::Result<()> {
+        // Render self.buffer to your target (canvas, GPU, network, etc.)
+        Ok(())
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    let mut backend = MyBackend { buffer: Buffer::empty(Rect::new(0, 0, 80, 24)) };
+    let mut state = AppState::new();
+    let config = RunConfig::default();
+
+    loop {
+        let events: Vec<Event> = vec![];
+        if !slt::frame(&mut backend, &mut state, &config, &events, &mut |ui| {
+            ui.text("Hello from custom backend!");
+        })? { break; }
+    }
+    Ok(())
+}
+```
+
+The `Backend` trait has 3 methods: `size()`, `buffer_mut()`, `flush()`. The built-in terminal backend handles ANSI escape codes, double-buffer diffing, and synchronized output internally. Custom backends receive the fully-rendered `Buffer` of `Cell`s and can present them however they choose — WebGL, egui embed, SSH tunnel, test harness, etc.
+
+### AI-Native Widgets
+
+SLT includes purpose-built widgets for AI/LLM workflows:
+
+| Widget | Description |
+|--------|-------------|
+| `streaming_text()` | Token-by-token text display with blinking cursor |
+| `streaming_markdown()` | Streaming markdown with headings, code blocks, inline formatting |
+| `tool_approval()` | Human-in-the-loop approve/reject for tool calls |
+| `context_bar()` | Token counter bar showing active context sources |
+| `markdown()` | Static markdown rendering |
+| `code_block()` | Syntax-highlighted code display |
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/src/context/widgets_display.rs
+++ b/src/context/widgets_display.rs
@@ -295,6 +295,216 @@ impl Context {
         Response::none()
     }
 
+    /// Render streaming markdown with a typing cursor indicator.
+    ///
+    /// Parses accumulated markdown content line-by-line while streaming.
+    /// Supports headings, lists, inline formatting, horizontal rules, and
+    /// fenced code blocks with open/close tracking across stream chunks.
+    ///
+    /// ```no_run
+    /// # use slt::widgets::StreamingMarkdownState;
+    /// # slt::run(|ui: &mut slt::Context| {
+    /// let mut stream = StreamingMarkdownState::new();
+    /// stream.start();
+    /// stream.push("# Hello\n");
+    /// stream.push("- **streaming** markdown\n");
+    /// stream.push("```rust\nlet x = 1;\n");
+    /// ui.streaming_markdown(&mut stream);
+    /// # });
+    /// ```
+    pub fn streaming_markdown(
+        &mut self,
+        state: &mut crate::widgets::StreamingMarkdownState,
+    ) -> Response {
+        if state.streaming {
+            state.cursor_tick = state.cursor_tick.wrapping_add(1);
+            state.cursor_visible = (state.cursor_tick / 8) % 2 == 0;
+        }
+
+        if state.content.is_empty() && state.streaming {
+            let cursor = if state.cursor_visible { "▌" } else { " " };
+            let primary = self.theme.primary;
+            self.text(cursor).fg(primary);
+            return Response::none();
+        }
+
+        let show_cursor = state.streaming && state.cursor_visible;
+        let trailing_newline = state.content.ends_with('\n');
+        let lines: Vec<&str> = state.content.lines().collect();
+        let last_line_index = lines.len().saturating_sub(1);
+
+        self.commands.push(Command::BeginContainer {
+            direction: Direction::Column,
+            gap: 0,
+            align: Align::Start,
+            justify: Justify::Start,
+            border: None,
+            border_sides: BorderSides::all(),
+            border_style: Style::new().fg(self.theme.border),
+            bg_color: None,
+            padding: Padding::default(),
+            margin: Margin::default(),
+            constraints: Constraints::default(),
+            title: None,
+            grow: 0,
+            group_name: None,
+        });
+        self.interaction_count += 1;
+
+        let text_style = Style::new().fg(self.theme.text);
+        let bold_style = Style::new().fg(self.theme.text).bold();
+        let code_style = Style::new().fg(self.theme.accent);
+        let border_style = Style::new().fg(self.theme.border).dim();
+
+        let mut in_code_block = false;
+        let mut code_block_lang = String::new();
+
+        for (idx, line) in lines.iter().enumerate() {
+            let line = *line;
+            let trimmed = line.trim();
+            let append_cursor = show_cursor && !trailing_newline && idx == last_line_index;
+            let cursor = if append_cursor { "▌" } else { "" };
+
+            if in_code_block {
+                if trimmed.starts_with("```") {
+                    in_code_block = false;
+                    code_block_lang.clear();
+                    self.styled(format!("  └────{cursor}"), border_style);
+                } else {
+                    self.styled(format!("  {line}{cursor}"), code_style);
+                }
+                continue;
+            }
+
+            if trimmed.is_empty() {
+                if append_cursor {
+                    self.styled("▌", Style::new().fg(self.theme.primary));
+                } else {
+                    self.text(" ");
+                }
+                continue;
+            }
+
+            if trimmed == "---" || trimmed == "***" || trimmed == "___" {
+                self.styled(format!("{}{}", "─".repeat(40), cursor), border_style);
+                continue;
+            }
+
+            if let Some(heading) = trimmed.strip_prefix("### ") {
+                self.styled(
+                    format!("{heading}{cursor}"),
+                    Style::new().bold().fg(self.theme.accent),
+                );
+                continue;
+            }
+
+            if let Some(heading) = trimmed.strip_prefix("## ") {
+                self.styled(
+                    format!("{heading}{cursor}"),
+                    Style::new().bold().fg(self.theme.secondary),
+                );
+                continue;
+            }
+
+            if let Some(heading) = trimmed.strip_prefix("# ") {
+                self.styled(
+                    format!("{heading}{cursor}"),
+                    Style::new().bold().fg(self.theme.primary),
+                );
+                continue;
+            }
+
+            if let Some(code) = trimmed.strip_prefix("```") {
+                in_code_block = true;
+                code_block_lang = code.trim().to_string();
+                let label = if code_block_lang.is_empty() {
+                    "code".to_string()
+                } else {
+                    format!("code:{}", code_block_lang)
+                };
+                self.styled(format!("  ┌─{label}─{cursor}"), border_style);
+                continue;
+            }
+
+            if let Some(item) = trimmed
+                .strip_prefix("- ")
+                .or_else(|| trimmed.strip_prefix("* "))
+            {
+                let segs = Self::parse_inline_segments(item, text_style, bold_style, code_style);
+                if segs.len() <= 1 {
+                    self.styled(format!("  • {item}{cursor}"), text_style);
+                } else {
+                    self.line(|ui| {
+                        ui.styled("  • ", text_style);
+                        for (s, st) in segs {
+                            ui.styled(s, st);
+                        }
+                        if append_cursor {
+                            ui.styled("▌", Style::new().fg(ui.theme.primary));
+                        }
+                    });
+                }
+                continue;
+            }
+
+            if trimmed.starts_with(|c: char| c.is_ascii_digit()) && trimmed.contains(". ") {
+                let parts: Vec<&str> = trimmed.splitn(2, ". ").collect();
+                if parts.len() == 2 {
+                    let segs =
+                        Self::parse_inline_segments(parts[1], text_style, bold_style, code_style);
+                    if segs.len() <= 1 {
+                        self.styled(
+                            format!("  {}. {}{}", parts[0], parts[1], cursor),
+                            text_style,
+                        );
+                    } else {
+                        self.line(|ui| {
+                            ui.styled(format!("  {}. ", parts[0]), text_style);
+                            for (s, st) in segs {
+                                ui.styled(s, st);
+                            }
+                            if append_cursor {
+                                ui.styled("▌", Style::new().fg(ui.theme.primary));
+                            }
+                        });
+                    }
+                } else {
+                    self.styled(format!("{trimmed}{cursor}"), text_style);
+                }
+                continue;
+            }
+
+            let segs = Self::parse_inline_segments(trimmed, text_style, bold_style, code_style);
+            if segs.len() <= 1 {
+                self.styled(format!("{trimmed}{cursor}"), text_style);
+            } else {
+                self.line(|ui| {
+                    for (s, st) in segs {
+                        ui.styled(s, st);
+                    }
+                    if append_cursor {
+                        ui.styled("▌", Style::new().fg(ui.theme.primary));
+                    }
+                });
+            }
+        }
+
+        if show_cursor && trailing_newline {
+            if in_code_block {
+                self.styled("  ▌", code_style);
+            } else {
+                self.styled("▌", Style::new().fg(self.theme.primary));
+            }
+        }
+
+        state.in_code_block = in_code_block;
+        state.code_block_lang = code_block_lang;
+
+        self.commands.push(Command::EndContainer);
+        self.last_text_idx = None;
+        Response::none()
+    }
+
     /// Render a tool approval widget with approve/reject buttons.
     ///
     /// Shows the tool name, description, and two action buttons.
@@ -425,8 +635,7 @@ impl Context {
     /// ```
     pub fn confirm(&mut self, question: &str, result: &mut bool) -> Response {
         let focused = self.register_focusable();
-        let selected_yes = self.use_state(|| true);
-        let mut is_yes = *selected_yes.get(self);
+        let mut is_yes = *result;
         let mut clicked = false;
 
         if focused {
@@ -452,6 +661,7 @@ impl Context {
                         }
                         KeyCode::Tab | KeyCode::BackTab | KeyCode::Left | KeyCode::Right => {
                             is_yes = !is_yes;
+                            *result = is_yes;
                             consumed_indices.push(i);
                         }
                         KeyCode::Enter => {
@@ -468,8 +678,6 @@ impl Context {
                 self.consumed[idx] = true;
             }
         }
-
-        *selected_yes.get_mut(self) = is_yes;
 
         let yes_style = if is_yes {
             if focused {

--- a/src/context/widgets_interactive.rs
+++ b/src/context/widgets_interactive.rs
@@ -1923,7 +1923,7 @@ impl Context {
         Response::none()
     }
 
-    fn parse_inline_segments(
+    pub(crate) fn parse_inline_segments(
         text: &str,
         base: Style,
         bold: Style,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ use std::io::IsTerminal;
 use std::sync::Once;
 use std::time::{Duration, Instant};
 
-use terminal::{InlineTerminal, Terminal, TerminalBackend};
+use terminal::{InlineTerminal, Terminal};
 
 pub use crate::test_utils::{EventBuilder, TestBackend};
 pub use anim::{
@@ -86,10 +86,160 @@ pub use style::{
 pub use widgets::{
     AlertLevel, ApprovalAction, ButtonVariant, CommandPaletteState, ContextItem, FileEntry,
     FilePickerState, FormField, FormState, ListState, MultiSelectState, PaletteCommand, RadioState,
-    ScrollState, SelectState, SpinnerState, StreamingTextState, TableState, TabsState,
-    TextInputState, TextareaState, ToastLevel, ToastMessage, ToastState, ToolApprovalState,
-    TreeNode, TreeState, Trend,
+    ScrollState, SelectState, SpinnerState, StreamingMarkdownState, StreamingTextState, TableState,
+    TabsState, TextInputState, TextareaState, ToastLevel, ToastMessage, ToastState,
+    ToolApprovalState, TreeNode, TreeState, Trend,
 };
+
+/// Rendering backend for SLT.
+///
+/// Implement this trait to render SLT UIs to custom targets — alternative
+/// terminals, GUI embeds, test harnesses, WASM canvas, etc.
+///
+/// The built-in terminal backend ([`run()`], [`run_with()`]) handles setup,
+/// teardown, and event polling automatically. For custom backends, pair this
+/// trait with [`AppState`] and [`frame()`] to drive the render loop yourself.
+///
+/// # Example
+///
+/// ```ignore
+/// use slt::{Backend, AppState, Buffer, Rect, RunConfig, Context, Event};
+///
+/// struct MyBackend {
+///     buffer: Buffer,
+/// }
+///
+/// impl Backend for MyBackend {
+///     fn size(&self) -> (u32, u32) {
+///         (self.buffer.area.width, self.buffer.area.height)
+///     }
+///     fn buffer_mut(&mut self) -> &mut Buffer {
+///         &mut self.buffer
+///     }
+///     fn flush(&mut self) -> std::io::Result<()> {
+///         // Render self.buffer to your target
+///         Ok(())
+///     }
+/// }
+///
+/// fn main() -> std::io::Result<()> {
+///     let mut backend = MyBackend {
+///         buffer: Buffer::empty(Rect::new(0, 0, 80, 24)),
+///     };
+///     let mut state = AppState::new();
+///     let config = RunConfig::default();
+///
+///     loop {
+///         let events: Vec<Event> = vec![]; // Collect your own events
+///         if !slt::frame(&mut backend, &mut state, &config, &events, &mut |ui| {
+///             ui.text("Hello from custom backend!");
+///         })? {
+///             break;
+///         }
+///     }
+///     Ok(())
+/// }
+/// ```
+pub trait Backend {
+    /// Returns the current display size as `(width, height)` in cells.
+    fn size(&self) -> (u32, u32);
+
+    /// Returns a mutable reference to the display buffer.
+    ///
+    /// SLT writes the UI into this buffer each frame. After [`frame()`]
+    /// returns, call [`flush()`](Backend::flush) to present the result.
+    fn buffer_mut(&mut self) -> &mut Buffer;
+
+    /// Flush the buffer contents to the display.
+    ///
+    /// Called automatically at the end of each [`frame()`] call. Implementations
+    /// should present the current buffer to the user — by writing ANSI escapes,
+    /// drawing to a canvas, updating a texture, etc.
+    fn flush(&mut self) -> io::Result<()>;
+}
+
+/// Opaque per-session state that persists between frames.
+///
+/// Tracks focus, scroll positions, hook state, and other frame-to-frame data.
+/// Create with [`AppState::new()`] and pass to [`frame()`] each iteration.
+///
+/// # Example
+///
+/// ```ignore
+/// let mut state = slt::AppState::new();
+/// // state is passed to slt::frame() in your render loop
+/// ```
+pub struct AppState {
+    pub(crate) inner: FrameState,
+}
+
+impl AppState {
+    /// Create a new empty application state.
+    pub fn new() -> Self {
+        Self {
+            inner: FrameState::default(),
+        }
+    }
+
+    /// Returns the current frame tick count (increments each frame).
+    pub fn tick(&self) -> u64 {
+        self.inner.tick
+    }
+
+    /// Returns the smoothed FPS estimate (exponential moving average).
+    pub fn fps(&self) -> f32 {
+        self.inner.fps_ema
+    }
+
+    /// Toggle the debug overlay (same as pressing F12).
+    pub fn set_debug(&mut self, enabled: bool) {
+        self.inner.debug_mode = enabled;
+    }
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Process a single UI frame with a custom [`Backend`].
+///
+/// This is the low-level entry point for custom backends. For standard terminal
+/// usage, prefer [`run()`] or [`run_with()`] which handle the event loop,
+/// terminal setup, and teardown automatically.
+///
+/// Returns `Ok(true)` to continue, `Ok(false)` when [`Context::quit()`] was
+/// called.
+///
+/// # Arguments
+///
+/// * `backend` — Your [`Backend`] implementation
+/// * `state` — Persistent [`AppState`] (reuse across frames)
+/// * `config` — [`RunConfig`] (theme, tick rate, etc.)
+/// * `events` — Input events for this frame (keyboard, mouse, resize)
+/// * `f` — Your UI closure, called once per frame
+///
+/// # Example
+///
+/// ```ignore
+/// let keep_going = slt::frame(
+///     &mut my_backend,
+///     &mut state,
+///     &config,
+///     &events,
+///     &mut |ui| { ui.text("hello"); },
+/// )?;
+/// ```
+pub fn frame(
+    backend: &mut impl Backend,
+    state: &mut AppState,
+    config: &RunConfig,
+    events: &[Event],
+    f: &mut impl FnMut(&mut Context),
+) -> io::Result<bool> {
+    run_frame(backend, &mut state.inner, config, events, f)
+}
 
 static PANIC_HOOK_ONCE: Once = Once::new();
 
@@ -322,7 +472,7 @@ pub fn run_with(config: RunConfig, mut f: impl FnMut(&mut Context)) -> io::Resul
                     break;
                 }
                 if let Event::Resize(_, _) = &ev {
-                    TerminalBackend::handle_resize(&mut term)?;
+                    term.handle_resize()?;
                 }
                 events.push(ev);
             }
@@ -334,7 +484,7 @@ pub fn run_with(config: RunConfig, mut f: impl FnMut(&mut Context)) -> io::Resul
                         return Ok(());
                     }
                     if let Event::Resize(_, _) = &ev {
-                        TerminalBackend::handle_resize(&mut term)?;
+                        term.handle_resize()?;
                     }
                     events.push(ev);
                 }
@@ -462,7 +612,7 @@ fn run_async_loop<M: Send + 'static>(
                     break;
                 }
                 if let Event::Resize(_, _) = &ev {
-                    TerminalBackend::handle_resize(&mut term)?;
+                    term.handle_resize()?;
                     clear_frame_layout_cache(&mut state);
                 }
                 events.push(ev);
@@ -475,7 +625,7 @@ fn run_async_loop<M: Send + 'static>(
                         return Ok(());
                     }
                     if let Event::Resize(_, _) = &ev {
-                        TerminalBackend::handle_resize(&mut term)?;
+                        term.handle_resize()?;
                         clear_frame_layout_cache(&mut state);
                     }
                     events.push(ev);
@@ -552,7 +702,7 @@ pub fn run_inline_with(
                     break;
                 }
                 if let Event::Resize(_, _) = &ev {
-                    TerminalBackend::handle_resize(&mut term)?;
+                    term.handle_resize()?;
                 }
                 events.push(ev);
             }
@@ -564,7 +714,7 @@ pub fn run_inline_with(
                         return Ok(());
                     }
                     if let Event::Resize(_, _) = &ev {
-                        TerminalBackend::handle_resize(&mut term)?;
+                        term.handle_resize()?;
                     }
                     events.push(ev);
                 }
@@ -596,12 +746,12 @@ pub fn run_inline_with(
     Ok(())
 }
 
-fn run_frame<T: TerminalBackend>(
-    term: &mut T,
+fn run_frame(
+    term: &mut impl Backend,
     state: &mut FrameState,
     config: &RunConfig,
     events: &[event::Event],
-    f: &mut dyn FnMut(&mut context::Context),
+    f: &mut impl FnMut(&mut context::Context),
 ) -> io::Result<bool> {
     let frame_start = Instant::now();
     let (w, h) = term.size();

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -41,13 +41,6 @@ pub(crate) struct InlineTerminal {
     pub(crate) theme_bg: Option<Color>,
 }
 
-pub(crate) trait TerminalBackend {
-    fn size(&self) -> (u32, u32);
-    fn buffer_mut(&mut self) -> &mut Buffer;
-    fn flush(&mut self) -> io::Result<()>;
-    fn handle_resize(&mut self) -> io::Result<()>;
-}
-
 impl Terminal {
     pub fn new(mouse: bool, kitty_keyboard: bool, color_depth: ColorDepth) -> io::Result<Self> {
         let (cols, rows) = terminal::size()?;
@@ -204,7 +197,7 @@ impl Terminal {
     }
 }
 
-impl TerminalBackend for Terminal {
+impl crate::Backend for Terminal {
     fn size(&self) -> (u32, u32) {
         Terminal::size(self)
     }
@@ -215,10 +208,6 @@ impl TerminalBackend for Terminal {
 
     fn flush(&mut self) -> io::Result<()> {
         Terminal::flush(self)
-    }
-
-    fn handle_resize(&mut self) -> io::Result<()> {
-        Terminal::handle_resize(self)
     }
 }
 
@@ -372,7 +361,7 @@ impl InlineTerminal {
     }
 }
 
-impl TerminalBackend for InlineTerminal {
+impl crate::Backend for InlineTerminal {
     fn size(&self) -> (u32, u32) {
         InlineTerminal::size(self)
     }
@@ -383,10 +372,6 @@ impl TerminalBackend for InlineTerminal {
 
     fn flush(&mut self) -> io::Result<()> {
         InlineTerminal::flush(self)
-    }
-
-    fn handle_resize(&mut self) -> io::Result<()> {
-        InlineTerminal::handle_resize(self)
     }
 }
 

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -1351,6 +1351,72 @@ impl Default for StreamingTextState {
     }
 }
 
+/// State for a streaming markdown display.
+///
+/// Accumulates markdown chunks as they arrive from an LLM stream.
+/// Pass to [`Context::streaming_markdown`](crate::Context::streaming_markdown) each frame.
+pub struct StreamingMarkdownState {
+    /// The accumulated markdown content.
+    pub content: String,
+    /// Whether the stream is still receiving data.
+    pub streaming: bool,
+    /// Cursor blink state (for the typing indicator).
+    pub cursor_visible: bool,
+    pub cursor_tick: u64,
+    pub in_code_block: bool,
+    pub code_block_lang: String,
+}
+
+impl StreamingMarkdownState {
+    /// Create a new empty streaming markdown state.
+    pub fn new() -> Self {
+        Self {
+            content: String::new(),
+            streaming: false,
+            cursor_visible: true,
+            cursor_tick: 0,
+            in_code_block: false,
+            code_block_lang: String::new(),
+        }
+    }
+
+    /// Append a markdown chunk (e.g., from an LLM stream delta).
+    pub fn push(&mut self, chunk: &str) {
+        self.content.push_str(chunk);
+    }
+
+    /// Start a new streaming session, clearing previous content.
+    pub fn start(&mut self) {
+        self.content.clear();
+        self.streaming = true;
+        self.cursor_visible = true;
+        self.cursor_tick = 0;
+        self.in_code_block = false;
+        self.code_block_lang.clear();
+    }
+
+    /// Mark the stream as complete (hides the typing cursor).
+    pub fn finish(&mut self) {
+        self.streaming = false;
+    }
+
+    /// Clear all content and reset state.
+    pub fn clear(&mut self) {
+        self.content.clear();
+        self.streaming = false;
+        self.cursor_visible = true;
+        self.cursor_tick = 0;
+        self.in_code_block = false;
+        self.code_block_lang.clear();
+    }
+}
+
+impl Default for StreamingMarkdownState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Approval state for a tool call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApprovalAction {


### PR DESCRIPTION
## Release v0.12.0

### Features
- **Custom Backend API**: `pub trait Backend { size, buffer_mut, flush }` + `AppState` + `slt::frame()` — enables custom rendering targets (WebGL, egui, SSH, test harnesses)
- **`streaming_markdown()`**: New widget combining streaming text with markdown rendering — headings, bold, italic, inline code, bullet lists, code blocks with blinking cursor

### Bug Fixes
- **`confirm()` hook panic on tab switch**: Removed internal `use_state()` — was the only widget using internal hooks, causing panic when conditionally rendered. Now uses `result: &mut bool` directly.

### Improvements
- `parse_inline_segments()` visibility → `pub(crate)` for cross-module reuse
- README: Added Custom Backends guide and AI-Native Widgets table

### Version files updated
- `Cargo.toml`: 0.11.0 → 0.12.0
- `Cargo.lock`: auto-updated
- `CHANGELOG.md`: added v0.12.0 section

### Changes since v0.11.0
- ci: Add dependency audit in CI (#19, @utilForever)
- feat: Backend trait, AppState, frame() public API
- feat: streaming_markdown widget
- fix: confirm() use_state removal
- docs: README architecture section