### PR TITLE
chore: release v0.12.11

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default: all files require review from @subinium
+# Expand per-module as contributors join.
+
+* @subinium

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Description
+
+<!-- What happened? What did you expect instead? -->
+
+## Steps to Reproduce
+
+```rust
+// Minimal code that demonstrates the issue
+```
+
+## Expected Behavior
+
+<!-- What should have happened? -->
+
+## Actual Behavior
+
+<!-- What actually happened? Include terminal output or screenshots if helpful. -->
+
+## Environment
+
+- **SLT version**: <!-- e.g., 0.12.10 -->
+- **Rust version**: <!-- `rustc --version` -->
+- **OS**: <!-- e.g., macOS 15.3, Ubuntu 24.04 -->
+- **Terminal**: <!-- e.g., iTerm2, WezTerm, Ghostty, Windows Terminal -->
+- **Features enabled**: <!-- e.g., async, serde, image, full -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+<!-- What problem does this solve? What's the use case? -->
+
+## Proposed Solution
+
+<!-- How should it work? Include API sketch if possible. -->
+
+```rust
+// Example of desired API
+```
+
+## Alternatives Considered
+
+<!-- Any other approaches you've thought about? -->
+
+## Additional Context
+
+<!-- Screenshots, links to similar features in other libraries, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## What
+
+<!-- One-line summary of what this PR does -->
+
+## Why
+
+<!-- Why is this change needed? Link to issue if applicable -->
+
+## Checklist
+
+### Required
+
+- [ ] `cargo fmt -- --check` passes
+- [ ] `cargo check --all-features` passes
+- [ ] `cargo clippy --all-features -- -D warnings` passes
+- [ ] `cargo test --all-features` passes
+- [ ] `cargo check --examples --all-features` passes
+
+### Public API Changes
+
+- [ ] New public items have doc comments (`///`)
+- [ ] Widget follows the [Response pattern](DESIGN_PRINCIPLES.md#3-widget-contract)
+- [ ] State struct in `widgets.rs`, impl on `Context`, re-export in `lib.rs`
+- [ ] Breaking change? Update CHANGELOG.md and note it here
+
+### If Adding a Widget
+
+- [ ] Calls `register_focusable()` if interactive
+- [ ] Consumes handled key events
+- [ ] Uses `self.theme.*` for default colors
+- [ ] Example added or existing example updated
+
+### If Applicable
+
+- [ ] Tests added
+- [ ] Animation uses build-time pre-sort (not per-frame)
+- [ ] No `unwrap()` in Result-returning functions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,24 @@ jobs:
           components: rustfmt
       - run: cargo fmt -- --check
 
+  docs:
+    name: Doc Coverage
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: RUSTFLAGS="-Wmissing_docs" cargo check --all-features 2>&1 | grep -c "missing documentation" || echo "0 missing docs"
+
+  semver:
+    name: Semver Check
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+
   audit:
     name: Audit
     runs-on: ubuntu-latest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,198 @@
+# SLT Architecture
+
+This document describes how the code is organized and how data flows through the system.
+For design philosophy and conventions, see [DESIGN_PRINCIPLES.md](DESIGN_PRINCIPLES.md).
+
+---
+
+## Module Map
+
+```
+src/
+├── lib.rs                      # Crate root
+│   ├── Re-exports (public API surface)
+│   ├── Backend trait
+│   ├── AppState, RunConfig
+│   └── run(), run_with(), run_inline(), run_async(), frame()
+│
+├── context.rs                  # The "UI handle" — passed to user closures
+│   ├── Context struct (25+ fields: layout, focus, scroll, animation, hooks, theme, events, debug)
+│   ├── ContainerBuilder        # Fluent builder for row/col/grid containers
+│   ├── Response                # Widget interaction result { clicked, hovered, changed, focused, rect }
+│   └── State<T> / use_state()  # Hook system for component-local state
+│
+├── context/
+│   ├── widgets_display.rs      # impl Context: text, styled, button, tabs, modal, overlay, markdown, code_block...
+│   ├── widgets_interactive.rs  # impl Context: list, table, select, radio, multi_select, tree, virtual_list...
+│   ├── widgets_input.rs        # impl Context: text_input, textarea, form_field, validation
+│   └── widgets_viz.rs          # impl Context: chart, bar_chart, sparkline, histogram, canvas, scatter, candlestick...
+│
+├── widgets.rs                  # State structs: TextInputState, TableState, ListState, SelectState, TabsState...
+│                               # (30+ state types — one per interactive widget)
+│
+├── layout.rs                   # Layout engine
+│   ├── Command enum            # Flat representation of UI calls
+│   ├── LayoutNode              # Tree node with resolved children
+│   ├── build_tree()            # Command list → LayoutNode tree
+│   └── collect_all()           # Single DFS pass — collects focus, scroll, hits, animations, draws, modals, toasts
+│
+├── layout/
+│   ├── flexbox.rs              # compute(), layout_row(), layout_column(), gap/grow/shrink resolution
+│   └── render.rs               # render(), render_inner(), render_border(), clipping, viewport culling
+│
+├── style.rs                    # Style struct, Border, Padding, Margin, Constraints, Modifiers, Align, Justify
+├── style/
+│   ├── color.rs                # Color enum (Named, Indexed, Rgb), ColorDepth, color blending
+│   └── theme.rs                # Theme struct, 7 presets (dark, light, dracula, catppuccin, nord, solarized, tokyo_night), ThemeBuilder
+│
+├── terminal.rs                 # Terminal backend
+│   ├── Terminal                # Full-screen mode — alternate screen, raw mode, mouse capture
+│   ├── InlineTerminal          # Inline mode — renders below cursor, no alternate screen
+│   └── ANSI output, synchronized output (DECSET 2026), event polling
+│
+├── terminal/
+│   └── selection.rs            # SelectionState, text selection overlay rendering
+│
+├── anim.rs                     # Animation primitives
+│   ├── Tween                   # Linear interpolation with 9 easing functions
+│   ├── Spring                  # Physics-based spring animation
+│   ├── Keyframes               # Timeline with stops and loop modes
+│   ├── Sequence                # Chained tween segments
+│   └── Stagger                 # Delayed animation for list items
+│
+├── chart.rs                    # ChartBuilder, ChartConfig, Dataset, Marker
+├── chart/
+│   ├── render.rs               # Chart rendering, histogram
+│   ├── axis.rs                 # Axis struct, label formatting
+│   ├── bar.rs                  # Bar chart rendering
+│   ├── grid.rs                 # Grid lines
+│   └── braille.rs              # Braille dot patterns for line/scatter charts
+│
+├── buffer.rs                   # Double-buffer with clip stack and diff tracking
+├── cell.rs                     # Cell = char + Style + optional URL
+├── rect.rs                     # Rect struct, bounds checking, intersection
+├── event.rs                    # Event, KeyCode, KeyModifiers, MouseEvent, MouseButton
+├── halfblock.rs                # Half-block (▀▄) image rendering
+├── keymap.rs                   # KeyMap, Binding structs
+├── palette.rs                  # 256-color palette definitions
+└── test_utils.rs               # TestBackend, EventBuilder for headless testing
+```
+
+---
+
+## Frame Lifecycle
+
+Every frame follows this exact sequence:
+
+```
+1. EVENT POLL
+   └── Terminal polls for keyboard/mouse events (non-blocking)
+   └── Events stored in Context for widget consumption
+
+2. USER CLOSURE
+   └── User's closure runs: ui.text(), ui.button(), ui.col(), etc.
+   └── Each call pushes a Command to Context's internal command list
+   └── No layout is computed yet — just recording intent
+
+3. BUILD TREE — build_tree()
+   └── Flat Command list → nested LayoutNode tree
+   └── Parent-child relationships resolved from open/close markers
+
+4. COLLECT ALL — collect_all()
+   └── Single DFS traversal of the LayoutNode tree
+   └── Collects: focus targets, scroll regions, hit areas,
+       animation values, draw closures, modals, toasts
+   └── This single pass replaced 7 separate traversals (v0.9)
+
+5. FLEXBOX LAYOUT
+   └── layout_row() / layout_column()
+   └── Resolves: sizes, gaps, grow factors, min/max constraints
+   └── Breakpoint-conditional styles evaluated against terminal width
+
+6. RENDER
+   └── render() → render_inner() → render_border()
+   └── Writes Cell values to the back buffer
+   └── Clip stack ensures children don't overflow parent bounds
+   └── Viewport culling: nodes fully outside the viewport are skipped
+
+7. DIFF + FLUSH
+   └── Compare front buffer (previous frame) vs back buffer (current frame)
+   └── apply_style_delta() — only emit ANSI attributes that changed
+   └── Synchronized output (DECSET 2026) prevents tearing on supported terminals
+   └── Swap front ↔ back buffers
+```
+
+---
+
+## One-Frame Delay Feedback
+
+Layout-computed data feeds back to the **next** frame via `prev_*` fields on Context:
+
+```
+Frame N:   closure runs → layout computed → focus_count, hit_areas, scroll_bounds stored
+                                            ↓
+Frame N+1: closure reads prev_focus_count, prev_hit_areas → makes decisions
+```
+
+This is an intentional design choice of immediate-mode UI:
+- Widget positions are not known until layout runs (after the closure)
+- So interaction checks (hover, click) use positions from the previous frame
+- This introduces a one-frame delay that is imperceptible at 60 FPS
+
+Interactive widgets depend on `prev_*` data for hit testing, scroll bounds, and focus count.
+
+---
+
+## Module Dependency Flow
+
+```
+lib.rs (entry point)
+  ├── context.rs ←── context/widgets_*.rs (impl blocks on Context)
+  │     ↑
+  │     ├── widgets.rs (state types)
+  │     ├── style.rs ←── style/color.rs, style/theme.rs
+  │     ├── layout.rs ←── layout/flexbox.rs, layout/render.rs
+  │     ├── buffer.rs ←── cell.rs
+  │     ├── anim.rs
+  │     ├── event.rs
+  │     └── rect.rs
+  │
+  ├── terminal.rs ←── terminal/selection.rs
+  │     ↑
+  │     └── buffer.rs, event.rs (for flush and polling)
+  │
+  └── chart.rs ←── chart/render.rs, chart/axis.rs, chart/bar.rs, chart/grid.rs, chart/braille.rs
+```
+
+Key observations:
+- `context.rs` is the central hub — it depends on almost everything
+- `terminal.rs` is isolated — it only knows about `buffer` and `event`
+- `style`, `layout`, `anim` are independent of each other
+- Widget submodules (`context/widgets_*.rs`) add `impl Context` blocks — they don't define new types
+
+---
+
+## Visibility Rules
+
+| Visibility | Use when | Example |
+|------------|----------|---------|
+| `pub` | Part of the user-facing API | `pub fn text()`, `pub struct Style` |
+| `pub(crate)` | Shared across modules, not for users | `pub(crate) struct FrameData` |
+| `pub(super)` | Shared with parent module's submodules only | `pub(super) fn render_border()` |
+| Private (no modifier) | Implementation detail within a single file | Helper functions, internal state |
+
+### Re-export Rule
+
+**The public API is defined by `lib.rs` re-exports.** Users should never need deep imports like `slt::context::widgets_display::...`. If something is public, it must be re-exported from the crate root.
+
+### Why This Matters for Semver
+
+Every `pub use` in `lib.rs` is a semver commitment. Adding a re-export is non-breaking. Removing one is breaking. Be deliberate about what gets re-exported.
+
+---
+
+## File Conventions
+
+- **Module pattern**: `module.rs` + `module/` directory (Rust 2018 style, NOT `mod.rs`)
+- **Submodule imports**: `use super::*;` to access parent types
+- **Splitting safety**: When splitting a file, keep `#[derive(...)]` and `#[cfg_attr(...)]` attached to their type definitions — they must not get separated by the split boundary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.12.11] — 2026-03-18
+
+### Documentation
+
+- Add `DESIGN_PRINCIPLES.md` — core design philosophy, widget contract, error handling guide, API stability policy
+- Add `ARCHITECTURE.md` — module map, frame lifecycle, data flow, visibility rules
+- Add `SECURITY.md` — vulnerability reporting policy
+- Add PR template with quality checklist
+- Add issue templates (bug report, feature request)
+- Add `CODEOWNERS`
+- Enhance `CONTRIBUTING.md` with widget creation checklist and design principles reference
+
+### Internal
+
+- Add crate-level lints: `forbid(unsafe_code)`, `deny(clippy::unwrap_in_result)`, `warn(clippy::unwrap_used)`, `warn(clippy::dbg_macro)`, `warn(clippy::print_stdout)`, `warn(clippy::print_stderr)`, rustdoc link lints
+- Add doc coverage CI check (non-blocking) for `missing_docs` tracking
+- Add `doc_auto_cfg` — feature-gated items now display their required feature on docs.rs
+- Add `cargo-semver-checks` to CI (informational, non-blocking)
+- Reduce crates.io package size (exclude `AUDIT-REPORT.md`, `CLAUDE.md`)
+
 ## [0.12.10] — 2026-03-17
 
 ### Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,13 @@
 # Contributing to SLT
 
