### PR TITLE
feat: v0.12.9 — border_fg, separator chaining, help_colored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.12.9] — 2026-03-17
+
+### Features
+
+- **`border_fg(Color)`**: ContainerBuilder shorthand for border foreground color
+- **`separator_colored(Color)`**: Separator with custom color
+- **`separator()` chaining**: Now returns `&mut Self` — `.fg()`, `.dim()` etc. chainable
+- **`help_colored(bindings, key_color, text_color)`**: Help bar with custom key/text colors
+
 ## [0.12.8] — 2026-03-17
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "superlighttui"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "compact_str",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "superlighttui"
-version = "0.12.8"
+version = "0.12.9"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/src/context.rs
+++ b/src/context.rs
@@ -1001,6 +1001,12 @@ impl<'a> ContainerBuilder<'a> {
         self
     }
 
+    /// Set the border foreground color.
+    pub fn border_fg(mut self, color: Color) -> Self {
+        self.border_style = self.border_style.fg(color);
+        self
+    }
+
     /// Border style used when dark mode is active.
     pub fn dark_border_style(mut self, style: Style) -> Self {
         self.dark_border_style = Some(style);

--- a/src/context/widgets_interactive.rs
+++ b/src/context/widgets_interactive.rs
@@ -2112,7 +2112,7 @@ impl Context {
     ///
     /// The line is drawn with the theme's border color and expands to fill the
     /// container width.
-    pub fn separator(&mut self) -> Response {
+    pub fn separator(&mut self) -> &mut Self {
         self.commands.push(Command::Text {
             content: "─".repeat(200),
             style: Style::new().fg(self.theme.border).dim(),
@@ -2123,7 +2123,21 @@ impl Context {
             constraints: Constraints::default(),
         });
         self.last_text_idx = Some(self.commands.len() - 1);
-        Response::none()
+        self
+    }
+
+    pub fn separator_colored(&mut self, color: Color) -> &mut Self {
+        self.commands.push(Command::Text {
+            content: "─".repeat(200),
+            style: Style::new().fg(color),
+            grow: 0,
+            align: Align::Start,
+            wrap: false,
+            margin: Margin::default(),
+            constraints: Constraints::default(),
+        });
+        self.last_text_idx = Some(self.commands.len() - 1);
+        self
     }
 
     /// Render a help bar showing keybinding hints.
@@ -2159,6 +2173,46 @@ impl Context {
             }
             self.styled(*key, Style::new().bold().fg(self.theme.primary));
             self.styled(*action, Style::new().fg(self.theme.text_dim));
+        }
+        self.commands.push(Command::EndContainer);
+        self.last_text_idx = None;
+
+        Response::none()
+    }
+
+    pub fn help_colored(
+        &mut self,
+        bindings: &[(&str, &str)],
+        key_color: Color,
+        text_color: Color,
+    ) -> Response {
+        if bindings.is_empty() {
+            return Response::none();
+        }
+
+        self.interaction_count += 1;
+        self.commands.push(Command::BeginContainer {
+            direction: Direction::Row,
+            gap: 2,
+            align: Align::Start,
+            justify: Justify::Start,
+            border: None,
+            border_sides: BorderSides::all(),
+            border_style: Style::new().fg(self.theme.border),
+            bg_color: None,
+            padding: Padding::default(),
+            margin: Margin::default(),
+            constraints: Constraints::default(),
+            title: None,
+            grow: 0,
+            group_name: None,
+        });
+        for (idx, (key, action)) in bindings.iter().enumerate() {
+            if idx > 0 {
+                self.styled("·", Style::new().fg(text_color));
+            }
+            self.styled(*key, Style::new().bold().fg(key_color));
+            self.styled(*action, Style::new().fg(text_color));
         }
         self.commands.push(Command::EndContainer);
         self.last_text_idx = None;


### PR DESCRIPTION
## Summary
- `border_fg(Color)` — ContainerBuilder shorthand for border color
- `separator()` → `&mut Self` — now chainable: `ui.separator().fg(Color::Cyan)`
- `separator_colored(Color)` — direct color shorthand
- `help_colored(bindings, key_color, text_color)` — customizable help bar