### PR TITLE
feat: v0.15.2 — focus API, markdown tables/links, text_input grow, image perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.15.2] — 2026-03-20
+
+### Features
+
+- **Programmatic focus control** — `ui.focus_index()`, `ui.set_focus_index(n)`, `ui.focus_count()` for keyboard focus management in complex UIs with multiple focusable widgets.
+- **Markdown pipe table rendering** — `ui.markdown()` now renders GFM-style pipe tables (`| A | B |`) with box-drawing borders and bold headers.
+- **Markdown link support** — `[text](url)` in `ui.markdown()` renders as clickable OSC 8 links via `ui.link()`. `![alt](url)` renders as `[Image: alt]` placeholder.
+- **text_input auto-fill** — `text_input()` now uses `grow(1)` internally, filling available width in row layouts without manual container wrapping.
+- **Sixel image docs** — `sixel_image()` docstring expanded with usage example and `SLT_FORCE_SIXEL` documentation (API was already public since v0.14.0).
+
+### Performance
+
+- **Image flush optimization** — `raw_sequences` (Kitty/Sixel image data) are now diff-compared between frames. Static images skip the delete + re-upload cycle entirely, reducing per-frame cost to zero for unchanged images.
+
+### Demo
+
+- **`v0.15.2` tab** in the demo showcasing markdown tables, links, focus control, and text_input grow.
+
 ## [0.15.1] — 2026-03-20
 
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/slt-wasm"]
 
 [package]
 name = "superlighttui"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -25,6 +25,7 @@ fn main() -> std::io::Result<()> {
         "v0.13.2",
         "v0.14.0",
         "v0.14.1",
+        "v0.15.2",
     ]);
     let mut section_tabs = TabsState::new(vec!["Primary", "Secondary", "Accent"]);
     let mut scroll = ScrollState::new();
@@ -385,6 +386,7 @@ fn main() -> std::io::Result<()> {
                             ),
                             14 => render_v014(ui, tick, &mut rich_log, &mut dir_tree),
                             15 => render_v0141(ui),
+                            16 => render_v0152(ui),
                             _ => {}
                         });
 