+Before contributing, read:
+- **[DESIGN_PRINCIPLES.md](DESIGN_PRINCIPLES.md)** — Why things are the way they are
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — How the code is organized
+
 ## Getting Started
 
 ```sh
-git clone https://github.com/[owner]/superlighttui.git
+git clone https://github.com/subinium/SuperLightTUI.git
 cd superlighttui
 cargo test
 cargo run --example demo
@@ -21,9 +25,8 @@ cargo build --features async
 ### Test
 
 ```sh
-cargo test
-cargo clippy
-cargo clippy --features async
+cargo test --all-features
+cargo clippy --all-features -- -D warnings
 ```
 
 ### Run Examples
@@ -37,31 +40,61 @@ cargo run --example anim
 cargo run --example async_demo --features async
 ```
 
+### Quality Gate (run ALL before submitting)
+
+```sh
+cargo fmt -- --check
+cargo check --all-features
+cargo clippy --all-features -- -D warnings
+cargo test --all-features
+cargo check --examples --all-features
+```
+
 ## Pull Requests
 
 - Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`
-- Run `cargo test` and `cargo clippy` before submitting
+- Run the full quality gate above before submitting
 - One logical change per PR
 - Add examples for new widgets
+- The [PR template](.github/PULL_REQUEST_TEMPLATE.md) includes a checklist — complete it
 
 ## Code Style
 
-- No `unsafe` code
+- No `unsafe` code — enforced by `#![forbid(unsafe_code)]`
+- No `unwrap()` in functions returning `Result` — enforced by lint
+- No `println!()`/`eprintln!()`/`dbg!()` in library code — enforced by lint
 - No unnecessary comments — code should be self-documenting
 - Use `self.theme.X` for colors, never hardcode
