### PR TITLE
chore: v0.14.2 — docs, Event accessors, cfg cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.14.2] — 2026-03-19
+
+### Improvements
+
+- **100% doc coverage** — all 101 previously undocumented pub items now have `///` doc comments
+- **`#![warn(missing_docs)]`** enabled crate-wide — future pub items without docs produce compiler warnings
+- **Event safe accessors** — `Event::as_key()`, `Event::as_mouse()`, `Event::as_resize()`, `Event::as_paste()` return `Option` instead of panicking
+
+### Fixes
+
+- **cfg-gate cleanup** — 9 dead-code warnings when building with `--no-default-features` eliminated. `PANIC_HOOK_ONCE`, `update_last_mouse_pos`, `clear_frame_layout_cache`, `sleep_for_fps_cap` now properly gated behind `crossterm` feature. `sixel_image()` split into crossterm/non-crossterm variants.
+
 ## [0.14.1] — 2026-03-19
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,7 +1052,7 @@ checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "superlighttui"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "compact_str",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/slt-wasm"]
 
 [package]
 name = "superlighttui"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/src/context.rs
+++ b/src/context.rs
@@ -126,7 +126,9 @@ pub struct Bar {
     pub value: f64,
     /// Bar color. If None, uses theme.primary.
     pub color: Option<Color>,
+    /// Optional text label displayed on the bar.
     pub text_value: Option<String>,
+    /// Optional style for the value text.
     pub value_style: Option<Style>,
 }
 
@@ -148,23 +150,31 @@ impl Bar {
         self
     }
 
+    /// Set the display text for this bar's value.
     pub fn text_value(mut self, text: impl Into<String>) -> Self {
         self.text_value = Some(text.into());
         self
     }
 
+    /// Set the style for the value text.
     pub fn value_style(mut self, style: Style) -> Self {
         self.value_style = Some(style);
         self
     }
 }
 
+/// Configuration for bar chart rendering.
 #[derive(Debug, Clone, Copy)]
 pub struct BarChartConfig {
+    /// Bar direction (horizontal or vertical).
     pub direction: BarDirection,
+    /// Width of each bar in cells.
     pub bar_width: u16,
+    /// Gap between bars in the same group.
     pub bar_gap: u16,
+    /// Gap between bar groups.
     pub group_gap: u16,
+    /// Optional maximum value for scaling.
     pub max_value: Option<f64>,
 }
 