@@ -2440,4 +2442,152 @@ fn render_v094(
     let _ = ui.container().h(3).col(|ui| {
         let _ = ui.empty_state("No items yet", "Items will appear here when added");
     });
+}
+
+fn render_v0152(ui: &mut Context) {
+    section(
+        ui,
+        "v0.15.2 — MARKDOWN TABLES, FOCUS CONTROL, TEXT INPUT GROW",
+    );
+
+    // ── Markdown pipe table ─────────────────────────────────────────
+    let _ = ui.divider_text("Markdown Pipe Tables");
+    ui.text("ui.markdown() now renders GFM-style pipe tables with box-drawing borders.")
+        .dim();
+    ui.text("");
+
+    let _ = ui.row_gap(1, |ui| {
+        let _ = ui
+            .bordered(Border::Rounded)
+            .title("Table in Markdown")
+            .p(1)
+            .grow(1)
+            .col(|ui| {
+                let _ = ui.markdown(
+                    "## Feature Matrix\n\n\
+                     | Feature | Status | Since |\n\
+                     |---------|--------|-------|\n\
+                     | Pipe tables | New | v0.15.2 |\n\
+                     | Focus API | New | v0.15.2 |\n\
+                     | Sixel image | Existing | v0.14.0 |\n\
+                     | Syntax HL | Existing | v0.14.1 |\n\n\
+                     Tables are **auto-detected** inside `markdown()` calls.",
+                );
+            });
+
+        let _ = ui
+            .bordered(Border::Rounded)
+            .title("Mixed Content")
+            .p(1)
+            .grow(1)
+            .col(|ui| {
+                let _ = ui.markdown(
+                    "# API Summary\n\n\
+                     Core methods added in this release:\n\n\
+                     | Method | Returns | Description |\n\
+                     |--------|---------|-------------|\n\
+                     | `focus_index()` | `usize` | Current focus |\n\
+                     | `set_focus_index(n)` | `()` | Set focus |\n\
+                     | `focus_count()` | `usize` | Widget count |\n\n\
+                     - All methods are on `Context`\n\
+                     - Index is **0-based**",
+                );
+            });
+    });
+
+    ui.text("");
+
+    // ── Markdown links & images ────────────────────────────────────
+    let _ = ui.divider_text("Markdown Links & Images");
+    ui.text("ui.markdown() now parses [text](url) as OSC 8 links and ![alt](url) as image placeholders.")
+        .dim();
+    ui.text("");
+
+    let _ = ui.row_gap(1, |ui| {
+        let _ = ui
+            .bordered(Border::Rounded)
+            .title("Links")
+            .p(1)
+            .grow(1)
+            .col(|ui| {
+                let _ = ui.markdown(
+                    "Visit [SLT on GitHub](https://github.com/user/slt) for the source.\n\n\
+                     - [Docs](https://docs.rs/superlighttui) — API reference\n\
+                     - [Examples](https://github.com/user/slt/examples) — demo code\n\n\
+                     Links are **clickable** in supporting terminals.",
+                );
+            });
+
+        let _ = ui
+            .bordered(Border::Rounded)
+            .title("Images")
+            .p(1)
+            .grow(1)
+            .col(|ui| {
+                let _ = ui.markdown(
+                    "Inline image: ![logo](./assets/logo.png)\n\n\
+                     Images render as `[Image: alt]` placeholders.\n\
+                     Use `kitty_image_placed()` for actual pixel rendering.\n\n\
+                     Mixed: text before ![icon](x.png) and after.",
+                );
+            });
+    });
+
+    ui.text("");
+
+    // ── Focus control API ───────────────────────────────────────────
+    let _ = ui.divider_text("Programmatic Focus Control");
+    ui.text("ui.set_focus_index(n) / ui.focus_index() / ui.focus_count()")
+        .dim();
+    ui.text("");
+
+    let focus_idx = ui.focus_index();
+    let focus_cnt = ui.focus_count();
+    let _ = ui.row_gap(1, |ui| {
+        let _ = ui
+            .bordered(Border::Rounded)
+            .title("Focus State")
+            .p(1)
+            .grow(1)
+            .col(|ui| {
+                ui.text(format!("focus_index() = {focus_idx}"));
+                ui.text(format!("focus_count() = {focus_cnt}"));
+                ui.text("");
+                ui.text("Press Tab/Shift+Tab to cycle focus,").dim();
+                ui.text("or use set_focus_index(n) in code.").dim();
+            });
+
+        let _ = ui
+            .bordered(Border::Rounded)
+            .title("Focusable Widgets")
+            .p(1)
+            .grow(1)
+            .col(|ui| {
+                let mut a = TextInputState::with_placeholder("Input A (focusable #0)");
+                let mut b = TextInputState::with_placeholder("Input B (focusable #1)");
+                ui.text("Two text inputs — Tab cycles between them:").dim();
+                let _ = ui.text_input(&mut a);
+                let _ = ui.text_input(&mut b);
+            });
+    });
+
+    ui.text("");
+
+    // ── text_input grow ─────────────────────────────────────────────
+    let _ = ui.divider_text("text_input auto-fill (grow)");
+    ui.text("text_input now uses grow(1) internally — fills available width in rows.")
+        .dim();
+    ui.text("");
+
+    let _ = ui
+        .bordered(Border::Rounded)
+        .title("Row with text_input + button")
+        .p(1)
+        .row(|ui| {
+            let mut search = TextInputState::with_placeholder("Search fills remaining space...");
+            let _ = ui.text_input(&mut search);
+            let _ = ui.button("Go");
+        });
+
+    ui.text("");
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1815,6 +1815,45 @@ impl Context {
         self.scroll_lines_per_event
     }
 
+    /// Get the current focus index.
+    ///
+    /// Widget indices are assigned in the order [`register_focusable()`](Self::register_focusable) is called.
+    /// Indices are 0-based and wrap at [`focus_count()`](Self::focus_count).
+    pub fn focus_index(&self) -> usize {
+        self.focus_index
+    }
+
+    /// Set the focus index to a specific focusable widget.
+    ///
+    /// Widget indices are assigned in the order [`register_focusable()`](Self::register_focusable) is called
+    /// (0-based). If `index` exceeds the number of focusable widgets it will
+    /// be clamped by the modulo in [`register_focusable`](Self::register_focusable).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # slt::run(|ui: &mut slt::Context| {
+    /// // Focus the second focusable widget (index 1)
+    /// ui.set_focus_index(1);
+    /// # });
+    /// ```
+    pub fn set_focus_index(&mut self, index: usize) {
+        self.focus_index = index;
+    }
+
+    /// Get the number of focusable widgets registered in the previous frame.
+    ///
+    /// Returns 0 on the very first frame. Useful together with
+    /// [`set_focus_index()`](Self::set_focus_index) for programmatic focus control.
+    ///
+    /// Note: this intentionally reads `prev_focus_count` (the settled count
+    /// from the last completed frame) rather than `focus_count` (the
+    /// still-incrementing counter for the current frame).
+    #[allow(clippy::misnamed_getters)]
+    pub fn focus_count(&self) -> usize {
+        self.prev_focus_count
+    }
+
     pub(crate) fn process_focus_keys(&mut self) {
         for (i, event) in self.events.iter().enumerate() {
             if self.consumed[i] {

--- a/src/context/widgets_display.rs
+++ b/src/context/widgets_display.rs
@@ -505,6 +505,23 @@ impl Context {
     }
 
     /// Render an image using the Sixel protocol.
+    ///
+    /// `rgba` is raw RGBA pixel data, `pixel_w`/`pixel_h` are pixel dimensions,
+    /// and `cols`/`rows` are the terminal cell size to reserve for the image.
+    ///
+    /// Requires the `crossterm` feature (enabled by default). Falls back to
+    /// `[sixel unsupported]` on terminals without Sixel support. Set the
+    /// `SLT_FORCE_SIXEL=1` environment variable to skip terminal detection.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # slt::run(|ui: &mut slt::Context| {
+    /// // 2x2 red square (RGBA: 4 pixels × 4 bytes)
+    /// let rgba = [255u8, 0, 0, 255].repeat(4);
+    /// ui.sixel_image(&rgba, 2, 2, 20, 2);
+    /// # });
+    /// ```
     #[cfg(feature = "crossterm")]
     pub fn sixel_image(
         &mut self,

--- a/src/context/widgets_input.rs
+++ b/src/context/widgets_input.rs
@@ -260,6 +260,7 @@ impl Context {
             .bordered(Border::Rounded)
             .border_style(Style::new().fg(border_color))
             .px(1)
+            .grow(1)
             .col(|ui| {
                 ui.styled(input_text, input_style);
             });

--- a/src/context/widgets_interactive.rs
+++ b/src/context/widgets_interactive.rs
@@ -1,6 +1,13 @@
 use super::*;
 use crate::{DirectoryTreeState, RichLogState, TreeNode};
 
+/// Inline markdown segment — text, link, or image reference.
+enum MdInline {
+    Text(String),
+    Link { text: String, url: String },
+    Image { alt: String, url: String },
+}
+
 impl Context {
     /// Render children in a fixed grid with the given number of columns.
     ///
@@ -2618,7 +2625,8 @@ impl Context {
     /// Render a markdown string with basic formatting.
     ///
     /// Supports headers (`#`), bold (`**`), italic (`*`), inline code (`` ` ``),
-    /// unordered lists (`-`/`*`), ordered lists (`1.`), and horizontal rules (`---`).
+    /// unordered lists (`-`/`*`), ordered lists (`1.`), horizontal rules (`---`),
+    /// code blocks with syntax highlighting, and GFM-style pipe tables.
     pub fn markdown(&mut self, text: &str) -> Response {
         self.commands.push(Command::BeginContainer {
             direction: Direction::Column,
@@ -2647,6 +2655,7 @@ impl Context {
         let mut in_code_block = false;
         let mut code_block_lang = String::new();
         let mut code_block_lines: Vec<String> = Vec::new();
+        let mut table_lines: Vec<String> = Vec::new();
 
         for line in text.lines() {
             let trimmed = line.trim();
@@ -2683,6 +2692,17 @@ impl Context {
                     code_block_lines.push(line.to_string());
                 }
                 continue;
+            }
+
+            // Table row detection — collect lines starting with `|`
+            if trimmed.starts_with('|') && trimmed.matches('|').count() >= 2 {
+                table_lines.push(trimmed.to_string());
+                continue;
+            }
+            // Flush accumulated table rows when a non-table line is encountered
+            if !table_lines.is_empty() {
+                self.render_markdown_table(&table_lines, text_style, bold_style, border_style);
+                table_lines.clear();
             }
 
             if trimmed.is_empty() {
@@ -2748,16 +2768,7 @@ impl Context {
                 in_code_block = true;
                 code_block_lang = lang.trim().to_string();
             } else {
-                let segs = Self::parse_inline_segments(trimmed, text_style, bold_style, code_style);
-                if segs.len() <= 1 {
-                    self.styled(trimmed, text_style);
-                } else {
-                    self.line(|ui| {
-                        for (s, st) in segs {
-                            ui.styled(s, st);
-                        }
-                    });
-                }
+                self.render_md_inline(trimmed, text_style, bold_style, code_style);
             }
         }
 
@@ -2767,9 +2778,139 @@ impl Context {
             }
         }
 
+        // Flush any remaining table rows at end of input
+        if !table_lines.is_empty() {
+            self.render_markdown_table(&table_lines, text_style, bold_style, border_style);
+        }
+
         self.commands.push(Command::EndContainer);
         self.last_text_idx = None;
         Response::none()
+    }
+
+    /// Render a GFM-style pipe table collected from markdown lines.
+    fn render_markdown_table(
+        &mut self,
+        lines: &[String],
+        text_style: Style,
+        bold_style: Style,
+        border_style: Style,
+    ) {
+        if lines.is_empty() {
+            return;
+        }
+
+        // Separate header, separator, and data rows
+        let is_separator = |line: &str| -> bool {
+            let inner = line.trim_matches('|').trim();
+            !inner.is_empty()
+                && inner
+                    .chars()
+                    .all(|c| c == '-' || c == ':' || c == '|' || c == ' ')
+        };
+
+        let parse_row = |line: &str| -> Vec<String> {
+            let trimmed = line.trim().trim_start_matches('|').trim_end_matches('|');
+            trimmed.split('|').map(|c| c.trim().to_string()).collect()
+        };
+
+        let mut header: Option<Vec<String>> = None;
+        let mut data_rows: Vec<Vec<String>> = Vec::new();
+        let mut found_separator = false;
+
+        for (i, line) in lines.iter().enumerate() {
+            if is_separator(line) {
+                found_separator = true;
+                continue;
+            }
+            if i == 0 && !found_separator {
+                header = Some(parse_row(line));
+            } else {
+                data_rows.push(parse_row(line));
+            }
+        }
+
+        // If no separator found, treat first row as header anyway
+        if !found_separator && header.is_none() && !data_rows.is_empty() {
+            header = Some(data_rows.remove(0));
+        }
+
+        // Calculate column count and widths
+        let all_rows: Vec<&Vec<String>> = header.iter().chain(data_rows.iter()).collect();
+        let col_count = all_rows.iter().map(|r| r.len()).max().unwrap_or(0);
+        if col_count == 0 {
+            return;
+        }
+        let mut col_widths = vec![0usize; col_count];
+        for row in &all_rows {
+            for (i, cell) in row.iter().enumerate() {
+                if i < col_count {
+                    col_widths[i] = col_widths[i].max(UnicodeWidthStr::width(cell.as_str()));
+                }
+            }
+        }
+
+        // Top border ┌───┬───┐
+        let mut top = String::from("┌");
+        for (i, &w) in col_widths.iter().enumerate() {
+            for _ in 0..w + 2 {
+                top.push('─');
+            }
+            top.push(if i < col_count - 1 { '┬' } else { '┐' });
+        }
+        self.styled(&top, border_style);
+
+        // Header row │ H1 │ H2 │
+        if let Some(ref hdr) = header {
+            let mut s = String::from("│");
+            for (i, w) in col_widths.iter().enumerate() {
+                let cell = hdr.get(i).map(String::as_str).unwrap_or("");
+                let cell_w = UnicodeWidthStr::width(cell);
+                s.push(' ');
+                s.push_str(cell);
+                for _ in cell_w..*w {
+                    s.push(' ');
+                }
+                s.push_str(" │");
+            }
+            self.styled(&s, bold_style);
+
+            // Separator ├───┼───┤
+            let mut sep = String::from("├");
+            for (i, &w) in col_widths.iter().enumerate() {
+                for _ in 0..w + 2 {
+                    sep.push('─');
+                }
+                sep.push(if i < col_count - 1 { '┼' } else { '┤' });
+            }
+            self.styled(&sep, border_style);
+        }
+
+        // Data rows
+        for row in &data_rows {
+            let mut s = String::from("│");
+            for (i, w) in col_widths.iter().enumerate() {
+                let cell = row.get(i).map(String::as_str).unwrap_or("");
+                let cell_w = UnicodeWidthStr::width(cell);
+                s.push(' ');
+                s.push_str(cell);
+                for _ in cell_w..*w {
+                    s.push(' ');
+                }
+                s.push_str(" │");
+            }
+            self.styled(&s, text_style);
+        }
+
+        // Bottom border └───┴───┘
+        let mut bot = String::from("└");
+        for (i, &w) in col_widths.iter().enumerate() {
+            for _ in 0..w + 2 {
+                bot.push('─');
+            }
+            bot.push(if i < col_count - 1 { '┴' } else { '┘' });
+        }
+        self.styled(&bot, border_style);
     }
 
     pub(crate) fn parse_inline_segments(
@@ -2832,6 +2973,154 @@ impl Context {
             segments.push((current, base));
         }
         segments
+    }
+
+    /// Render a markdown line with link/image support.
+    ///
+    /// Parses `[text](url)` as clickable OSC 8 links and `![alt](url)` as
+    /// image placeholders, delegating the rest to `parse_inline_segments`.
+    fn render_md_inline(
+        &mut self,
+        text: &str,
+        text_style: Style,
+        bold_style: Style,
+        code_style: Style,
+    ) {
+        let items = Self::split_md_links(text);
+
+        // Fast path: no links/images found
+        if items.len() == 1 {
+            if let MdInline::Text(ref t) = items[0] {
+                let segs = Self::parse_inline_segments(t, text_style, bold_style, code_style);
+                if segs.len() <= 1 {
+                    self.styled(text, text_style);
+                } else {
+                    self.line(|ui| {
+                        for (s, st) in segs {
+                            ui.styled(s, st);
+                        }
+                    });
+                }
+                return;
+            }
+        }
+
+        // Mixed content — render in a line container
+        self.line(|ui| {
+            for item in &items {
+                match item {
+                    MdInline::Text(t) => {
+                        let segs =
+                            Self::parse_inline_segments(t, text_style, bold_style, code_style);
+                        for (s, st) in segs {
+                            ui.styled(s, st);
+                        }
+                    }
+                    MdInline::Link { text, url } => {
+                        ui.link(text.clone(), url.clone());
+                    }
+                    MdInline::Image { alt, url } => {
+                        let label = format!("[Image: {alt}]");
+                        ui.styled(label, code_style);
+                        if !url.is_empty() {
+                            ui.styled(format!(" ({url})"), text_style.dim());
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    /// Split a markdown line into text, link, and image segments.
+    fn split_md_links(text: &str) -> Vec<MdInline> {
+        let chars: Vec<char> = text.chars().collect();
+        let mut items: Vec<MdInline> = Vec::new();
+        let mut current = String::new();
+        let mut i = 0;
+
+        while i < chars.len() {
+            // Image: ![alt](url)
+            if chars[i] == '!' && i + 1 < chars.len() && chars[i + 1] == '[' {
+                if let Some((alt, url, consumed)) = Self::parse_md_bracket_paren(&chars, i + 1) {
+                    if !current.is_empty() {
+                        items.push(MdInline::Text(std::mem::take(&mut current)));
+                    }
+                    items.push(MdInline::Image { alt, url });
+                    i += 1 + consumed;
+                    continue;
+                }
+            }
+            // Link: [text](url)
+            if chars[i] == '[' {
+                if let Some((link_text, url, consumed)) = Self::parse_md_bracket_paren(&chars, i) {
+                    if !current.is_empty() {
+                        items.push(MdInline::Text(std::mem::take(&mut current)));
+                    }
+                    items.push(MdInline::Link {
+                        text: link_text,
+                        url,
+                    });
+                    i += consumed;
+                    continue;
+                }
+            }
+            current.push(chars[i]);
+            i += 1;
+        }
+        if !current.is_empty() {
+            items.push(MdInline::Text(current));
+        }
+        if items.is_empty() {
+            items.push(MdInline::Text(String::new()));
+        }
+        items
+    }
+
+    /// Parse `[text](url)` starting at `chars[start]` which must be `[`.
+    /// Returns `(text, url, chars_consumed)` or `None` if no match.
+    fn parse_md_bracket_paren(chars: &[char], start: usize) -> Option<(String, String, usize)> {
+        if start >= chars.len() || chars[start] != '[' {
+            return None;
+        }
+        // Find closing ]
+        let mut depth = 0i32;
+        let mut bracket_end = None;
+        for (j, &ch) in chars.iter().enumerate().skip(start) {
+            if ch == '[' {
+                depth += 1;
+            } else if ch == ']' {
+                depth -= 1;
+                if depth == 0 {
+                    bracket_end = Some(j);
+                    break;
+                }
+            }
+        }
+        let bracket_end = bracket_end?;
+        // Must be followed by (
+        if bracket_end + 1 >= chars.len() || chars[bracket_end + 1] != '(' {
+            return None;
+        }
+        // Find closing )
+        let paren_start = bracket_end + 2;
+        let mut paren_end = None;
+        let mut paren_depth = 1i32;
+        for (j, &ch) in chars.iter().enumerate().skip(paren_start) {
+            if ch == '(' {
+                paren_depth += 1;
+            } else if ch == ')' {
+                paren_depth -= 1;
+                if paren_depth == 0 {
+                    paren_end = Some(j);
+                    break;
+                }
+            }
+        }
+        let paren_end = paren_end?;
+        let text: String = chars[start + 1..bracket_end].iter().collect();
+        let url: String = chars[paren_start..paren_end].iter().collect();
+        let consumed = paren_end - start + 1;
+        Some((text, url, consumed))
     }
 
     // ── key sequence ─────────────────────────────────────────────────

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -161,13 +161,16 @@ impl Terminal {
             queue!(self.stdout, ResetColor, SetAttribute(Attribute::Reset))?;
         }
 
-        if !self.previous.raw_sequences.is_empty() || !self.current.raw_sequences.is_empty() {
-            queue!(self.stdout, Print("\x1b_Ga=d,d=A,q=2\x1b\\"))?;
-        }
-
-        for (x, y, seq) in &self.current.raw_sequences {
-            queue!(self.stdout, cursor::MoveTo(*x as u16, *y as u16))?;
-            queue!(self.stdout, Print(seq))?;
+        // Only delete + re-upload images when raw_sequences actually changed.
+        // This avoids the expensive a=d,d=A + re-upload cycle for static images.
+        if self.current.raw_sequences != self.previous.raw_sequences {
+            if !self.previous.raw_sequences.is_empty() || !self.current.raw_sequences.is_empty() {
+                queue!(self.stdout, Print("\x1b_Ga=d,d=A,q=2\x1b\\"))?;
+            }
+            for (x, y, seq) in &self.current.raw_sequences {
+                queue!(self.stdout, cursor::MoveTo(*x as u16, *y as u16))?;
+                queue!(self.stdout, Print(seq))?;
+            }
         }
 
         queue!(self.stdout, EndSynchronizedUpdate)?;
@@ -342,14 +345,15 @@ impl InlineTerminal {
             queue!(self.stdout, ResetColor, SetAttribute(Attribute::Reset))?;
         }
 
-        if !self.previous.raw_sequences.is_empty() || !self.current.raw_sequences.is_empty() {
-            queue!(self.stdout, Print("\x1b_Ga=d,d=A,q=2\x1b\\"))?;
-        }
-
-        for (x, y, seq) in &self.current.raw_sequences {
-            let abs_y = self.start_row as u32 + *y;
-            queue!(self.stdout, cursor::MoveTo(*x as u16, abs_y as u16))?;
-            queue!(self.stdout, Print(seq))?;
+        if self.current.raw_sequences != self.previous.raw_sequences {
+            if !self.previous.raw_sequences.is_empty() || !self.current.raw_sequences.is_empty() {
+                queue!(self.stdout, Print("\x1b_Ga=d,d=A,q=2\x1b\\"))?;
+            }
+            for (x, y, seq) in &self.current.raw_sequences {
+                let abs_y = self.start_row as u32 + *y;
+                queue!(self.stdout, cursor::MoveTo(*x as u16, abs_y as u16))?;
+                queue!(self.stdout, Print(seq))?;
+            }
         }
 
         queue!(self.stdout, EndSynchronizedUpdate)?;

--- a/tests/widgets.rs
+++ b/tests/widgets.rs
@@ -3255,3 +3255,75 @@ fn markdown_unclosed_code_block_no_panic() {
     });
     tb.assert_contains("def");
 }
+
+#[test]
+fn markdown_pipe_table_renders() {
+    let mut tb = slt::TestBackend::new(60, 12);
+    tb.render(|ui| {
+        ui.markdown("| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |");
+    });
+    tb.assert_contains("Name");
+    tb.assert_contains("Age");
+    tb.assert_contains("Alice");
+    tb.assert_contains("Bob");
+    // Box-drawing borders
+    tb.assert_contains("┌");
+    tb.assert_contains("┘");
+    tb.assert_contains("├");
+}
+
+#[test]
+fn markdown_pipe_table_followed_by_text() {
+    let mut tb = slt::TestBackend::new(60, 12);
+    tb.render(|ui| {
+        ui.markdown("| A | B |\n|---|---|\n| 1 | 2 |\n\nParagraph after table.");
+    });
+    tb.assert_contains("A");
+    tb.assert_contains("1");
+    tb.assert_contains("Paragraph after table");
+}
+
+#[test]
+fn focus_control_api() {
+    let mut tb = slt::TestBackend::new(40, 10);
+    tb.render(|ui| {
+        assert_eq!(ui.focus_count(), 0, "first frame has no prev focus count");
+        let mut input1 = slt::TextInputState::with_placeholder("A");
+        let mut input2 = slt::TextInputState::with_placeholder("B");
+        ui.text_input(&mut input1);
+        ui.text_input(&mut input2);
+        // On the first frame, set_focus_index should work without panic
+        ui.set_focus_index(1);
+        assert_eq!(ui.focus_index(), 1);
+    });
+}
+
+#[test]
+fn markdown_link_renders_text() {
+    let mut tb = slt::TestBackend::new(80, 5);
+    tb.render(|ui| {
+        ui.markdown("Click [here](https://example.com) for info.");
+    });
+    tb.assert_contains("here");
+    tb.assert_contains("for info");
+}
+
+#[test]
+fn markdown_image_renders_placeholder() {
+    let mut tb = slt::TestBackend::new(80, 5);
+    tb.render(|ui| {
+        ui.markdown("See ![screenshot](./img.png) below.");
+    });
+    tb.assert_contains("[Image: screenshot]");
+    tb.assert_contains("below");
+}
+
+#[test]
+fn markdown_mixed_links_and_text() {
+    let mut tb = slt::TestBackend::new(80, 5);
+    tb.render(|ui| {
+        ui.markdown("Use [SLT](https://github.com/user/slt) or [Ratatui](https://ratatui.rs).");
+    });
+    tb.assert_contains("SLT");
+    tb.assert_contains("Ratatui");
+}


### PR DESCRIPTION
## Summary

- **Focus control API** — `set_focus_index()`, `focus_index()`, `focus_count()` for programmatic keyboard focus management
- **Markdown pipe tables** — `ui.markdown()` now renders GFM `| A | B |` tables with box-drawing borders
- **Markdown links** — `[text](url)` → clickable OSC 8 links, `![alt](url)` → `[Image: alt]` placeholder
- **text_input grow(1)** — auto-fills available width in row layouts
- **Image flush perf** — `raw_sequences` diff optimization skips re-upload for static images
- **Sixel docs** — expanded `sixel_image()` docstring with example

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --all-features` (489 tests pass)
- [x] `cargo check --examples --all-features`
- [ ] CI passes on branch
- [ ] `cargo run --example demo --all-features --release` — v0.15.2 tab renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)