-- Follow existing patterns in `context.rs` for new widgets:
-  1. State struct in `widgets.rs`
-  2. Rendering method on `Context` in `context.rs`
-  3. Re-export in `lib.rs`
-- Widget methods should:
-  - Call `register_focusable()` if interactive
-  - Consume handled key events
-  - Use theme colors as defaults
+
+## Adding a Widget
+
+Follow this checklist when adding a new widget:
+
+1. **State struct** in `widgets.rs` — name it `{Widget}State`, implement `Default`
+2. **Rendering method** on `Context` in `context/widgets_interactive.rs` (or `widgets_display.rs` for non-interactive)
+3. **Re-export** in `lib.rs`
+4. **Doc comment** (`///`) on the public method with usage example
+5. **Response pattern** — interactive widgets return `Response`, display widgets return `&mut Self`
+6. **Focus** — call `register_focusable()` if the widget accepts keyboard input
+7. **Events** — consume handled key events so they don't bubble
+8. **Theme** — use `self.theme.*` for default colors
+9. **Example** — add to an existing example or create a new one
+
+## Error Handling
+
+See [DESIGN_PRINCIPLES.md — Error Handling](DESIGN_PRINCIPLES.md#6-error-handling) for the full policy.
+
+Summary:
+- Use `io::Result` for fallible operations
+- `panic!()` only for programmer errors (with descriptive messages)
+- No custom error types — `io::Error` is sufficient for SLT's error paths
 
 ## Architecture
 
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full module map and data flow.
+
 ```
-User closure -> Context collects Commands -> build_tree() -> flexbox compute -> render to Buffer -> diff -> flush
+User closure → Context collects Commands → build_tree() → flexbox compute → render to Buffer → diff → flush
 ```
 
 - **Immediate mode**: Each frame, the closure runs and describes the UI
@@ -87,7 +120,7 @@ git push --tags
 ```
 
 The release workflow (`.github/workflows/release.yml`) will:
-1. Run full CI (check, test, clippy, fmt) on stable + MSRV 1.74
+1. Run full CI (check, test, clippy, fmt) on stable + MSRV 1.81
 2. Verify tag matches `Cargo.toml` version
 3. Publish to crates.io
 4. Create GitHub Release with notes extracted from CHANGELOG.md
@@ -96,4 +129,6 @@ The release workflow (`.github/workflows/release.yml`) will:
 
 ## Dependencies
 
-Only `crossterm` and `unicode-width`. `tokio` is optional behind the `async` feature flag. Do not add new dependencies without discussion.
+Core: `crossterm`, `unicode-width`, `compact_str`. Optional: `tokio` (async), `serde`, `image`.
+
+Do not add new dependencies without discussion. See [DESIGN_PRINCIPLES.md — Dependencies](DESIGN_PRINCIPLES.md#9-dependencies).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "superlighttui"
-version = "0.12.10"
+version = "0.12.11"
 dependencies = [
  "compact_str",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "superlighttui"
-version = "0.12.10"
+version = "0.12.11"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"
@@ -11,7 +11,7 @@ readme = "README.md"
 keywords = ["tui", "terminal", "cli", "ui", "immediate-mode"]
 categories = ["command-line-interface"]
 rust-version = "1.81"
-exclude = ["examples/", ".github/"]
+exclude = ["examples/", ".github/", "AUDIT-REPORT.md", "CLAUDE.md"]
 
 [lib]
 name = "slt"

--- a/DESIGN_PRINCIPLES.md
+++ b/DESIGN_PRINCIPLES.md
@@ -1,0 +1,236 @@
+# SLT Design Principles
+
+These principles guide every design decision in SLT.
+Read this before contributing code. If a decision conflicts with these principles, raise it in the PR.
+
+---
+
+## 1. Ease of Use Above All
+
+SLT exists so that building a TUI is as easy as building a web page.
+Every API decision is judged by: **"Can a developer use this correctly on the first try, without reading the docs?"**
+
+```rust
+// 5 lines. No App struct. No Model/Update/View. No event loop.
+fn main() -> std::io::Result<()> {
+    slt::run(|ui| {
+        ui.text("hello, world");
+    })
+}
+```
+
+If an API requires explanation, the API is wrong — not the developer.
+
+---
+
+## 2. Your Closure IS the App
+
+SLT is an **immediate-mode** UI library. There is no framework state to manage.
+
+- You write a closure. SLT calls it every frame.
+- State lives in YOUR code — variables, structs, whatever you want.
+- Layout is described every frame, not stored in a retained tree.
+- No message passing, no trait implementations, no lifecycle hooks.
+
+```rust
+let mut count = 0;
+slt::run(|ui| {
+    if ui.button("+1").clicked { count += 1; }
+    ui.text(format!("Count: {count}"));
+});
+```
+
+This is the foundational decision. Every other principle flows from it.
+
+---
+
+## 3. Widget Contract
+
+Every widget follows the same pattern. No exceptions.
+
+### Interactive Widgets
+
+```rust
+pub fn widget_name(&mut self, state: &mut WidgetState) -> Response
+```
+
+- Return `Response` — contains `clicked`, `hovered`, `changed`, `focused`, `rect`
+- Call `register_focusable()` for keyboard navigation
+- Consume handled key events (don't let them bubble)
+- Use `self.theme.*` for default colors — never hardcode
+
+### Display Widgets
+
+```rust
+pub fn text(&mut self, content: impl Into<String>) -> &mut Self
+```
+
+- Return `&mut Self` for chaining (`.bold().fg(Color::Cyan)`)
+- No focusable registration
+- No event consumption
+
+### Containers
+
+```rust
+pub fn col(self, f: impl FnOnce(&mut Context)) -> Response
+```
+
+- `ContainerBuilder` uses consuming `self` pattern (builder is done after `.col()`/`.row()`)
+- Return `Response` for interaction detection
+
+### State Structs
+
+- Live in `widgets.rs` — e.g., `TextInputState`, `TableState`
+- Named `{Widget}State`
+- Implement `Default` when sensible
+- Re-exported from `lib.rs`
+
+---
+
+## 4. Layout = CSS Flexbox, Syntax = Tailwind
+
+Layout uses flexbox semantics: `row()`, `col()`, `gap()`, `grow()`, `spacer()`.
+Styling uses Tailwind-inspired shorthand:
+
+| Full name | Shorthand |
+|-----------|-----------|
+| `.padding(2)` | `.p(2)` |
+| `.margin(1)` | `.m(1)` |
+| `.width(20)` | `.w(20)` |
+| `.height(10)` | `.h(10)` |
+
+Both forms are always available. Shorthand is preferred in examples.
+
+### Responsive Breakpoints
+
+Prefix with breakpoint: `.md_w(40)`, `.lg_p(2)`, `.xl_gap(3)`.
+Breakpoints: Xs (<40), Sm (40-79), Md (80-119), Lg (120-159), Xl (>=160).
+
+### Builder Patterns
+
+| Builder | Pattern | Why |
+|---------|---------|-----|
+| `ContainerBuilder` | Consuming `self` | Forces explicit finalization (`.col()`, `.row()`, `.draw()`) |
+| `Style` | Consuming `mut self` | Chainable, zero-cost |
+| `ChartBuilder` | Mutable `&mut self` | Historical — scheduled for unification in v1.0 |
+
+---
+
+## 5. State Ownership
+
+| State type | Owner | Example |
+|------------|-------|---------|
+| Application state | User's closure | `let mut count = 0;` |
+| Component-local state | Hook system | `ui.use_state(|| 0)` |
+| Widget state | User | `let mut input = TextInputState::new()` |
+
+### Hook Rules (same as React)
+
+- `use_state()` and `use_memo()` must be called in the **same order** every frame
+- Never call hooks inside conditionals or loops
+- Hook type mismatches panic with a descriptive message — this is a programmer error
+
+---
+
+## 6. Error Handling
+
+SLT uses `std::io::Result` for all fallible operations.
+**We intentionally avoid custom error types.**
+
+| Category | Mechanism | When |
+|----------|-----------|------|
+| Terminal I/O failure | `io::Result` | `run()`, `flush()`, event polling |
+| Programmer error | `panic!()` with message | Hook type mismatch, invariant violation |
+| Input validation | `Result<(), String>` | User-provided validator closures |
+
+### Rules
+
+- **No `unwrap()` in Result-returning functions** — enforced by `clippy::unwrap_in_result`
+- **Panics are for programmer errors only** — never for user input or I/O
+- Panic messages must include context: index, expected type, actual value
+- Use `#[track_caller]` on public functions that may panic
+
+### Why No Custom Error Type?
+
+SLT's only runtime error path is terminal I/O. Wrapping `io::Error` in `SltError` would:
+- Add API surface that becomes a semver commitment
+- Require `From` conversions with no added information
+- Complicate downstream `?` chains
+
+When distinct error categories emerge (config parsing, resource loading, backend initialization), we will introduce a structured error type. Not before.
+
+---
+
+## 7. Performance Principles
+
+SLT renders at 60+ FPS on modest hardware. These patterns keep it fast:
+
+| Technique | What it does |
+|-----------|-------------|
+| `collect_all()` | Single DFS pass replaces 7 separate tree traversals |
+| `apply_style_delta()` | Only emits changed ANSI attributes per cell during flush |
+| Keyframe pre-sort | Stops sorted at build time, not per-frame |
+| Double-buffer diff | Only changed cells are written to the terminal |
+| Viewport culling | Off-screen widgets are skipped entirely |
+
+### Rules
+
+- Performance changes must not break correctness — run the full test suite
+- Measure before optimizing — use the `benchmarks` bench suite (`cargo bench`)
+- Minimize per-frame allocations — prefer reuse over allocation
+- Profile before assuming — `cargo flamegraph` for hot path identification
+
+---
+
+## 8. API Stability
+
+SLT follows [Semantic Versioning](https://semver.org/).
+
+| Version range | Compatibility promise |
+|---------------|----------------------|
+| 0.12.x (patch) | Backward compatible — no breaking changes |
+| 0.x → 0.y (minor) | May contain breaking changes (pre-1.0) |
+| 1.x (post-1.0) | Strict semver — breaking changes only in major versions |
+
+### MSRV Policy
+
+- Minimum Supported Rust Version is declared in `Cargo.toml` (`rust-version`)
+- MSRV bumps only happen in **minor** version releases
+- MSRV bumps are documented in CHANGELOG.md
+
+### Deprecation
+
+- Deprecate before removing: at least one minor version with `#[deprecated]`
+- Deprecated items include a migration path in the deprecation message
+- Removal happens in the next minor version at earliest
+
+---
+
+## 9. Dependencies
+
+**Minimal by design.**
+
+| Dependency | Purpose | Required? |
+|------------|---------|-----------|
+| `crossterm` | Terminal I/O, event polling | Yes |
+| `unicode-width` | Character width measurement | Yes |
+| `compact_str` | String optimization | Yes |
+| `tokio` | Async runtime | Optional (`async` feature) |
+| `serde` | Serialization | Optional (`serde` feature) |
+| `image` | Image loading | Optional (`image` feature) |
+
+### Rules
+
+- Do not add new required dependencies without discussion
+- Optional dependencies go behind feature flags
+- Feature flags must be **additive** — enabling a feature must not remove types or change existing behavior
+- Prefer `dep:` syntax in `[features]` to avoid implicit feature names
+
+---
+
+## 10. Safety
+
+- **Zero `unsafe` code** — enforced by `#![forbid(unsafe_code)]`
+- No `unwrap()` in library code where `Result` is returned — enforced by `clippy::unwrap_in_result`
+- `dbg!()`, `println!()`, `eprintln!()` are forbidden in library code — enforced by clippy lints
+- `missing_docs` tracked via CI (non-blocking) — all new public API items should have doc comments

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.12.x  | Yes       |
+| < 0.12  | No        |
+
+Only the latest minor release receives security fixes.
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, use one of these methods:
+
+1. **GitHub Security Advisory** (preferred): [Report a vulnerability](https://github.com/subinium/SuperLightTUI/security/advisories/new)
+2. **Email**: Contact the maintainer directly (see GitHub profile)
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Impact assessment (if known)
+
+### Response Timeline
+
+- **Acknowledgment**: Within 48 hours
+- **Initial assessment**: Within 7 days
+- **Fix release**: Depends on severity (critical: ASAP, others: next patch)
+
+### Scope
+
+SLT is a terminal UI rendering library. Security concerns typically involve:
+
+- Terminal escape sequence injection
+- Denial of service through malformed input
+- Unsafe memory access (SLT uses `#![forbid(unsafe_code)]`)
+- Dependency vulnerabilities (monitored by `cargo-audit` in CI)
+
+### After a Fix
+
+- A patch version is released with the fix
+- The vulnerability is disclosed in CHANGELOG.md after the fix is available
+- Credit is given to the reporter (unless they prefer anonymity)

--- a/src/context.rs
+++ b/src/context.rs
@@ -24,7 +24,7 @@ fn slt_assert(condition: bool, msg: &str) {
 }
 
 #[cfg(debug_assertions)]
-#[allow(dead_code)]
+#[allow(dead_code, clippy::print_stderr)]
 fn slt_warn(msg: &str) {
     eprintln!("\x1b[33m[SLT warning]\x1b[0m {}", msg);
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1091,6 +1091,7 @@ fn collect_raw_draw_rects_inner(node: &LayoutNode, rects: &mut Vec<(usize, Rect)
 }
 
 #[cfg(test)]
+#[allow(clippy::print_stderr)]
 mod tests {
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,17 @@
+// Safety
+#![forbid(unsafe_code)]
+// Documentation
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![warn(rustdoc::broken_intra_doc_links)]
+#![warn(rustdoc::private_intra_doc_links)]
+// Correctness
+#![deny(clippy::unwrap_in_result)]
+#![warn(clippy::unwrap_used)]
+// Library hygiene — a library must not write to stdout/stderr
+#![warn(clippy::dbg_macro)]
+#![warn(clippy::print_stdout)]
+#![warn(clippy::print_stderr)]
+
 //! # SLT — Super Light TUI
 //!
 //! Immediate-mode terminal UI for Rust. Two dependencies. Zero `unsafe`.
@@ -244,6 +258,7 @@ pub fn frame(
 
 static PANIC_HOOK_ONCE: Once = Once::new();
 
+#[allow(clippy::print_stderr)]
 fn install_panic_hook() {
     PANIC_HOOK_ONCE.call_once(|| {
         let original = std::panic::take_hook();


### PR DESCRIPTION
## Release v0.12.11 — Governance Setup

### Summary
Project governance foundation: design principles, architecture docs, security policy, crate-level lints, CI enhancements, and docs.rs improvements. Zero code logic changes.

### New Files (7)
- `DESIGN_PRINCIPLES.md` — 10-section design philosophy (widget contract, error handling, API stability, performance rules)
- `ARCHITECTURE.md` — Module map, frame lifecycle (7-stage pipeline), data flow, visibility rules
- `SECURITY.md` — Vulnerability reporting policy (GitHub Security Advisory)
- `.github/PULL_REQUEST_TEMPLATE.md` — Quality checklist for PRs
- `.github/CODEOWNERS` — Review assignment
- `.github/ISSUE_TEMPLATE/bug_report.md` — Structured bug reports
- `.github/ISSUE_TEMPLATE/feature_request.md` — Feature request template

### Modified Files (7)
- `src/lib.rs` — Crate-level lints: `forbid(unsafe_code)`, `deny(clippy::unwrap_in_result)`, `warn(clippy::unwrap_used, dbg_macro, print_stdout, print_stderr)`, rustdoc link lints, `doc_auto_cfg` for docs.rs
- `.github/workflows/ci.yml` — Added `docs` (non-blocking doc coverage) and `semver` (non-blocking API compat check) jobs
- `CONTRIBUTING.md` — Added design principles references, 9-step widget creation checklist, error handling guide
- `Cargo.toml` — Version 0.12.11, exclude `AUDIT-REPORT.md` and `CLAUDE.md` from crates.io
- `CHANGELOG.md` — v0.12.11 entry
- `src/context.rs` — `#[allow(clippy::print_stderr)]` on `slt_warn` (debug-only stderr output)
- `src/layout.rs` — `#[allow(clippy::print_stderr)]` on test module

### Quality Gate
- [x] `cargo fmt -- --check`
- [x] `cargo check --all-features`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --all-features` (52 passed)
- [x] `cargo check --examples --all-features`