@@ -181,26 +191,31 @@ impl Default for BarChartConfig {
 }
 
 impl BarChartConfig {
+    /// Set the bar direction.
     pub fn direction(&mut self, direction: BarDirection) -> &mut Self {
         self.direction = direction;
         self
     }
 
+    /// Set the width of each bar in cells.
     pub fn bar_width(&mut self, bar_width: u16) -> &mut Self {
         self.bar_width = bar_width.max(1);
         self
     }
 
+    /// Set the gap between bars.
     pub fn bar_gap(&mut self, bar_gap: u16) -> &mut Self {
         self.bar_gap = bar_gap;
         self
     }
 
+    /// Set the gap between bar groups.
     pub fn group_gap(&mut self, group_gap: u16) -> &mut Self {
         self.group_gap = group_gap;
         self
     }
 
+    /// Set the maximum value for bar scaling.
     pub fn max_value(&mut self, max_value: f64) -> &mut Self {
         self.max_value = Some(max_value);
         self
@@ -509,6 +524,7 @@ struct CanvasLayer {
     labels: Vec<CanvasLabel>,
 }
 
+/// Drawing context for the canvas widget.
 pub struct CanvasContext {
     layers: Vec<CanvasLayer>,
     cols: usize,
@@ -1140,6 +1156,7 @@ impl<'a> ContainerBuilder<'a> {
         self
     }
 
+    /// Set the background color.
     pub fn bg(mut self, color: Color) -> Self {
         self.bg = Some(color);
         self
@@ -1303,7 +1320,7 @@ impl<'a> ContainerBuilder<'a> {
         md = md_w => ["Width applied only at Md breakpoint (80-119 cols)."],
         lg = lg_w => ["Width applied only at Lg breakpoint (120-159 cols)."],
         xl = xl_w => ["Width applied only at Xl breakpoint (>= 160 cols)."],
-        at = w_at => []
+        at = w_at => ["Width applied only at the given breakpoint."]
     );
 
     /// Set a fixed height (sets both min and max height).
@@ -1321,7 +1338,7 @@ impl<'a> ContainerBuilder<'a> {
         md = md_h => ["Height applied only at Md breakpoint (80-119 cols)."],
         lg = lg_h => ["Height applied only at Lg breakpoint (120-159 cols)."],
         xl = xl_h => ["Height applied only at Xl breakpoint (>= 160 cols)."],
-        at = h_at => []
+        at = h_at => ["Height applied only at the given breakpoint."]
     );
 
     /// Set the minimum width constraint. Shorthand for [`min_width`](Self::min_width).
@@ -1338,7 +1355,7 @@ impl<'a> ContainerBuilder<'a> {
         md = md_min_w => ["Minimum width applied only at Md breakpoint (80-119 cols)."],
         lg = lg_min_w => ["Minimum width applied only at Lg breakpoint (120-159 cols)."],
         xl = xl_min_w => ["Minimum width applied only at Xl breakpoint (>= 160 cols)."],
-        at = min_w_at => []
+        at = min_w_at => ["Minimum width applied only at the given breakpoint."]
     );
 
     /// Set the maximum width constraint. Shorthand for [`max_width`](Self::max_width).
@@ -1355,7 +1372,7 @@ impl<'a> ContainerBuilder<'a> {
         md = md_max_w => ["Maximum width applied only at Md breakpoint (80-119 cols)."],
         lg = lg_max_w => ["Maximum width applied only at Lg breakpoint (120-159 cols)."],
         xl = xl_max_w => ["Maximum width applied only at Xl breakpoint (>= 160 cols)."],
-        at = max_w_at => []
+        at = max_w_at => ["Maximum width applied only at the given breakpoint."]
     );
 
     /// Set the minimum height constraint. Shorthand for [`min_height`](Self::min_height).
@@ -1449,7 +1466,7 @@ impl<'a> ContainerBuilder<'a> {
         ],
         lg = lg_gap => ["Gap applied only at Lg breakpoint (120-159 cols)."],
         xl = xl_gap => ["Gap applied only at Xl breakpoint (>= 160 cols)."],
-        at = gap_at => []
+        at = gap_at => ["Gap applied only at the given breakpoint."]
     );
 
     /// Set the flex-grow factor. `1` means the container expands to fill available space.
@@ -1466,7 +1483,7 @@ impl<'a> ContainerBuilder<'a> {
         md = md_grow => ["Grow factor applied only at Md breakpoint (80-119 cols)."],
         lg = lg_grow => ["Grow factor applied only at Lg breakpoint (120-159 cols)."],
         xl = xl_grow => ["Grow factor applied only at Xl breakpoint (>= 160 cols)."],
-        at = grow_at => []
+        at = grow_at => ["Grow factor applied only at the given breakpoint."]
     );
 
     define_breakpoint_methods!(
@@ -1477,7 +1494,7 @@ impl<'a> ContainerBuilder<'a> {
         md = md_p => ["Uniform padding applied only at Md breakpoint (80-119 cols)."],
         lg = lg_p => ["Uniform padding applied only at Lg breakpoint (120-159 cols)."],
         xl = xl_p => ["Uniform padding applied only at Xl breakpoint (>= 160 cols)."],
-        at = p_at => []
+        at = p_at => ["Padding applied only at the given breakpoint."]
     );
 
     // ── alignment ───────────────────────────────────────────────────
@@ -2312,6 +2329,7 @@ fn textarea_visual_to_logical(
     }
 }
 
+#[allow(unused_variables)]
 fn open_url(url: &str) -> std::io::Result<()> {
     #[cfg(target_os = "macos")]
     {

--- a/src/context/widgets_display.rs
+++ b/src/context/widgets_display.rs
@@ -265,6 +265,7 @@ impl Context {
         self
     }
 
+    /// Set foreground color when the current group is hovered or focused.
     pub fn group_hover_fg(&mut self, color: Color) -> &mut Self {
         let apply_group_style = self
             .group_stack
@@ -277,6 +278,7 @@ impl Context {
         self
     }
 
+    /// Set background color when the current group is hovered or focused.
     pub fn group_hover_bg(&mut self, color: Color) -> &mut Self {
         let apply_group_style = self
             .group_stack
@@ -502,6 +504,8 @@ impl Context {
         Response::none()
     }
 
+    /// Render an image using the Sixel protocol.
+    #[cfg(feature = "crossterm")]
     pub fn sixel_image(
         &mut self,
         rgba: &[u8],
@@ -521,23 +525,9 @@ impl Context {
             return Response::none();
         }
 
-        #[cfg(not(feature = "crossterm"))]
-        {
-            self.container().w(cols).h(rows).draw(|buf, rect| {
-                if rect.width == 0 || rect.height == 0 {
-                    return;
-                }
-                buf.set_string(rect.x, rect.y, "[sixel unsupported]", Style::new());
-            });
-            return Response::none();
-        }
-
-        #[cfg(feature = "crossterm")]
         let rgba = normalize_rgba(rgba, pixel_w, pixel_h);
-        #[cfg(feature = "crossterm")]
         let encoded = crate::sixel::encode_sixel(&rgba, pixel_w, pixel_h, 256);
 
-        #[cfg(feature = "crossterm")]
         if encoded.is_empty() {
             self.container().w(cols).h(rows).draw(|buf, rect| {
                 if rect.width == 0 || rect.height == 0 {
@@ -548,12 +538,30 @@ impl Context {
             return Response::none();
         }
 
-        #[cfg(feature = "crossterm")]
         self.container().w(cols).h(rows).draw(move |buf, rect| {
             if rect.width == 0 || rect.height == 0 {
                 return;
             }
             buf.raw_sequence(rect.x, rect.y, encoded);
+        });
+        Response::none()
+    }
+
+    /// Render an image using the Sixel protocol.
+    #[cfg(not(feature = "crossterm"))]
+    pub fn sixel_image(
+        &mut self,
+        _rgba: &[u8],
+        _pixel_w: u32,
+        _pixel_h: u32,
+        cols: u32,
+        rows: u32,
+    ) -> Response {
+        self.container().w(cols).h(rows).draw(|buf, rect| {
+            if rect.width == 0 || rect.height == 0 {
+                return;
+            }
+            buf.set_string(rect.x, rect.y, "[sixel unsupported]", Style::new());
         });
         Response::none()
     }
@@ -935,6 +943,7 @@ impl Context {
         Response::none()
     }
 
+    /// Render an alert banner with icon and level-based coloring.
     pub fn alert(&mut self, message: &str, level: crate::widgets::AlertLevel) -> Response {
         use crate::widgets::AlertLevel;
 
@@ -1079,10 +1088,12 @@ impl Context {
         response
     }
 
+    /// Render a breadcrumb navigation bar. Returns the clicked segment index.
     pub fn breadcrumb(&mut self, segments: &[&str]) -> Option<usize> {
         self.breadcrumb_with(segments, " › ")
     }
 
+    /// Render a breadcrumb with a custom separator string.
     pub fn breadcrumb_with(&mut self, segments: &[&str], separator: &str) -> Option<usize> {
         let theme = self.theme;
         let last_idx = segments.len().saturating_sub(1);
@@ -1114,6 +1125,7 @@ impl Context {
         clicked_idx
     }
 
+    /// Collapsible section that toggles on click or Enter.
     pub fn accordion(
         &mut self,
         title: &str,
@@ -1154,6 +1166,7 @@ impl Context {
         response
     }
 
+    /// Render a key-value definition list with aligned columns.
     pub fn definition_list(&mut self, items: &[(&str, &str)]) -> Response {
         let max_key_width = items
             .iter()
@@ -1175,6 +1188,7 @@ impl Context {
         Response::none()
     }
 
+    /// Render a horizontal divider with a centered text label.
     pub fn divider_text(&mut self, label: &str) -> Response {
         let w = self.width();
         let label_len = unicode_width::UnicodeWidthStr::width(label) as u32;
@@ -1197,11 +1211,13 @@ impl Context {
         Response::none()
     }
 
+    /// Render a badge with the theme's primary color.
     pub fn badge(&mut self, label: &str) -> Response {
         let theme = self.theme;
         self.badge_colored(label, theme.primary)
     }
 
+    /// Render a badge with a custom background color.
     pub fn badge_colored(&mut self, label: &str, color: Color) -> Response {
         let fg = Color::contrast_fg(color);
         let mut label_text = String::with_capacity(label.len() + 2);
@@ -1213,6 +1229,7 @@ impl Context {
         Response::none()
     }
 
+    /// Render a keyboard shortcut hint with reversed styling.
     pub fn key_hint(&mut self, key: &str) -> Response {
         let theme = self.theme;
         let mut key_text = String::with_capacity(key.len() + 2);
@@ -1224,6 +1241,7 @@ impl Context {
         Response::none()
     }
 
+    /// Render a label-value stat pair.
     pub fn stat(&mut self, label: &str, value: &str) -> Response {
         let _ = self.col(|ui| {
             ui.text(label).dim();
@@ -1233,6 +1251,7 @@ impl Context {
         Response::none()
     }
 
+    /// Render a stat pair with a custom value color.
     pub fn stat_colored(&mut self, label: &str, value: &str, color: Color) -> Response {
         let _ = self.col(|ui| {
             ui.text(label).dim();
@@ -1242,6 +1261,7 @@ impl Context {
         Response::none()
     }
 
+    /// Render a stat pair with an up/down trend arrow.
     pub fn stat_trend(
         &mut self,
         label: &str,
@@ -1267,6 +1287,7 @@ impl Context {
         Response::none()
     }
 
+    /// Render a centered empty-state placeholder.
     pub fn empty_state(&mut self, title: &str, description: &str) -> Response {
         let _ = self.container().center().col(|ui| {
             ui.text(title).align(Align::Center);
@@ -1276,6 +1297,7 @@ impl Context {
         Response::none()
     }
 
+    /// Render a centered empty-state placeholder with an action button.
     pub fn empty_state_action(
         &mut self,
         title: &str,
@@ -1298,13 +1320,16 @@ impl Context {
         }
     }
 
+    /// Render a code block with keyword-based syntax highlighting.
     pub fn code_block(&mut self, code: &str) -> Response {
         self.code_block_lang(code, "")
     }
 
+    /// Render a code block with language-aware syntax highlighting.
     pub fn code_block_lang(&mut self, code: &str, lang: &str) -> Response {
         let theme = self.theme;
-        let highlighted = crate::syntax::highlight_code(code, lang, &theme);
+        let highlighted: Option<Vec<Vec<(String, Style)>>> =
+            crate::syntax::highlight_code(code, lang, &theme);
         let _ = self
             .bordered(Border::Rounded)
             .bg(theme.surface)
@@ -1322,15 +1347,18 @@ impl Context {
         Response::none()
     }
 
+    /// Render a code block with line numbers and keyword highlighting.
     pub fn code_block_numbered(&mut self, code: &str) -> Response {
         self.code_block_numbered_lang(code, "")
     }
 
+    /// Render a code block with line numbers and language-aware highlighting.
     pub fn code_block_numbered_lang(&mut self, code: &str, lang: &str) -> Response {
         let lines: Vec<&str> = code.lines().collect();
         let gutter_w = format!("{}", lines.len()).len();
         let theme = self.theme;
-        let highlighted = crate::syntax::highlight_code(code, lang, &theme);
+        let highlighted: Option<Vec<Vec<(String, Style)>>> =
+            crate::syntax::highlight_code(code, lang, &theme);
         let _ = self
             .bordered(Border::Rounded)
             .bg(theme.surface)
@@ -1412,6 +1440,7 @@ impl Context {
 
     // ── containers ───────────────────────────────────────────────────
 
+    /// Conditionally render content when the named screen is active.
     pub fn screen(&mut self, name: &str, screens: &ScreenState, f: impl FnOnce(&mut Context)) {
         if screens.current() == name {
             f(self);
@@ -2582,6 +2611,7 @@ fn split_base64(encoded: &str, chunk_size: usize) -> Vec<&str> {
     chunks
 }
 
+#[cfg(feature = "crossterm")]
 fn terminal_supports_sixel() -> bool {
     let force = std::env::var("SLT_FORCE_SIXEL")
         .ok()

--- a/src/context/widgets_input.rs
+++ b/src/context/widgets_input.rs
@@ -20,6 +20,7 @@ impl Context {
         self.text_input_colored(state, &WidgetColors::new())
     }
 
+    /// Render a text input with custom widget colors.
     pub fn text_input_colored(
         &mut self,
         state: &mut TextInputState,
@@ -786,10 +787,12 @@ impl Context {
     ///
     /// `ratio` is clamped to `0.0..=1.0`. `width` is the total number of
     /// characters rendered.
+    /// Render a progress bar filled to the given ratio (0.0–1.0).
     pub fn progress_bar(&mut self, ratio: f64, width: u32) -> &mut Self {
         self.progress_bar_colored(ratio, width, self.theme.primary)
     }
 
+    /// Render a progress bar with a custom fill color.
     pub fn progress_bar_colored(&mut self, ratio: f64, width: u32, color: Color) -> &mut Self {
         let clamped = ratio.clamp(0.0, 1.0);
         let filled = (clamped * width as f64).round() as u32;

--- a/src/context/widgets_interactive.rs
+++ b/src/context/widgets_interactive.rs
@@ -132,10 +132,12 @@ impl Context {
     ///
     /// The selected item is highlighted with the theme's primary color. If the
     /// list is empty, nothing is rendered.
+    /// Render a navigable list widget.
     pub fn list(&mut self, state: &mut ListState) -> Response {
         self.list_colored(state, &WidgetColors::new())
     }
 
+    /// Render a navigable list with custom widget colors.
     pub fn list_colored(&mut self, state: &mut ListState, colors: &WidgetColors) -> Response {
         let visible = state.visible_indices().to_vec();
         if visible.is_empty() && state.items.is_empty() {
@@ -250,6 +252,7 @@ impl Context {
         response
     }
 
+    /// Render a calendar date picker with month navigation.
     pub fn calendar(&mut self, state: &mut CalendarState) -> Response {
         let focused = self.register_focusable();
         let interaction_id = self.next_interaction_id();
@@ -494,6 +497,7 @@ impl Context {
         response
     }
 
+    /// Render a file system browser with directory navigation.
     pub fn file_picker(&mut self, state: &mut FilePickerState) -> Response {
         if state.dirty {
             state.refresh();
@@ -651,10 +655,12 @@ impl Context {
     ///
     /// Column widths are computed automatically from header and cell content.
     /// The selected row is highlighted with the theme's selection colors.
+    /// Render a data table with sortable columns and row selection.
     pub fn table(&mut self, state: &mut TableState) -> Response {
         self.table_colored(state, &WidgetColors::new())
     }
 
+    /// Render a data table with custom widget colors.
     pub fn table_colored(&mut self, state: &mut TableState, colors: &WidgetColors) -> Response {
         if state.is_dirty() {
             state.recompute_widths();
@@ -945,10 +951,12 @@ impl Context {
     ///
     /// The active tab is rendered in the theme's primary color. If the labels
     /// list is empty, nothing is rendered.
+    /// Render a horizontal tab bar.
     pub fn tabs(&mut self, state: &mut TabsState) -> Response {
         self.tabs_colored(state, &WidgetColors::new())
     }
 
+    /// Render a horizontal tab bar with custom widget colors.
     pub fn tabs_colored(&mut self, state: &mut TabsState, colors: &WidgetColors) -> Response {
         if state.labels.is_empty() {
             state.selected = 0;
@@ -1073,10 +1081,12 @@ impl Context {
     ///
     /// The button is styled with the theme's primary color when focused and the
     /// accent color when hovered.
+    /// Render a clickable button.
     pub fn button(&mut self, label: impl Into<String>) -> Response {
         self.button_colored(label, &WidgetColors::new())
     }
 
+    /// Render a clickable button with custom widget colors.
     pub fn button_colored(&mut self, label: impl Into<String>, colors: &WidgetColors) -> Response {
         let focused = self.register_focusable();
         let interaction_id = self.next_interaction_id();
@@ -1293,10 +1303,12 @@ impl Context {
     ///
     /// The checked state is shown with the theme's success color. When focused,
     /// a `▸` prefix is added.
+    /// Render a checkbox toggle.
     pub fn checkbox(&mut self, label: impl Into<String>, checked: &mut bool) -> Response {
         self.checkbox_colored(label, checked, &WidgetColors::new())
     }
 
+    /// Render a checkbox toggle with custom widget colors.
     pub fn checkbox_colored(
         &mut self,
         label: impl Into<String>,
@@ -1390,10 +1402,12 @@ impl Context {
     /// Toggles `on` when activated via Enter, Space, or click. The switch
     /// renders as `●━━ ON` or `━━● OFF` colored with the theme's success or
     /// dim color respectively.
+    /// Render an on/off toggle switch.
     pub fn toggle(&mut self, label: impl Into<String>, on: &mut bool) -> Response {
         self.toggle_colored(label, on, &WidgetColors::new())
     }
 
+    /// Render an on/off toggle switch with custom widget colors.
     pub fn toggle_colored(
         &mut self,
         label: impl Into<String>,
@@ -1487,10 +1501,12 @@ impl Context {
     /// Render a dropdown select. Shows the selected item; expands on activation.
     ///
     /// Returns `true` when the selection changed this frame.
+    /// Render a dropdown select widget.
     pub fn select(&mut self, state: &mut SelectState) -> Response {
         self.select_colored(state, &WidgetColors::new())
     }
 
+    /// Render a dropdown select widget with custom widget colors.
     pub fn select_colored(&mut self, state: &mut SelectState, colors: &WidgetColors) -> Response {
         if state.items.is_empty() {
             return Response::none();
@@ -1669,10 +1685,12 @@ impl Context {
     // ── radio ────────────────────────────────────────────────────────
 
     /// Render a radio button group. Returns `true` when selection changed.
+    /// Render a radio button group.
     pub fn radio(&mut self, state: &mut RadioState) -> Response {
         self.radio_colored(state, &WidgetColors::new())
     }
 
+    /// Render a radio button group with custom widget colors.
     pub fn radio_colored(&mut self, state: &mut RadioState, colors: &WidgetColors) -> Response {
         if state.items.is_empty() {
             return Response::none();
@@ -2637,7 +2655,7 @@ impl Context {
                     in_code_block = false;
                     let code_content = code_block_lines.join("\n");
                     let theme = self.theme;
-                    let highlighted =
+                    let highlighted: Option<Vec<Vec<(String, Style)>>> =
                         crate::syntax::highlight_code(&code_content, &code_block_lang, &theme);
                     let _ = self.container().bg(theme.surface).p(1).col(|ui| {
                         if let Some(ref hl_lines) = highlighted {
@@ -2875,6 +2893,7 @@ impl Context {
         self
     }
 
+    /// Render a horizontal separator line with a custom color.
     pub fn separator_colored(&mut self, color: Color) -> &mut Self {
         self.commands.push(Command::Text {
             content: "─".repeat(200),
@@ -2931,6 +2950,7 @@ impl Context {
         Response::none()
     }
 
+    /// Render a help bar with custom key/description colors.
     pub fn help_colored(
         &mut self,
         bindings: &[(&str, &str)],

--- a/src/context/widgets_viz.rs
+++ b/src/context/widgets_viz.rs
@@ -137,6 +137,7 @@ impl Context {
         )
     }
 
+    /// Render a bar chart with custom configuration.
     pub fn bar_chart_with(
         &mut self,
         bars: &[Bar],
@@ -498,6 +499,7 @@ impl Context {
         self.bar_chart_grouped_with(groups, |_| {}, max_width)
     }
 
+    /// Render a grouped bar chart with custom configuration.
     pub fn bar_chart_grouped_with(
         &mut self,
         groups: &[BarGroup],
@@ -1484,6 +1486,7 @@ impl Context {
     }
 
     #[cfg(feature = "qrcode")]
+    /// Render a QR code using half-block characters.
     pub fn qr_code(&mut self, data: impl AsRef<str>) -> Response {
         let code = match qrcode::QrCode::new(data.as_ref()) {
             Ok(code) => code,

--- a/src/event.rs
+++ b/src/event.rs
@@ -97,6 +97,38 @@ impl Event {
     pub fn paste(text: impl Into<String>) -> Self {
         Event::Paste(text.into())
     }
+
+    /// Returns the key event data if this is a `Key` variant.
+    pub fn as_key(&self) -> Option<&KeyEvent> {
+        match self {
+            Event::Key(k) => Some(k),
+            _ => None,
+        }
+    }
+
+    /// Returns the mouse event data if this is a `Mouse` variant.
+    pub fn as_mouse(&self) -> Option<&MouseEvent> {
+        match self {
+            Event::Mouse(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    /// Returns `(columns, rows)` if this is a `Resize` variant.
+    pub fn as_resize(&self) -> Option<(u32, u32)> {
+        match self {
+            Event::Resize(w, h) => Some((*w, *h)),
+            _ => None,
+        }
+    }
+
+    /// Returns the pasted text if this is a `Paste` variant.
+    pub fn as_paste(&self) -> Option<&str> {
+        match self {
+            Event::Paste(s) => Some(s),
+            _ => None,
+        }
+    }
 }
 
 /// A keyboard event with key code and modifiers.

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -29,10 +29,12 @@ pub struct Binding {
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct KeyMap {
+    /// Registered key bindings.
     pub bindings: Vec<Binding>,
 }
 
 impl KeyMap {
+    /// Create an empty key map.
     pub fn new() -> Self {
         Self::default()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 // Documentation
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(rustdoc::broken_intra_doc_links)]
+#![warn(missing_docs)]
 #![warn(rustdoc::private_intra_doc_links)]
 // Correctness
 #![deny(clippy::unwrap_in_result)]
@@ -51,13 +52,21 @@
 
 pub mod anim;
 pub mod buffer;
+/// Terminal cell representation.
 pub mod cell;
+/// Chart and data visualization widgets.
 pub mod chart;
+/// UI context, container builder, and widget rendering.
 pub mod context;
+/// Input events (keyboard, mouse, resize, paste).
 pub mod event;
+/// Half-block image rendering.
 pub mod halfblock;
+/// Keyboard shortcut mapping.
 pub mod keymap;
+/// Flexbox layout engine and command tree.
 pub mod layout;
+/// Color palettes (Tailwind-style).
 pub mod palette;
 pub mod rect;
 #[cfg(feature = "crossterm")]
@@ -74,6 +83,7 @@ use std::io;
 use std::io::IsTerminal;
 #[cfg(feature = "crossterm")]
 use std::io::Write;
+#[cfg(feature = "crossterm")]
 use std::sync::Once;
 use std::time::{Duration, Instant};
 
@@ -267,6 +277,7 @@ pub fn frame(
     run_frame(backend, &mut state.inner, config, events, f)
 }
 
+#[cfg(feature = "crossterm")]
 static PANIC_HOOK_ONCE: Once = Once::new();
 
 #[allow(clippy::print_stderr)]
@@ -1025,6 +1036,7 @@ fn run_frame(
     Ok(true)
 }
 
+#[cfg(feature = "crossterm")]
 fn update_last_mouse_pos(state: &mut FrameState, events: &[Event]) {
     for ev in events {
         match ev {
@@ -1039,6 +1051,7 @@ fn update_last_mouse_pos(state: &mut FrameState, events: &[Event]) {
     }
 }
 
+#[cfg(feature = "crossterm")]
 fn clear_frame_layout_cache(state: &mut FrameState) {
     state.prev_hit_map.clear();
     state.prev_group_rects.clear();
@@ -1062,6 +1075,7 @@ fn is_ctrl_c(ev: &Event) -> bool {
     )
 }
 
+#[cfg(feature = "crossterm")]
 fn sleep_for_fps_cap(max_fps: Option<u32>, frame_start: Instant) {
     if let Some(fps) = max_fps.filter(|fps| *fps > 0) {
         let target = Duration::from_secs_f64(1.0 / fps as f64);

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -3,19 +3,31 @@ use crate::Color;
 /// A color palette with 11 shades from lightest (c50) to darkest (c950).
 #[derive(Debug, Clone, Copy)]
 pub struct Palette {
+    /// Lightest shade (50).
     pub c50: Color,
+    /// Shade 100.
     pub c100: Color,
+    /// Shade 200.
     pub c200: Color,
+    /// Shade 300.
     pub c300: Color,
+    /// Shade 400.
     pub c400: Color,
+    /// Mid shade (500).
     pub c500: Color,
+    /// Shade 600.
     pub c600: Color,
+    /// Shade 700.
     pub c700: Color,
+    /// Shade 800.
     pub c800: Color,
+    /// Shade 900.
     pub c900: Color,
+    /// Darkest shade (950).
     pub c950: Color,
 }
 
+/// Tailwind CSS color palettes.
 pub mod tailwind {
     use super::Palette;
     use crate::Color;

--- a/src/style.rs
+++ b/src/style.rs
@@ -71,9 +71,13 @@ pub struct BorderChars {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BorderSides {
+    /// Top border visible.
     pub top: bool,
+    /// Right border visible.
     pub right: bool,
+    /// Bottom border visible.
     pub bottom: bool,
+    /// Left border visible.
     pub left: bool,
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -5,7 +5,25 @@
 //! Without those features the function always returns `None` so callers
 //! can fall back to the built-in keyword highlighter.
 
-use crate::style::{Color, Style, Theme};
+#[cfg(any(
+    feature = "syntax-rust",
+    feature = "syntax-python",
+    feature = "syntax-javascript",
+    feature = "syntax-typescript",
+    feature = "syntax-go",
+    feature = "syntax-bash",
+    feature = "syntax-json",
+    feature = "syntax-toml",
+    feature = "syntax-c",
+    feature = "syntax-cpp",
+    feature = "syntax-java",
+    feature = "syntax-ruby",
+    feature = "syntax-css",
+    feature = "syntax-html",
+    feature = "syntax-yaml",
+))]
+use crate::style::Color;
+use crate::style::{Style, Theme};
 
 /// Ordered list of tree-sitter highlight capture names.
 ///

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -462,11 +462,15 @@ pub(crate) use selection::{apply_selection_overlay, extract_selection_text, Sele
 #[cfg(test)]
 pub(crate) use selection::{find_innermost_rect, normalize_selection};
 
+/// Detected terminal color scheme from OSC 11.
 #[cfg(feature = "crossterm")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ColorScheme {
+    /// Dark background detected.
     Dark,
+    /// Light background detected.
     Light,
+    /// Could not determine the scheme.
     Unknown,
 }
 
@@ -509,6 +513,7 @@ fn read_osc_response(timeout: Duration) -> Option<String> {
     String::from_utf8(bytes).ok()
 }
 
+/// Query the terminal's background color via OSC 11 and return the detected scheme.
 #[cfg(feature = "crossterm")]
 pub fn detect_color_scheme() -> ColorScheme {
     let mut stdout = io::stdout();
@@ -621,6 +626,7 @@ fn parse_osc52_response(response: &str) -> Option<String> {
     base64_decode(encoded)
 }
 
+/// Read clipboard contents via OSC 52 terminal query.
 #[cfg(feature = "crossterm")]
 pub fn read_clipboard() -> Option<String> {
     let mut stdout = io::stdout();

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -361,6 +361,7 @@ pub enum ToastLevel {
     Error,
 }
 
+/// Severity level for alert widgets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AlertLevel {
     /// Informational alert.
@@ -1211,20 +1212,26 @@ impl Default for RichLogState {
     }
 }
 
+/// State for the calendar date picker widget.
 #[derive(Debug, Clone)]
 pub struct CalendarState {
+    /// Current display year.
     pub year: i32,
+    /// Current display month (1–12).
     pub month: u32,
+    /// Currently selected day, if any.
     pub selected_day: Option<u32>,
     pub(crate) cursor_day: u32,
 }
 
 impl CalendarState {
+    /// Create a new `CalendarState` initialized to the current month.
     pub fn new() -> Self {
         let (year, month) = Self::current_year_month();
         Self::from_ym(year, month)
     }
 
+    /// Create a `CalendarState` for a specific year and month.
     pub fn from_ym(year: i32, month: u32) -> Self {
         let month = month.clamp(1, 12);
         Self {
@@ -1235,10 +1242,12 @@ impl CalendarState {
         }
     }
 
+    /// Returns the selected date as `(year, month, day)`, if any.
     pub fn selected_date(&self) -> Option<(i32, u32, u32)> {
         self.selected_day.map(|day| (self.year, self.month, day))
     }
 
+    /// Navigate to the previous month.
     pub fn prev_month(&mut self) {
         if self.month == 1 {
             self.month = 12;
@@ -1249,6 +1258,7 @@ impl CalendarState {
         self.clamp_days();
     }
 
+    /// Navigate to the next month.
     pub fn next_month(&mut self) {
         if self.month == 12 {
             self.month = 1;
@@ -1351,6 +1361,7 @@ pub enum ButtonVariant {
     Outline,
 }
 
+/// Direction indicator for stat widgets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Trend {
     /// Positive movement.


### PR DESCRIPTION
## Summary

- **100% doc coverage** — 101 previously undocumented pub items now have doc comments
- **`#![warn(missing_docs)]`** enabled crate-wide
- **Event safe accessors** — `as_key()`, `as_mouse()`, `as_resize()`, `as_paste()` (non-breaking)
- **cfg-gate cleanup** — 9 dead-code warnings with `--no-default-features` eliminated

## No breaking changes

All changes are additive or internal cleanup. Existing API unchanged.