### PR TITLE
fix: v0.12.13 — docs.rs build fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.12.13] — 2026-03-18
+
+### Fixes
+
+- Fix docs.rs build failure: replace removed `doc_auto_cfg` feature with `doc_cfg` (removed in rustc 1.92.0, merged into `doc_cfg`)
+
 ## [0.12.12] — 2026-03-18
 
 ### Improvements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "superlighttui"
-version = "0.12.12"
+version = "0.12.13"
 dependencies = [
  "compact_str",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "superlighttui"
-version = "0.12.12"
+version = "0.12.13"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // Safety
 #![forbid(unsafe_code)]
 // Documentation
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(rustdoc::broken_intra_doc_links)]
 #![warn(rustdoc::private_intra_doc_links)]
 // Correctness


### PR DESCRIPTION
## Hotfix v0.12.13

### Problem
docs.rs fails to build v0.12.11 and v0.12.12 because `feature(doc_auto_cfg)` was removed in rustc 1.92.0 and merged into `doc_cfg` ([rust-lang/rust#138907](https://github.com/rust-lang/rust/pull/138907)).

### Fix
`#![cfg_attr(docsrs, feature(doc_auto_cfg))]` → `#![cfg_attr(docsrs, feature(doc_cfg))]`

### Changes
- `src/lib.rs`: one-line feature gate fix
- `Cargo.toml`: version bump to 0.12.13
- `CHANGELOG.md`: hotfix entry