### PR TITLE
feat: v0.12.6 — Kitty graphics protocol image widget and BLACKPINK wiki demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.12.6] — 2026-03-17
+
+### Features
+
+- **Kitty graphics protocol**: `kitty_image()` renders pixel-perfect images via Kitty protocol (Ghostty, Kitty, WezTerm)
+- **demo_wiki**: BLACKPINK wiki-style demo with Kitty images and tabbed member profiles
+
 ## [0.12.5] — 2026-03-17
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "superlighttui"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "compact_str",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "superlighttui"
-version = "0.12.5"
+version = "0.12.6"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"
@@ -82,6 +82,10 @@ path = "examples/demo_website.rs"
 [[example]]
 name = "demo_infoviz"
 path = "examples/demo_infoviz.rs"
+
+[[example]]
+name = "demo_wiki"
+path = "examples/demo_wiki.rs"
 
 [[example]]
 name = "demo_fire"

--- a/examples/demo_wiki.rs
+++ b/examples/demo_wiki.rs
@@ -1,0 +1,271 @@
+use slt::{Border, Color, Context, KeyCode, RunConfig, ScrollState, Style, TabsState, Theme};
+
+struct MemberProfile {
+    tab: &'static str,
+    name: &'static str,
+    born: &'static str,
+    position: &'static str,
+    nationality: &'static str,
+    note: &'static str,
+}
+
+const MEMBERS: [MemberProfile; 4] = [
+    MemberProfile {
+        tab: "Jisoo",
+        name: "Kim Jisoo (김지수)",
+        born: "1995-01-03",
+        position: "Lead Vocal",
+        nationality: "South Korea",
+        note: "Eldest member, actress in Snowdrop",
+    },
+    MemberProfile {
+        tab: "Jennie",
+        name: "Jennie Kim (제니)",
+        born: "1996-01-16",
+        position: "Main Rapper & Lead Vocal",
+        nationality: "South Korea",
+        note: "Solo debut 2018, 6 years trainee",
+    },
+    MemberProfile {
+        tab: "Rosé",
+        name: "Park Chaeyoung (로제/박채영)",
+        born: "1997-02-11",
+        position: "Main Vocal & Lead Dancer",
+        nationality: "South Korea/New Zealand",
+        note: "Born in NZ, raised in Australia",
+    },
+    MemberProfile {
+        tab: "Lisa",
+        name: "Lalisa Manobal (리사)",
+        born: "1997-03-27",
+        position: "Main Dancer & Lead Rapper",
+        nationality: "Thailand",
+        note: "Most followed K-pop idol on Instagram",
+    },
+];
+
+fn main() -> std::io::Result<()> {
+    let mut tabs = TabsState::new(vec![
+        "Jisoo",
+        "Jennie",
+        "Rosé",
+        "Lisa",
+        "Group",
+        "Discography",
+    ]);
+    let mut scroll = ScrollState::new();
+
+    let member_images: Vec<Vec<u8>> = vec![
+        gen_member_image(200, 300, [255, 105, 180], "JISOO"),
+        gen_member_image(200, 300, [220, 20, 60], "JENNIE"),
+        gen_member_image(200, 300, [255, 127, 80], "ROSE"),
+        gen_member_image(200, 300, [148, 103, 189], "LISA"),
+    ];
+
+    slt::run_with(
+        RunConfig {
+            mouse: true,
+            theme: Theme::dark(),
+            ..Default::default()
+        },
+        move |ui: &mut Context| {
+            let quit_q = ui.key('q');
+            let quit_esc = ui.key_code(KeyCode::Esc);
+            if quit_q || quit_esc {
+                ui.quit();
+            }
+
+            ui.bordered(Border::Single).col(|ui| {
+                ui.container().bg(Color::Rgb(28, 30, 34)).p(1).row(|ui| {
+                    ui.text("BLACKPINK").bold().fg(Color::Rgb(255, 105, 180));
+                    ui.text("  블랙핑크").fg(Color::White);
+                    ui.spacer();
+                    ui.text("나무위키 스타일").fg(Color::Rgb(126, 211, 33));
+                });
+
+                let tab_resp = ui.tabs(&mut tabs);
+                if tab_resp.changed {
+                    scroll.offset = 0;
+                }
+
+                ui.scrollable(&mut scroll)
+                    .grow(1)
+                    .col(|ui| match tabs.selected {
+                        0..=3 => render_member(ui, tabs.selected, &member_images),
+                        4 => render_group(ui),
+                        _ => render_discography(ui),
+                    });
+
+                ui.help(&[("← →", "tab"), ("q", "quit"), ("↑ ↓", "scroll")]);
+            });
+        },
+    )
+}
+
+fn render_member(ui: &mut Context, idx: usize, member_images: &[Vec<u8>]) {
+    let p = &MEMBERS[idx];
+    ui.bordered(Border::Single).p(1).row(|ui| {
+        ui.bordered(Border::Single)
+            .title(format!("{} Photo", p.tab))
+            .w(34)
+            .p(1)
+            .col(|ui| {
+                ui.kitty_image(&member_images[idx], 200, 300, 30, 18);
+            });
+
+        ui.bordered(Border::Single)
+            .title("Profile Info")
+            .grow(1)
+            .p(1)
+            .col(|ui| {
+                info_row(ui, "Name", p.name);
+                info_row(ui, "Born", p.born);
+                info_row(ui, "Position", p.position);
+                info_row(ui, "Nationality", p.nationality);
+                info_row(ui, "Note", p.note);
+            });
+    });
+}
+
+fn render_group(ui: &mut Context) {
+    ui.bordered(Border::Single).title("Group").p(1).col(|ui| {
+        info_row(ui, "Debut", "2016-08-08");
+        info_row(ui, "Agency", "YG Entertainment");
+        info_row(ui, "Fandom", "BLINK");
+        info_row(ui, "Note", "First K-pop girl group at Coachella");
+    });
+}
+
+fn render_discography(ui: &mut Context) {
+    ui.bordered(Border::Single)
+        .title("Discography")
+        .p(1)
+        .col(|ui| {
+            ui.text("SQUARE ONE (2016)");
+            ui.text("SQUARE UP (2018)");
+            ui.text("THE ALBUM (2020)");
+            ui.text("BORN PINK (2022)");
+        });
+}
+
+fn info_row(ui: &mut Context, key: &str, value: &str) {
+    ui.line(|ui| {
+        ui.styled(
+            format!("{key}: "),
+            Style::new().fg(Color::Indexed(250)).bold(),
+        );
+        ui.text(value);
+    });
+}
+
+fn gen_member_image(w: u32, h: u32, base: [u8; 3], label: &str) -> Vec<u8> {
+    let mut rgba = gen_gradient(w, h, base);
+    draw_label_band(&mut rgba, w, h);
+    draw_text_5x7(&mut rgba, w, h, label, Color::Rgb(245, 245, 245), 3);
+    rgba
+}
+
+fn gen_gradient(w: u32, h: u32, base: [u8; 3]) -> Vec<u8> {
+    let mut rgba = Vec::with_capacity((w * h * 4) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let tx = x as f32 / w as f32;
+            let ty = y as f32 / h as f32;
+            let glow = (0.08 * tx).min(0.08);
+            let r = (base[0] as f32 * (1.0 - ty * 0.52) + 255.0 * glow).clamp(0.0, 255.0) as u8;
+            let g = (base[1] as f32 * (1.0 - ty * 0.30) + 220.0 * glow).clamp(0.0, 255.0) as u8;
+            let b = (base[2] as f32 * (1.0 - ty * 0.50) + 255.0 * glow).clamp(0.0, 255.0) as u8;
+            rgba.extend_from_slice(&[r, g, b, 255]);
+        }
+    }
+    rgba
+}
+
+fn draw_label_band(rgba: &mut [u8], w: u32, h: u32) {
+    let y_start = h.saturating_sub(86);
+    for y in y_start..h {
+        for x in 0..w {
+            let idx = ((y * w + x) * 4) as usize;
+            rgba[idx] = ((rgba[idx] as u16 * 38) / 100) as u8;
+            rgba[idx + 1] = ((rgba[idx + 1] as u16 * 38) / 100) as u8;
+            rgba[idx + 2] = ((rgba[idx + 2] as u16 * 38) / 100) as u8;
+        }
+    }
+}
+
+fn draw_text_5x7(rgba: &mut [u8], w: u32, h: u32, text: &str, color: Color, scale: u32) {
+    let color = match color {
+        Color::Rgb(r, g, b) => [r, g, b],
+        _ => [245, 245, 245],
+    };
+
+    let glyph_w = 5 * scale;
+    let spacing = scale;
+    let count = text.chars().count() as u32;
+    let total_w = count
+        .saturating_mul(glyph_w + spacing)
+        .saturating_sub(spacing);
+    let start_x = w.saturating_sub(total_w) / 2;
+    let start_y = h.saturating_sub(68);
+
+    for (i, ch) in text.chars().enumerate() {
+        let Some(rows) = glyph_rows(ch) else {
+            continue;
+        };
+        let ox = start_x + (i as u32) * (glyph_w + spacing);
+        for (row, bits) in rows.iter().enumerate() {
+            for col in 0..5 {
+                if (bits >> (4 - col)) & 1 == 0 {
+                    continue;
+                }
+                for sy in 0..scale {
+                    for sx in 0..scale {
+                        let x = ox + col as u32 * scale + sx;
+                        let y = start_y + row as u32 * scale + sy;
+                        if x >= w || y >= h {
+                            continue;
+                        }
+                        let idx = ((y * w + x) * 4) as usize;
+                        rgba[idx] = color[0];
+                        rgba[idx + 1] = color[1];
+                        rgba[idx + 2] = color[2];
+                        rgba[idx + 3] = 255;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn glyph_rows(ch: char) -> Option<[u8; 7]> {
+    match ch {
+        'A' => Some([
+            0b01110, 0b10001, 0b10001, 0b11111, 0b10001, 0b10001, 0b10001,
+        ]),
+        'E' => Some([
+            0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b11111,
+        ]),
+        'I' => Some([
+            0b11111, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b11111,
+        ]),
+        'J' => Some([
+            0b00111, 0b00010, 0b00010, 0b00010, 0b10010, 0b10010, 0b01100,
+        ]),
+        'L' => Some([
+            0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b11111,
+        ]),
+        'N' => Some([
+            0b10001, 0b11001, 0b10101, 0b10011, 0b10001, 0b10001, 0b10001,
+        ]),
+        'O' => Some([
+            0b01110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01110,
+        ]),
+        'R' => Some([
+            0b11110, 0b10001, 0b10001, 0b11110, 0b10100, 0b10010, 0b10001,
+        ]),
+        'S' => Some([
+            0b01111, 0b10000, 0b10000, 0b01110, 0b00001, 0b00001, 0b11110,
+        ]),
+        _ => None,
+    }
+}

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -23,6 +23,7 @@ pub struct Buffer {
     /// Flat row-major storage of all cells. Length equals `area.width * area.height`.
     pub content: Vec<Cell>,
     pub(crate) clip_stack: Vec<Rect>,
+    pub(crate) raw_sequences: Vec<(u32, u32, String)>,
 }
 
 impl Buffer {
@@ -33,7 +34,15 @@ impl Buffer {
             area,
             content: vec![Cell::default(); size],
             clip_stack: Vec::new(),
+            raw_sequences: Vec::new(),
         }
+    }
+
+    /// Store a raw escape sequence to be written at position `(x, y)` during flush.
+    ///
+    /// Used for Kitty graphics protocol and other passthrough sequences.
+    pub fn raw_sequence(&mut self, x: u32, y: u32, seq: String) {
+        self.raw_sequences.push((x, y, seq));
     }
 
     /// Push a clipping rectangle onto the clip stack.
@@ -248,6 +257,7 @@ impl Buffer {
             cell.reset();
         }
         self.clip_stack.clear();
+        self.raw_sequences.clear();
     }
 
     /// Reset every cell and apply a background color to all cells.
@@ -257,6 +267,7 @@ impl Buffer {
             cell.style.bg = Some(bg);
         }
         self.clip_stack.clear();
+        self.raw_sequences.clear();
     }
 
     /// Resize the buffer to fit a new area, resetting all cells.

--- a/src/context/widgets_display.rs
+++ b/src/context/widgets_display.rs
@@ -256,6 +256,55 @@ impl Context {
         Response::none()
     }
 
+    /// Render a pixel-perfect image using the Kitty graphics protocol.
+    ///
+    /// The image data must be raw RGBA bytes (4 bytes per pixel).
+    /// The widget allocates `cols` x `rows` cells and renders the image
+    /// at full pixel resolution within that space.
+    ///
+    /// Requires a Kitty-compatible terminal (Kitty, Ghostty, WezTerm).
+    /// On unsupported terminals, the area will be blank.
+    ///
+    /// # Arguments
+    /// * `rgba` - Raw RGBA pixel data
+    /// * `pixel_width` - Image width in pixels
+    /// * `pixel_height` - Image height in pixels
+    /// * `cols` - Terminal cell columns to occupy
+    /// * `rows` - Terminal cell rows to occupy
+    pub fn kitty_image(
+        &mut self,
+        rgba: &[u8],
+        pixel_width: u32,
+        pixel_height: u32,
+        cols: u32,
+        rows: u32,
+    ) {
+        let encoded = base64_encode(rgba);
+        let pw = pixel_width;
+        let ph = pixel_height;
+        let c = cols;
+        let r = rows;
+
+        self.container().w(cols).h(rows).draw(move |buf, rect| {
+            let chunks = split_base64(&encoded, 4096);
+            let mut all_sequences = String::new();
+
+            for (i, chunk) in chunks.iter().enumerate() {
+                let more = if i < chunks.len() - 1 { 1 } else { 0 };
+                if i == 0 {
+                    all_sequences.push_str(&format!(
+                        "\x1b_Ga=T,f=32,s={},v={},c={},r={},C=1,q=2,m={};{}\x1b\\",
+                        pw, ph, c, r, more, chunk
+                    ));
+                } else {
+                    all_sequences.push_str(&format!("\x1b_Gm={};{}\x1b\\", more, chunk));
+                }
+            }
+
+            buf.raw_sequence(rect.x, rect.y, all_sequences);
+        });
+    }
+
     /// Render streaming text with a typing cursor indicator.
     ///
     /// Displays the accumulated text content. While `streaming` is true,
@@ -1799,4 +1848,43 @@ fn render_highlighted_line(ui: &mut Context, line: &str) {
         ui.text(&trimmed[pos..end]);
         pos = end;
     }
+}
+
+fn base64_encode(data: &[u8]) -> String {
+    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut result = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as u32;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as u32;
+        let triple = (b0 << 16) | (b1 << 8) | b2;
+        result.push(CHARS[((triple >> 18) & 0x3F) as usize] as char);
+        result.push(CHARS[((triple >> 12) & 0x3F) as usize] as char);
+        if chunk.len() > 1 {
+            result.push(CHARS[((triple >> 6) & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
+        if chunk.len() > 2 {
+            result.push(CHARS[(triple & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
+    }
+    result
+}
+
+fn split_base64(encoded: &str, chunk_size: usize) -> Vec<&str> {
+    let mut chunks = Vec::new();
+    let bytes = encoded.as_bytes();
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let end = (offset + chunk_size).min(bytes.len());
+        chunks.push(&encoded[offset..end]);
+        offset = end;
+    }
+    if chunks.is_empty() {
+        chunks.push("");
+    }
+    chunks
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -153,6 +153,11 @@ impl Terminal {
             queue!(self.stdout, ResetColor, SetAttribute(Attribute::Reset))?;
         }
 
+        for (x, y, seq) in &self.current.raw_sequences {
+            queue!(self.stdout, cursor::MoveTo(*x as u16, *y as u16))?;
+            queue!(self.stdout, Print(seq))?;
+        }
+
         queue!(self.stdout, EndSynchronizedUpdate)?;
 
         let cursor_pos = find_cursor_marker(&self.current);
@@ -316,6 +321,12 @@ impl InlineTerminal {
                 queue!(self.stdout, Print("\x1b]8;;\x07"))?;
             }
             queue!(self.stdout, ResetColor, SetAttribute(Attribute::Reset))?;
+        }
+
+        for (x, y, seq) in &self.current.raw_sequences {
+            let abs_y = self.start_row as u32 + *y;
+            queue!(self.stdout, cursor::MoveTo(*x as u16, abs_y as u16))?;
+            queue!(self.stdout, Print(seq))?;
         }
 
         queue!(self.stdout, EndSynchronizedUpdate)?;


### PR DESCRIPTION
## Summary

- **Kitty graphics protocol**: New `kitty_image()` widget renders pixel-perfect images via Kitty protocol. Works on Ghostty, Kitty, WezTerm. No external dependencies (manual base64 impl).
- **demo_wiki**: BLACKPINK namu-wiki-style demo with tabbed member profiles, gradient placeholder images via kitty_image(), and group/discography views.
- **Buffer raw_sequences**: New infrastructure for passthrough escape sequences (used by Kitty images, extensible for future protocols like Sixel/iTerm2).

## Files Changed
- `src/buffer.rs` — raw_sequences field + raw_sequence() method
- `src/terminal.rs` — flush raw sequences in Terminal + InlineTerminal
- `src/context/widgets_display.rs` — kitty_image() + base64 helpers
- `examples/demo_wiki.rs` — BLACKPINK wiki demo (300 lines)
- `Cargo.toml` + `CHANGELOG.md` — version 0.12.6