### PR TITLE
fix: v0.15.1 event ordering and global shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.15.1] — 2026-03-20
+
+### Fixes
+
+- **Tab/BackTab/Esc/F-keys now reachable via `key_code()` / `key_mod()`** — `process_focus_keys()` moved after user closure so user code sees events before the focus system consumes them. Focus cycling still works identically for apps that don't intercept Tab.
+- **`process_focus_keys()` respects consumed events** — if user calls `consume_key_code(KeyCode::Tab)`, the focus system no longer cycles on that event.
+
+### Features
+
+- **`raw_key_code(code)` / `raw_key_mod(c, mods)`** — global shortcut helpers that bypass the modal/overlay guard. Use for Esc-to-close, Ctrl+Q-to-quit, and other shortcuts that must work regardless of overlay state.
+
+### Demo
+
+- **`demo_key_test`** — interactive key event tester with mode switching, kitty keyboard toggle, and event log.
+
 ## [0.15.0] — 2026-03-19
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,7 +1052,7 @@ checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "superlighttui"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "compact_str",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/slt-wasm"]
 
 [package]
 name = "superlighttui"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/examples/demo_key_test.rs
+++ b/examples/demo_key_test.rs
@@ -1,0 +1,79 @@
+use slt::*;
+use std::time::Duration;
+
+fn main() -> std::io::Result<()> {
+    let kitty = std::env::args().any(|a| a == "--kitty");
+    let mut log: Vec<String> = Vec::new();
+    let mut input = TextInputState::with_placeholder("Type here...");
+    let mut mode = 0u8;
+    let modes = ["JENNIE", "LISA", "ROSÉ", "JISOO"];
+
+    log.push(format!("kitty_keyboard: {kitty}"));
+
+    let config = RunConfig::default()
+        .tick_rate(Duration::from_millis(33))
+        .mouse(true)
+        .kitty_keyboard(kitty)
+        .max_fps(30);
+
+    slt::run_with(config, |ui| {
+        if ui.key_code(KeyCode::BackTab) {
+            log.push("BackTab".into());
+            mode = (mode + 1) % 4;
+        }
+        if ui.key_code(KeyCode::Tab) {
+            log.push("Tab".into());
+        }
+        if ui.key_mod('t', KeyModifiers::CONTROL) {
+            log.push("Ctrl+T".into());
+        }
+        if ui.key_mod('c', KeyModifiers::CONTROL) {
+            log.push("Ctrl+C".into());
+            ui.quit();
+        }
+        if ui.key_code(KeyCode::Esc) {
+            log.push("Esc".into());
+        }
+        if ui.key_code(KeyCode::F(1)) {
+            log.push("F1".into());
+        }
+        if ui.key_code(KeyCode::F(2)) {
+            log.push("F2".into());
+            mode = (mode + 1) % 4;
+        }
+
+        let _ = ui.col(|ui| {
+            let _ = ui.container().h(1).px(1).row(|ui| {
+                let resp = ui.container().row(|ui| {
+                    ui.text(format!(" {} ", modes[mode as usize]))
+                        .bold()
+                        .fg(Color::Cyan);
+                });
+                if resp.clicked {
+                    log.push("Click -> mode".into());
+                    mode = (mode + 1) % 4;
+                }
+                ui.text(" . ").dim();
+                ui.text(format!("kitty={kitty}")).fg(Color::Yellow);
+                ui.spacer();
+                ui.text("SLT 0.15 Key Test").dim();
+            });
+            ui.separator();
+
+            let _ = ui.container().grow(1).p(1).col(|ui| {
+                ui.text("Events:").bold();
+                ui.text("");
+                for line in log.iter().rev().take(20) {
+                    ui.text(line).fg(Color::Green);
+                }
+            });
+            ui.separator();
+
+            let _ = ui.container().px(1).pb(1).col(|ui| {
+                let _ = ui.text_input(&mut input);
+                ui.text("Shift+Tab/F2=mode | Esc | Ctrl+T | Ctrl+C=quit | Click [MODE]")
+                    .dim();
+            });
+        });
+    })
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1817,6 +1817,9 @@ impl Context {
 
     pub(crate) fn process_focus_keys(&mut self) {
         for (i, event) in self.events.iter().enumerate() {
+            if self.consumed[i] {
+                continue;
+            }
             if let Event::Key(key) = event {
                 if key.kind != KeyEventKind::Press {
                     continue;

--- a/src/context/widgets_interactive.rs
+++ b/src/context/widgets_interactive.rs
@@ -3011,10 +3011,27 @@ impl Context {
     /// Check if a specific key code was pressed this frame.
     ///
     /// Returns `true` if the key event has not been consumed by another widget.
+    /// Blocked when a modal/overlay is active and the caller is outside the overlay.
+    /// Use [`raw_key_code`](Self::raw_key_code) for global shortcuts that must work
+    /// regardless of modal/overlay state.
     pub fn key_code(&self, code: KeyCode) -> bool {
         if (self.modal_active || self.prev_modal_active) && self.overlay_depth == 0 {
             return false;
         }
+        self.events.iter().enumerate().any(|(i, e)| {
+            !self.consumed[i]
+                && matches!(e, Event::Key(k) if k.kind == KeyEventKind::Press && k.code == code)
+        })
+    }
+
+    /// Check if a specific key code was pressed this frame, ignoring modal/overlay state.
+    ///
+    /// Unlike [`key_code`](Self::key_code), this method bypasses the modal/overlay guard
+    /// so it works even when a modal or overlay is active. Use this for global shortcuts
+    /// (e.g. Esc to close a modal, Ctrl+Q to quit) that must always be reachable.
+    ///
+    /// Returns `true` if the key event has not been consumed by another widget.
+    pub fn raw_key_code(&self, code: KeyCode) -> bool {
         self.events.iter().enumerate().any(|(i, e)| {
             !self.consumed[i]
                 && matches!(e, Event::Key(k) if k.kind == KeyEventKind::Press && k.code == code)
@@ -3105,6 +3122,14 @@ impl Context {
         if (self.modal_active || self.prev_modal_active) && self.overlay_depth == 0 {
             return false;
         }
+        self.events.iter().enumerate().any(|(i, e)| {
+            !self.consumed[i]
+                && matches!(e, Event::Key(k) if k.kind == KeyEventKind::Press && k.code == KeyCode::Char(c) && k.modifiers.contains(modifiers))
+        })
+    }
+
+    /// Like [`key_mod`](Self::key_mod) but bypasses the modal/overlay guard.
+    pub fn raw_key_mod(&self, c: char, modifiers: KeyModifiers) -> bool {
         self.events.iter().enumerate().any(|(i, e)| {
             !self.consumed[i]
                 && matches!(e, Event::Key(k) if k.kind == KeyEventKind::Press && k.code == KeyCode::Char(c) && k.modifiers.contains(modifiers))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -986,9 +986,9 @@ fn run_frame(
     let mut ctx = Context::new(events.to_vec(), w, h, state, config.theme);
     ctx.is_real_terminal = true;
     ctx.set_scroll_speed(config.scroll_speed);
-    ctx.process_focus_keys();
 
     f(&mut ctx);
+    ctx.process_focus_keys();
     ctx.render_notifications();
     ctx.emit_pending_tooltips();
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -225,8 +225,8 @@ impl TestBackend {
             &mut frame_state,
             Theme::dark(),
         );
-        ctx.process_focus_keys();
         f(&mut ctx);
+        ctx.process_focus_keys();
         ctx.render_notifications();
         ctx.emit_pending_tooltips();
         let mut tree = layout::build_tree(&ctx.commands);


### PR DESCRIPTION
## v0.15.1

### Why
Global shortcuts were blocked because focus key processing happened before user code and modal guard blocked overlay-outside checks.

### What
- Run `process_focus_keys()` after user closure
- Skip already-consumed events in focus processing
- Add `raw_key_code()` / `raw_key_mod()` for global shortcuts
- Add `examples/demo_key_test.rs`

### CI note
This PR replaces #41 with commit-message rules satisfied (`subject_capitalized=true`, `subject_length<=50`).