### PR TITLE
feat: v0.15.8 — docs overhaul, run-loop dedup, safety fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.15.8] — 2026-03-22
+
+### Documentation
+
+- **Complete docs overhaul** — added 7 new guides: `ANIMATION.md`, `THEMING.md`, `BACKENDS.md`, `TESTING.md`, `DEBUGGING.md`, `FEATURES.md`, `AI_GUIDE.md`.
+- **WIDGETS.md rewritten** — now a complete API catalog of every widget, state type, ContainerBuilder method, and CanvasContext primitive.
+- **PATTERNS.md expanded** — added animation patterns, responsive layout patterns; removed single-API-usage sections that belong in WIDGETS.md.
+- **Translation sync** — Korean, Chinese, Japanese, and Spanish READMEs aligned with the current English structure including all new guide links.
+- **Cross-reference cleanup** — README.md, docs/README.md, CONTRIBUTING.md, ARCHITECTURE.md, and DESIGN_PRINCIPLES.md now link to all guides consistently.
+- **Stale data fixed** — SECURITY.md version updated to 0.15.x, DESIGN_PRINCIPLES.md version range updated, EXAMPLES.md now shows feature flag requirements.
+
+### Fixes
+
+- **Buffer bounds safety** — `Buffer::get()` and `get_mut()` upgraded from `debug_assert!` to `assert!`, enforcing bounds checks in release builds. Selection overlay now guards against out-of-bounds widget rects.
+- **F12 debug toggle missing in async** — `run_async_loop` was the only run loop without F12 support; now fixed via shared `poll_events()`.
+- **Syntax highlighting graceful degradation** — tree-sitter config failures now return `None` instead of panicking, allowing fallback to keyword highlighting.
+
+### Performance
+
+- **Events clone eliminated** — internal run loops now transfer event ownership via `std::mem::take` instead of cloning the events vector every frame.
+
+### Internal
+
+- **Run loop dedup** — extracted `poll_events()` shared function, reducing ~160 lines of duplicated event polling across 4 run loops to a single implementation.
+- **Saturating u16 casts** — all `u32` to `u16` coordinate casts in `terminal.rs` now use a saturating helper instead of raw `as u16` truncation.
+- **CLAUDE.md architecture tree** — updated to reflect current module split with accurate line counts.
+
 ## [0.15.7] — 2026-03-22
 
 ### Improvements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Before contributing, read:
 - **[`docs/DESIGN_PRINCIPLES.md`](docs/DESIGN_PRINCIPLES.md)** — Why things are the way they are
 - **[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)** — How the code is organized
 - **[`docs/WIDGETS.md`](docs/WIDGETS.md)** — Which APIs and state types live where
+- **[`docs/TESTING.md`](docs/TESTING.md)** — How to verify widget and layout behavior
+- **[`docs/BACKENDS.md`](docs/BACKENDS.md)** — Low-level backend and run-loop contracts
 
 ## Getting Started
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/slt-wasm"]
 
 [package]
 name = "superlighttui"
-version = "0.15.7"
+version = "0.15.8"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ For the categorized widget list, see [Widget Guide].
 | [Patterns Guide] | State, forms, overlays, async, custom widgets, testing |
 | [Examples Guide] | Curated example index with commands and use cases |
 | [Architecture Guide] | Module map, frame lifecycle, dependency flow |
+| [Backends Guide] | `Backend`, `AppState`, `frame()`, inline mode, static output |
+| [Testing Guide] | `TestBackend`, `EventBuilder`, interaction testing |
+| [Debugging Guide] | F12 overlay, clipping, one-frame delay, focus issues |
+| [AI Guide] | Fastest path for AI-assisted builders and agents |
+| [Animation Guide] | Tween, spring, keyframes, sequence, stagger |
+| [Theming Guide] | Theme struct, presets, ThemeBuilder, custom themes |
+| [Features Guide] | Feature flags, optional dependencies, recommended combos |
 | [`docs/DESIGN_PRINCIPLES.md`](docs/DESIGN_PRINCIPLES.md) | Why the API is shaped this way |
 
 ## Example Highlights
@@ -192,10 +199,17 @@ The release and CI process expects formatting, check, clippy, tests, and example
 [Crate]: https://crates.io/crates/superlighttui
 [Docs Index]: docs/README.md
 [Docs]: https://docs.rs/superlighttui
+[Backends Guide]: docs/BACKENDS.md
+[Testing Guide]: docs/TESTING.md
+[Debugging Guide]: docs/DEBUGGING.md
+[AI Guide]: docs/AI_GUIDE.md
 [Quick Start]: docs/QUICK_START.md
 [Widget Guide]: docs/WIDGETS.md
 [Examples Guide]: docs/EXAMPLES.md
 [Patterns Guide]: docs/PATTERNS.md
 [Architecture Guide]: docs/ARCHITECTURE.md
+[Animation Guide]: docs/ANIMATION.md
+[Theming Guide]: docs/THEMING.md
+[Features Guide]: docs/FEATURES.md
 [Contributing]: CONTRIBUTING.md
 [License]: ./LICENSE

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.13.x  | Yes       |
-| < 0.13  | No        |
+| 0.15.x  | Yes       |
+| < 0.15  | No        |
 
 Only the latest minor release receives security fixes.
 

--- a/docs/AI_GUIDE.md
+++ b/docs/AI_GUIDE.md
@@ -1,0 +1,95 @@
+# AI and Agent Guide
+
+Quick-start for AI coding agents working with SLT.
+
+## Core mental model
+
+- SLT is immediate mode: the closure is the app.
+- Application state usually lives in normal Rust variables or structs.
+- Widget-local persistent state uses `use_state()` / `use_memo()`.
+- Interactive widgets usually return `Response`.
+- Layout is mostly `row()`, `col()`, `container()`, `scrollable()`.
+
+## Reading order
+
+1. `README.md`
+2. `docs/QUICK_START.md`
+3. `docs/WIDGETS.md`
+4. `docs/PATTERNS.md`
+5. `docs/EXAMPLES.md`
+6. `docs/ARCHITECTURE.md` for internals
+
+## Questions agents get wrong
+
+### "What's the difference between text().bold() and styled()?"
+
+`text().bold()` chains after the last text command. `styled()` applies a pre-built `Style` in one call. Use `styled()` when reusing styles across widgets.
+
+### "I called ui.bg() but the container background didn't change"
+
+`ui.bg()` modifies the LAST TEXT element, not the container. For container background, use `container().bg(color).col(...)`.
+
+### "How do I animate something?"
+
+Animation types (`Tween`, `Spring`, `Keyframes`, `Sequence`, `Stagger`) are standalone structs, not Context methods. Compute values with `tick()` and pass them to style/layout methods. See `docs/ANIMATION.md`.
+
+### "Where are the color palettes?"
+
+Use `palette::tailwind::{BLUE, RED, ...}.c500` for Tailwind-style colors. See `docs/THEMING.md`.
+
+### "What's the difference between line() and row()?"
+
+Both are horizontal. `row()` is a full layout container returning `Response`. `line()` is for inline rich text returning `&mut Self` with zero gap between children.
+
+### "How do I use _colored variants?"
+
+Pass `WidgetColors::new().fg(color).bg(color)` as the last argument. See `docs/THEMING.md`.
+
+### "Why does my hook panic?"
+
+`use_state()` and `use_memo()` must be called in the same order every frame. Never put them inside conditionals.
+
+### "How do I handle keyboard shortcuts?"
+
+Use `key(c)`, `key_code(code)`, or `key_mod(c, mods)`. For modal-aware shortcuts use the regular versions. For global shortcuts that bypass modals, use `raw_key_code()` or `raw_key_mod()`. For key sequence detection use `key_seq("gg")`.
+
+### "How do I make a custom widget?"
+
+Implement the `Widget` trait with `type Response` and `fn ui(&mut self, ctx: &mut Context) -> Self::Response`. Use `register_focusable()` for keyboard support and `interaction()` for click/hover.
+
+### "Can I use SLT without crossterm?"
+
+Yes, for custom backends with `Backend`, `AppState`, and `frame()`.
+
+### "Should I create an app struct?"
+
+Only if it helps. SLT does not require one.
+
+### "Should every widget return Response?"
+
+No. Built-in interactive widgets usually do. Custom widgets can return `()`, `bool`, or `Response`.
+
+### "Why is hover/focus data weird on the first frame?"
+
+Because layout feedback often uses previous-frame data in immediate-mode UI.
+
+## Implementation rules for agents
+
+- Prefer `ui.container().p(1).col(...)` over inventing new layout patterns.
+- Prefer existing `*State` types over custom ad-hoc input structs.
+- Use `Response.changed` / `.clicked` instead of inventing parallel booleans.
+- Use `register_focusable()` and `interaction()` in custom widgets.
+- Respect hook ordering rules.
+- Animation types are standalone structs, not Context methods — compute values separately.
+- Use `palette::tailwind` colors instead of hardcoding RGB values.
+- Check `docs/FEATURES.md` before using feature-gated APIs.
+
+## Keep docs and implementation aligned
+
+When an agent changes a public API, it should update:
+
+- crate rustdoc in `src/lib.rs` or the defining file
+- the most relevant guide in `docs/`
+- example coverage if the new API needs a runnable reference
+
+If the behavior is hard to explain cleanly, the API may still need refinement.

--- a/docs/ANIMATION.md
+++ b/docs/ANIMATION.md
@@ -1,0 +1,355 @@
+# Animation
+
+SLT animations are standalone structs, not Context methods. Each animation computes an `f64` value from tick counts. You pass the computed value to style or layout methods yourself.
+
+```rust
+let mut fade = Tween::new(0.0, 1.0, 30).easing(ease_out_quad);
+fade.reset(ui.tick());
+
+// Each frame: compute the value, use it however you want
+let opacity = fade.value(ui.tick());
+ui.text("Hello").fg(Color::Rgb(255, 255, (255.0 * opacity) as u8));
+```
+
+## Tick-based model
+
+Animations run on frame ticks, not wall-clock time.
+
+- `ui.tick()` returns a `u64` frame counter that increments every render frame.
+- `RunConfig::default().tick_rate(Duration::from_millis(16))` controls the polling interval (default 16ms / ~60fps).
+- All animation types use `reset(tick)` to set a start time and `value(tick)` to sample.
+- Lower `tick_rate` = smoother animations but more CPU usage.
+
+## Animation types
+
+### Tween
+
+Linear interpolation from A to B over a fixed number of ticks.
+
+```rust
+use slt::{Tween, Context, Color};
+use slt::anim::ease_out_quad;
+
+let mut tween = Tween::new(0.0, 100.0, 60)
+    .easing(ease_out_quad);
+
+slt::run(|ui: &mut Context| {
+    if ui.tick() == 0 {
+        tween.reset(ui.tick());
+    }
+    let x = tween.value(ui.tick()) as u16;
+    ui.text("sliding").ml(x);
+});
+```
+
+Key methods:
+- `Tween::new(from, to, duration_ticks)` — constructor, linear easing by default
+- `.easing(fn)` — set easing function (builder)
+- `.on_complete(fn)` — callback when done (builder)
+- `.reset(tick)` — start/restart the tween
+- `.value(tick) -> f64` — sample current value
+- `.is_done() -> bool` — completion check
+
+### Spring
+
+Physics-based damped harmonic oscillator. Unlike Tween, Spring has no fixed duration -- it settles naturally based on stiffness and damping.
+
+```rust
+use slt::{Spring, Context};
+
+let mut spring = Spring::new(0.0, 0.2, 0.85);
+
+slt::run(|ui: &mut Context| {
+    let hovered = ui.button("Hover me").hovered;
+    spring.set_target(if hovered { 10.0 } else { 0.0 });
+    spring.tick();
+
+    let offset = spring.value() as u16;
+    ui.text("bouncy").ml(offset);
+});
+```
+
+Key methods:
+- `Spring::new(initial, stiffness, damping)` — constructor
+  - `stiffness`: acceleration per unit displacement (`0.1`..`0.5`)
+  - `damping`: velocity decay per tick, `< 1.0` (`0.8`..`0.95`)
+- `.on_settle(fn)` — callback when settled (builder)
+- `.set_target(value)` — change the goal position (interactive use)
+- `.tick()` — advance simulation by one frame (call once per frame)
+- `.value() -> f64` — current position
+- `.is_settled() -> bool` — true when velocity and distance are both < 0.01
+
+Spring does not use `reset(tick)`. Call `.tick()` every frame and `.set_target()` to change direction.
+
+### Keyframes
+
+Multi-stop timeline animation, like CSS `@keyframes`. Each segment between stops can use its own easing.
+
+```rust
+use slt::anim::{Keyframes, LoopMode, ease_out_quad, ease_in_cubic};
+
+let mut kf = Keyframes::new(90)
+    .stop(0.0, 0.0)       // start at 0
+    .stop(0.3, 100.0)     // ramp up to 100 at 30%
+    .stop(0.7, 100.0)     // hold at 100 until 70%
+    .stop(1.0, 40.0)      // ease down to 40
+    .segment_easing(0, ease_out_quad)
+    .segment_easing(2, ease_in_cubic)
+    .loop_mode(LoopMode::PingPong);
+
+kf.reset(ui.tick());
+let brightness = kf.value(ui.tick());
+```
+
+Key methods:
+- `Keyframes::new(duration_ticks)` — constructor
+- `.stop(position, value)` — add a stop at normalized position `[0.0, 1.0]`
+- `.easing(fn)` — default easing for all segments
+- `.segment_easing(index, fn)` — override easing for segment `index` (0 = first-to-second stop)
+- `.loop_mode(mode)` — set loop behavior
+- `.on_complete(fn)` — callback when done
+- `.reset(tick)` — start/restart
+- `.value(tick) -> f64` — sample current value
+- `.is_done() -> bool` — completion check (always false for looping modes)
+
+### Sequence
+
+Chain multiple tween segments end-to-end into a single timeline.
+
+```rust
+use slt::anim::{Sequence, LoopMode, ease_linear, ease_out_quad, ease_in_cubic};
+
+let mut seq = Sequence::new()
+    .then(0.0, 100.0, 30, ease_out_quad)   // slide right
+    .then(100.0, 100.0, 10, ease_linear)   // pause
+    .then(100.0, 0.0, 20, ease_in_cubic)   // slide back
+    .loop_mode(LoopMode::Repeat);
+
+seq.reset(ui.tick());
+let x = seq.value(ui.tick());
+```
+
+Key methods:
+- `Sequence::new()` — constructor
+- `.then(from, to, duration_ticks, easing)` — append a segment
+- `.loop_mode(mode)` — set loop behavior
+- `.on_complete(fn)` — callback when done
+- `.reset(tick)` — start/restart
+- `.value(tick) -> f64` — sample current value
+- `.is_done() -> bool` — completion check
+
+### Stagger
+
+Apply the same tween to N items with a fixed delay between each start.
+
+```rust
+use slt::anim::{Stagger, LoopMode, ease_out_quad};
+
+let items = vec!["Alpha", "Beta", "Gamma", "Delta"];
+let mut stagger = Stagger::new(0.0, 1.0, 20)
+    .easing(ease_out_quad)
+    .delay(5)
+    .items(items.len())
+    .loop_mode(LoopMode::Once);
+
+stagger.reset(ui.tick());
+
+for (i, label) in items.iter().enumerate() {
+    let opacity = stagger.value(ui.tick(), i);
+    let gray = (255.0 * opacity) as u8;
+    ui.text(*label).fg(Color::Rgb(gray, gray, gray));
+}
+```
+
+Key methods:
+- `Stagger::new(from, to, duration_ticks)` — constructor
+- `.easing(fn)` — easing for each item's tween
+- `.delay(ticks)` — ticks between consecutive item starts
+- `.items(count)` — set item count (inferred from usage if not set)
+- `.loop_mode(mode)` — set loop behavior
+- `.on_complete(fn)` — callback when done
+- `.reset(tick)` — start/restart
+- `.value(tick, item_index) -> f64` — sample value for a specific item
+- `.is_done() -> bool` — true if the most recently sampled item finished
+
+## Easing functions
+
+All easing functions have signature `fn(f64) -> f64`, mapping `[0, 1]` to `[0, 1]`.
+
+| Function | Curve | Use case |
+|----------|-------|----------|
+| `ease_linear` | Constant rate | Default, mechanical motion |
+| `ease_in_quad` | Slow start | Accelerating elements |
+| `ease_out_quad` | Slow end | Decelerating, natural stops |
+| `ease_in_out_quad` | Slow both ends | Smooth transitions |
+| `ease_in_cubic` | Slower start | Stronger acceleration |
+| `ease_out_cubic` | Slower end | Stronger deceleration |
+| `ease_in_out_cubic` | Slower both ends | Emphasis on middle speed |
+| `ease_out_elastic` | Overshoot + oscillate | Attention-grabbing, playful |
+| `ease_out_bounce` | Bouncing ball | Landing, drop effects |
+
+Helper: `lerp(a, b, t)` — linear interpolation, not clamped. Apply easing to `t` before calling.
+
+```rust
+use slt::anim::{lerp, ease_out_quad};
+
+let t = ease_out_quad(0.5);
+let value = lerp(0.0, 100.0, t); // ~75.0
+```
+
+## LoopMode
+
+Controls what happens when an animation reaches its end.
+
+| Mode | Behavior |
+|------|----------|
+| `LoopMode::Once` | Play once, hold at final value. `is_done()` returns `true`. |
+| `LoopMode::Repeat` | Restart from the beginning each cycle. |
+| `LoopMode::PingPong` | Alternate forward and backward each cycle. |
+
+Applies to `Keyframes`, `Sequence`, and `Stagger`. `Tween` always plays once (use `Sequence` with `LoopMode::Repeat` for looping tweens). `Spring` has no loop mode -- it settles naturally.
+
+## Common patterns
+
+### Fade-in on mount
+
+```rust
+let mut fade = Tween::new(0.0, 1.0, 30).easing(ease_out_quad);
+let mut started = false;
+
+slt::run(|ui: &mut Context| {
+    if !started {
+        fade.reset(ui.tick());
+        started = true;
+    }
+    let alpha = fade.value(ui.tick());
+    let g = (255.0 * alpha) as u8;
+    ui.text("Welcome").fg(Color::Rgb(g, g, g));
+});
+```
+
+### Button hover spring
+
+```rust
+let mut spring = Spring::new(0.0, 0.3, 0.8);
+
+slt::run(|ui: &mut Context| {
+    let btn = ui.button("Click me");
+    spring.set_target(if btn.hovered { 2.0 } else { 0.0 });
+    spring.tick();
+
+    let pad = spring.value() as u16;
+    ui.text(">>").ml(pad);
+});
+```
+
+### Staggered list entry
+
+```rust
+let items = vec!["One", "Two", "Three", "Four", "Five"];
+let mut stagger = Stagger::new(0.0, 1.0, 15)
+    .easing(ease_out_cubic)
+    .delay(3)
+    .items(items.len());
+
+let mut started = false;
+
+slt::run(|ui: &mut Context| {
+    if !started {
+        stagger.reset(ui.tick());
+        started = true;
+    }
+    for (i, item) in items.iter().enumerate() {
+        let t = stagger.value(ui.tick(), i);
+        let brightness = (255.0 * t) as u8;
+        ui.text(*item).fg(Color::Rgb(brightness, brightness, brightness));
+    }
+});
+```
+
+### Loading sequence (multi-phase)
+
+```rust
+let mut loading = Keyframes::new(120)
+    .stop(0.0, 0.0)     // idle
+    .stop(0.25, 100.0)  // fill bar
+    .stop(0.5, 100.0)   // hold
+    .stop(0.75, 0.0)    // reset
+    .stop(1.0, 0.0)     // idle
+    .easing(ease_in_out_quad)
+    .loop_mode(LoopMode::Repeat);
+
+loading.reset(ui.tick());
+let pct = loading.value(ui.tick());
+ui.text(format!("[{:>3.0}%]", pct));
+```
+
+### Chained transitions
+
+```rust
+let mut chain = Sequence::new()
+    .then(0.0, 50.0, 20, ease_out_quad)    // move to center
+    .then(50.0, 50.0, 30, ease_linear)     // hold
+    .then(50.0, 100.0, 20, ease_in_cubic); // move to end
+
+chain.reset(ui.tick());
+let pos = chain.value(ui.tick()) as u16;
+ui.text("->").ml(pos);
+```
+
+## API quick reference
+
+### Tween
+
+| | |
+|---|---|
+| Constructor | `Tween::new(from, to, duration_ticks)` |
+| Builder | `.easing(fn)`, `.on_complete(fn)` |
+| Control | `.reset(tick)` |
+| Sample | `.value(tick) -> f64` |
+| Done | `.is_done() -> bool` |
+
+### Spring
+
+| | |
+|---|---|
+| Constructor | `Spring::new(initial, stiffness, damping)` |
+| Builder | `.on_settle(fn)` |
+| Control | `.set_target(value)`, `.tick()` |
+| Sample | `.value() -> f64` |
+| Done | `.is_settled() -> bool` |
+
+### Keyframes
+
+| | |
+|---|---|
+| Constructor | `Keyframes::new(duration_ticks)` |
+| Builder | `.stop(pos, val)`, `.easing(fn)`, `.segment_easing(idx, fn)`, `.loop_mode(mode)`, `.on_complete(fn)` |
+| Control | `.reset(tick)` |
+| Sample | `.value(tick) -> f64` |
+| Done | `.is_done() -> bool` |
+
+### Sequence
+
+| | |
+|---|---|
+| Constructor | `Sequence::new()` |
+| Builder | `.then(from, to, ticks, easing)`, `.loop_mode(mode)`, `.on_complete(fn)` |
+| Control | `.reset(tick)` |
+| Sample | `.value(tick) -> f64` |
+| Done | `.is_done() -> bool` |
+
+### Stagger
+
+| | |
+|---|---|
+| Constructor | `Stagger::new(from, to, duration_ticks)` |
+| Builder | `.easing(fn)`, `.delay(ticks)`, `.items(count)`, `.loop_mode(mode)`, `.on_complete(fn)` |
+| Control | `.reset(tick)` |
+| Sample | `.value(tick, item_index) -> f64` |
+| Done | `.is_done() -> bool` |
+
+## Related docs
+
+- [PATTERNS.md](PATTERNS.md) -- common composition patterns
+- [WIDGETS.md](WIDGETS.md) -- widget catalog and usage

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,6 +8,9 @@ Related docs:
 - [WIDGETS.md](WIDGETS.md)
 - [PATTERNS.md](PATTERNS.md)
 - [EXAMPLES.md](EXAMPLES.md)
+- [BACKENDS.md](BACKENDS.md)
+- [DEBUGGING.md](DEBUGGING.md)
+- [TESTING.md](TESTING.md)
 
 ---
 
@@ -144,6 +147,8 @@ Every frame follows this exact sequence:
    └── Swap front ↔ back buffers
 ```
 
+For the custom-backend entry point that drives this lifecycle manually, see `docs/BACKENDS.md`.
+
 ---
 
 ## One-Frame Delay Feedback
@@ -192,6 +197,8 @@ Key observations:
 - `terminal.rs` is isolated — it only knows about `buffer` and `event`
 - `style`, `layout`, `anim` are largely independent of each other
 - Widget facades under `src/context/widgets_*.rs` now act as indexes for narrower implementation files
+
+- The `Backend` / `AppState` / `frame()` path in `src/lib.rs` is the low-level escape hatch when SLT does not own the event loop
 
 ---
 

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -1,0 +1,159 @@
+# Backends and Run Loops
+
+This guide covers the low-level path: custom render targets, external event loops, inline mode, and static output.
+
+If you just want a normal terminal app, use `slt::run(...)` and stop here.
+
+## Choose the right entry point
+
+| Goal | API |
+|------|-----|
+| Full-screen terminal app | `run()` / `run_with()` |
+| Inline widget below the current prompt | `run_inline()` / `run_inline_with()` |
+| Inline widget plus scrollback log output | `run_static()` + `StaticOutput` |
+| Non-terminal target or external loop | `Backend` + `AppState` + `frame()` |
+
+## Full-screen vs inline vs static
+
+- `run()` enters alternate screen mode and owns the terminal session.
+- `run_inline(height, ...)` keeps you in the normal terminal screen and reserves `height` rows below the current cursor position for the interactive UI.
+- `run_static(output, dynamic_height, ...)` keeps a fixed inline UI at the bottom while `StaticOutput` writes permanent log lines into scrollback above it.
+
+## `RunConfig` in practice
+
+`RunConfig` is the runtime policy object for all built-in loops.
+
+```rust
+use slt::{RunConfig, Theme};
+use std::time::Duration;
+
+let config = RunConfig::default()
+    .tick_rate(Duration::from_millis(33))
+    .mouse(true)
+    .theme(Theme::light())
+    .max_fps(60)
+    .scroll_speed(2)
+    .title("My App");
+```
+
+Important details:
+
+- `tick_rate` controls how often the loop wakes up even if no input arrives.
+- `max_fps` caps the render rate after work is done.
+- `mouse(true)` enables clicks, hovers, and wheel input.
+- `kitty_keyboard(true)` requests richer key events on supported terminals.
+- `RunConfig` is `#[non_exhaustive]`, so use the builder methods instead of struct literals.
+
+## Custom backend model
+
+The low-level contract is intentionally small.
+
+```rust
+pub trait Backend {
+    fn size(&self) -> (u32, u32);
+    fn buffer_mut(&mut self) -> &mut Buffer;
+    fn flush(&mut self) -> std::io::Result<()>;
+}
+```
+
+SLT renders into your `Buffer`. Your backend decides how to present it: terminal, WASM DOM, texture, SSH stream, test harness, or something else.
+
+## Driving `frame()` yourself
+
+```rust
+use slt::{AppState, Backend, Buffer, Context, Event, Rect, RunConfig};
+
+struct MyBackend {
+    buffer: Buffer,
+}
+
+impl Backend for MyBackend {
+    fn size(&self) -> (u32, u32) {
+        (self.buffer.area.width, self.buffer.area.height)
+    }
+
+    fn buffer_mut(&mut self) -> &mut Buffer {
+        &mut self.buffer
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    let mut backend = MyBackend {
+        buffer: Buffer::empty(Rect::new(0, 0, 80, 24)),
+    };
+    let mut app = AppState::new();
+    let config = RunConfig::default();
+
+    loop {
+        let events: Vec<Event> = vec![];
+        let keep_going = slt::frame(&mut backend, &mut app, &config, &events, &mut |ui: &mut Context| {
+            ui.text("Hello from a custom backend");
+        })?;
+
+        if !keep_going {
+            break;
+        }
+    }
+
+    Ok(())
+}
+```
+
+### What `AppState` actually stores
+
+`AppState` is the persistent frame-to-frame session state for:
+
+- hook storage (`use_state`, `use_memo`)
+- focus position and focus counts
+- previous-frame hit areas and scroll bounds
+- toast queue and debug overlay state
+- smoothed FPS estimate and tick counter
+
+Do not recreate it every frame. Reuse one instance for the whole session.
+
+### What `frame()` expects from you
+
+- Reuse the same `AppState` across frames.
+- Pass the current frame's `events` slice.
+- Rebuild the event list each frame in your outer loop.
+- Stop when `frame()` returns `Ok(false)` after `ui.quit()`.
+
+## Inline mode details
+
+`run_inline(height, ...)` is for CLI tools that should remain embedded in normal terminal flow.
+
+- It does not enter alternate screen mode.
+- It reserves a fixed display area below the cursor.
+- Resize events can change the width, but the reserved height stays the one you requested.
+- Pressing `Ctrl+C` still exits the loop like the regular terminal backend.
+
+Use it when the TUI is a helper surface rather than the whole app.
+
+## Static output mode details
+
+`StaticOutput` is a scrollback-friendly companion for inline apps.
+
+```rust
+use slt::StaticOutput;
+
+let mut output = StaticOutput::new();
+output.push("Build started...");
+output.push("Fetching data...");
+```
+
+Use it when you want:
+
+- a fixed inline control surface at the bottom
+- persistent logs or messages above it
+- a CLI tool that mixes streaming text output with interaction
+
+## Related APIs
+
+- `docs/FEATURES.md` - feature-gated runtime behavior
+- `docs/DEBUGGING.md` - F12 overlay, one-frame delay, layout debugging
+- `docs/PATTERNS.md` - hooks, overlays, custom widgets
+- `src/lib.rs` - canonical rustdoc for `Backend`, `AppState`, `frame()`, `RunConfig`

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -1,0 +1,109 @@
+# Debugging Guide
+
+This guide covers the runtime behaviors that are easy to misread if you only look at widget code.
+
+## The big idea: interaction is often previous-frame data
+
+SLT is immediate mode.
+
+1. your closure records commands
+2. layout runs later
+3. hit areas and focus rectangles are known after layout
+4. the next frame reads that data back through `prev_*`
+
+That means hover/click/focus-sensitive behavior can feel one frame delayed in the implementation even though it looks instant at runtime.
+
+## F12 layout debugger
+
+Press `F12` in a running terminal app to toggle the debug overlay.
+
+Use it when you need to inspect:
+
+- container bounds
+- nesting depth
+- widget count
+- frame timing / FPS
+- current terminal dimensions
+
+This is the fastest way to debug clipping, spacing, and invisible layout issues.
+
+## Common failure modes
+
+### 1. Hover or click seems "off"
+
+Check:
+
+- was the widget laid out in the previous frame?
+- are you reading a child response when the container owns the interaction area?
+- are you conditionally rendering the widget in a way that changes call order?
+
+### 2. Hook panic or state mismatch
+
+`use_state()` and `use_memo()` must be called in the same order every frame.
+
+Bad:
+
+```rust
+if show_sidebar {
+    let state = ui.use_state(|| 0);
+}
+```
+
+Good:
+
+```rust
+let state = ui.use_state(|| 0);
+if show_sidebar {
+    ui.text(format!("{}", state.get(ui)));
+}
+```
+
+### 3. `Response.rect` is empty
+
+`Response.rect` is meaningful only after the widget has participated in layout.
+If the widget was not laid out or the response comes from a helper path that has no visible rect yet, you may see a zero-sized rect.
+
+### 4. `focused` is not what you expected
+
+`Response.focused` is for the widget that actually registered focus.
+Wrapping a focused child inside `row()` or `container()` does not automatically mean the container response is focused.
+
+### 5. Raw draw output is clipped strangely
+
+`raw_draw` is clipped by the same layout and viewport rules as other content.
+Verify:
+
+- parent container bounds
+- scrollable viewport
+- draw rect size
+- child margin/padding
+
+## Layout debugging checklist
+
+1. Toggle F12.
+2. Reduce the case to one container and one child.
+3. Replace dynamic content with `ui.text("X")` to prove layout is correct first.
+4. Check whether you want `row()` or `line()`.
+5. If using overlays or modals, verify whether background interaction should be blocked.
+
+## Focus and modal debugging
+
+Focus handling changes inside modal layers.
+
+- `register_focusable()` inside a modal participates in modal-local focus.
+- widgets outside the modal are effectively inert while the modal is active.
+- `interaction()` also short-circuits outside the active modal layer.
+
+If a custom widget behaves strangely in overlays, inspect both `focused` and whether it is inside the active overlay depth.
+
+## Clipboard and terminal caveats
+
+- `read_clipboard()` depends on OSC 52 support in the terminal.
+- `copy_to_clipboard(...)` writes OSC 52 escape sequences through the active terminal backend.
+- Kitty keyboard support is best-effort: unsupported terminals silently ignore it.
+
+## Related docs
+
+- `docs/ARCHITECTURE.md` - frame lifecycle and module map
+- `docs/PATTERNS.md` - hooks, overlays, custom widgets
+- `docs/TESTING.md` - headless testing patterns

--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -52,7 +52,7 @@ This is the foundational decision. Every other principle flows from it.
 
 ## 3. Widget Contract
 
-Every widget follows the same pattern. No exceptions.
+Every widget should fit one of a very small number of patterns. Prefer consistency over cleverness.
 
 ### Interactive Widgets
 
@@ -194,7 +194,7 @@ SLT follows [Semantic Versioning](https://semver.org/).
 
 | Version range | Compatibility promise |
 |---------------|----------------------|
-| 0.12.x (patch) | Backward compatible — no breaking changes |
+| 0.15.x (patch) | Backward compatible — no breaking changes |
 | 0.x → 0.y (minor) | May contain breaking changes (pre-1.0) |
 | 1.x (post-1.0) | Strict semver — breaking changes only in major versions |
 
@@ -218,12 +218,15 @@ SLT follows [Semantic Versioning](https://semver.org/).
 
 | Dependency | Purpose | Required? |
 |------------|---------|-----------|
-| `crossterm` | Terminal I/O, event polling | Yes |
+| `crossterm` | Built-in terminal runtime and terminal helpers | Default feature |
 | `unicode-width` | Character width measurement | Yes |
 | `compact_str` | String optimization | Yes |
 | `tokio` | Async runtime | Optional (`async` feature) |
 | `serde` | Serialization | Optional (`serde` feature) |
 | `image` | Image loading | Optional (`image` feature) |
+| `qrcode` | QR code widget support | Optional (`qrcode` feature) |
+| `syntax` / `syntax-*` | Tree-sitter syntax highlighting | Optional |
+| `kitty-compress` | Compressed Kitty image uploads | Optional |
 
 ### Rules
 
@@ -231,6 +234,7 @@ SLT follows [Semantic Versioning](https://semver.org/).
 - Optional dependencies go behind feature flags
 - Feature flags must be **additive** — enabling a feature must not remove types or change existing behavior
 - Prefer `dep:` syntax in `[features]` to avoid implicit feature names
+- Keep docs explicit about which APIs require `crossterm` and which work on the core backend path without it
 
 ---
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -5,58 +5,58 @@ Use this index to find the smallest example that matches what you want to build.
 
 ## Basics
 
-| Example | Command | Purpose |
-|---------|---------|---------|
-| `hello` | `cargo run --example hello` | Smallest possible SLT app |
-| `counter` | `cargo run --example counter` | State + keyboard input |
-| `inline` | `cargo run --example inline` | Inline rendering below the prompt |
-| `anim` | `cargo run --example anim` | Tween, spring, keyframes |
+| Example | Command | Features | Purpose |
+|---------|---------|----------|---------|
+| `hello` | `cargo run --example hello` | — | Smallest possible SLT app |
+| `counter` | `cargo run --example counter` | — | State + keyboard input |
+| `inline` | `cargo run --example inline` | — | Inline rendering below the prompt |
+| `anim` | `cargo run --example anim` | — | Tween, spring, keyframes |
 
 ## Widget and layout tours
 
-| Example | Command | Purpose |
-|---------|---------|---------|
-| `demo` | `cargo run --example demo` | Broad widget overview |
-| `demo_cli` | `cargo run --example demo_cli` | CLI-style layout |
-| `demo_table` | `cargo run --example demo_table` | Table widget focus |
-| `demo_wiki` | `cargo run --example demo_wiki` | Text-heavy layout and markdown |
-| `demo_website` | `cargo run --example demo_website` | Website-style terminal layout |
+| Example | Command | Features | Purpose |
+|---------|---------|----------|---------|
+| `demo` | `cargo run --example demo` | `qrcode`, `syntax` (optional) | Broad widget overview |
+| `demo_cli` | `cargo run --example demo_cli` | — | CLI-style layout |
+| `demo_table` | `cargo run --example demo_table` | — | Table widget focus |
+| `demo_wiki` | `cargo run --example demo_wiki` | — | Text-heavy layout and markdown |
+| `demo_website` | `cargo run --example demo_website` | — | Website-style terminal layout |
 
 ## Data and visualization
 
-| Example | Command | Purpose |
-|---------|---------|---------|
-| `demo_dashboard` | `cargo run --example demo_dashboard` | Dashboard composition |
-| `demo_infoviz` | `cargo run --example demo_infoviz` | Charts and visual summaries |
-| `demo_trading` | `cargo run --example demo_trading` | Dense market/trading layout |
-| `demo_spreadsheet` | `cargo run --example demo_spreadsheet` | Grid and data entry feel |
-| `demo_raw_draw` | `cargo run --example demo_raw_draw` | Direct buffer drawing |
+| Example | Command | Features | Purpose |
+|---------|---------|----------|---------|
+| `demo_dashboard` | `cargo run --example demo_dashboard` | — | Dashboard composition |
+| `demo_infoviz` | `cargo run --example demo_infoviz` | — | Charts and visual summaries |
+| `demo_trading` | `cargo run --example demo_trading` | — | Dense market/trading layout |
+| `demo_spreadsheet` | `cargo run --example demo_spreadsheet` | — | Grid and data entry feel |
+| `demo_raw_draw` | `cargo run --example demo_raw_draw` | — | Direct buffer drawing |
 
 ## Rich terminal features
 
-| Example | Command | Purpose |
-|---------|---------|---------|
-| `demo_kitty_image` | `cargo run --example demo_kitty_image` | Kitty graphics protocol |
-| `demo_fire` | `cargo run --release --example demo_fire` | Half-block visual effect |
-| `demo_ime` | `cargo run --example demo_ime` | IME and CJK input |
-| `demo_key_test` | `cargo run --example demo_key_test` | Inspect key events |
-| `debug_selection` | `cargo run --example debug_selection` | Selection overlay debugging |
+| Example | Command | Features | Purpose |
+|---------|---------|----------|---------|
+| `demo_kitty_image` | `cargo run --example demo_kitty_image` | — | Kitty graphics protocol |
+| `demo_fire` | `cargo run --release --example demo_fire` | — | Half-block visual effect |
+| `demo_ime` | `cargo run --example demo_ime` | — | IME and CJK input |
+| `demo_key_test` | `cargo run --example demo_key_test` | — | Inspect key events |
+| `debug_selection` | `cargo run --example debug_selection` | — | Selection overlay debugging |
 
 ## Interaction-heavy apps
 
-| Example | Command | Purpose |
-|---------|---------|---------|
-| `demo_game` | `cargo run --example demo_game` | Games in immediate mode |
-| `error_boundary_demo` | `cargo run --example error_boundary_demo` | Panic recovery surface |
-| `test_mouse` | `cargo run --example test_mouse` | Mouse interaction behavior |
+| Example | Command | Features | Purpose |
+|---------|---------|----------|---------|
+| `demo_game` | `cargo run --example demo_game` | — | Games in immediate mode |
+| `error_boundary_demo` | `cargo run --example error_boundary_demo` | — | Panic recovery surface |
+| `test_mouse` | `cargo run --example test_mouse` | — | Mouse interaction behavior |
 
 ## Async and performance
 
-| Example | Command | Purpose |
-|---------|---------|---------|
-| `async_demo` | `cargo run --example async_demo --features async` | Background message flow |
-| `perf_interactive` | `cargo run --example perf_interactive` | Interactive perf sanity checks |
-| `perf_regression` | `cargo run --example perf_regression` | Headless perf regression coverage |
+| Example | Command | Features | Purpose |
+|---------|---------|----------|---------|
+| `async_demo` | `cargo run --example async_demo --features async` | `async` | Background message flow |
+| `perf_interactive` | `cargo run --example perf_interactive` | — | Interactive perf sanity checks |
+| `perf_regression` | `cargo run --example perf_regression` | — | Headless perf regression coverage |
 
 ## Suggested path
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,68 @@
+# Feature Flags
+
+> **Canonical source:** `Cargo.toml [features]`. This document is a human-readable companion.
+
+This guide is the human-readable feature matrix.
+For the canonical API surface, also check docs.rs and `src/lib.rs`.
+
+## Core model
+
+- `unicode-width` and `compact_str` are always part of the small core.
+- `crossterm` is a **default feature**, not a hard requirement.
+- The low-level core (`Backend`, `AppState`, `frame()`, widgets, events, style/layout types) works without terminal I/O.
+
+## Main flags
+
+| Flag | What it enables |
+|------|------------------|
+| `crossterm` | Built-in terminal runtime: `run()`, `run_with()`, `run_inline()`, terminal polling, clipboard query, terminal helpers |
+| `async` | `run_async()` and tokio-based message-driven apps |
+| `serde` | Serialize/Deserialize for style, theme, and layout-related public types |
+| `image` | Image loading helpers for terminal image widgets |
+| `qrcode` | `ui.qr_code(...)` |
+| `syntax` | Tree-sitter syntax highlighting support |
+| `syntax-*` | Per-language syntax bundles such as `syntax-rust`, `syntax-python`, `syntax-typescript` |
+| `kitty-compress` | zlib compression for Kitty image protocol uploads |
+| `full` | Convenience bundle: enables `crossterm`, `async`, `serde`, `image`, `qrcode`, and `kitty-compress` (does **not** include `syntax` — add language bundles separately) |
+
+## What disappears without `crossterm`
+
+When you disable default features and do not re-enable `crossterm`:
+
+- `run()` and terminal-owned loops are unavailable
+- terminal helpers such as color scheme detection are unavailable
+- terminal clipboard query support is unavailable
+
+What still remains:
+
+- `Backend`
+- `AppState`
+- `frame()`
+- `Context`, widgets, events, styles, layout, charts
+
+That makes SLT usable as a rendering core for non-terminal environments.
+
+## Recommended combos
+
+| Goal | Suggested dependency |
+|------|----------------------|
+| Regular terminal app | `superlighttui = "..."` |
+| Async terminal app | `superlighttui = { version = "...", features = ["async"] }` |
+| QR output | `superlighttui = { version = "...", features = ["qrcode"] }` |
+| Syntax-highlighted code blocks | `superlighttui = { version = "...", features = ["syntax", "syntax-rust"] }` |
+| Custom backend only | `superlighttui = { version = "...", default-features = false }` |
+
+## AI-friendly rule of thumb
+
+When reading or generating code:
+
+- if you see `run()` / `run_inline()` / clipboard query usage, assume `crossterm` is needed
+- if you see `run_async()`, assume `async` is needed
+- if you see `ui.qr_code(...)`, assume `qrcode` is needed
+- if you see `code_block_lang(...)` with tree-sitter behavior, check `syntax` flags
+
+## Related docs
+
+- `docs/BACKENDS.md` - no-default-features and custom backend path
+- `docs/README.md` - docs index
+- `src/lib.rs` - crate-level rustdoc and cfg-gated API surface

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -44,6 +44,20 @@ if ui.button("+1").clicked {
 Use hooks for small local state when a dedicated app struct feels heavy.
 Keep hook call order stable across frames.
 
+## Derived state with `use_memo`
+
+```rust
+let filtered = ui.use_memo(&(query.clone(), items.len()), |(query, _)| {
+    items.iter()
+        .filter(|item| item.contains(query))
+        .cloned()
+        .collect::<Vec<_>>()
+});
+```
+
+Use `use_memo` when the computation is deterministic and should only rerun when the dependency tuple changes.
+Like `use_state`, call order must stay stable across frames.
+
 ## Forms and validation
 
 ```rust
@@ -76,6 +90,21 @@ if ui.raw_key_code(KeyCode::Esc) {
 
 Use `raw_*` shortcuts for keys that must work regardless of modal or overlay state.
 
+## Screen helpers and navigation
+
+```rust
+ui.screen("home", &screens, |ui| {
+    ui.text("Home").bold();
+});
+
+ui.screen("settings", &screens, |ui| {
+    ui.text("Settings");
+});
+```
+
+Use `screen(name, &screens, ...)` when you want declarative rendering that only runs for the active screen.
+Use manual `push()` / `pop()` logic on `ScreenState` when you need explicit navigation transitions.
+
 ## Modal, overlay, and screen composition
 
 ```rust
@@ -100,6 +129,31 @@ if show_modal {
 
 Use screens for view-level navigation and modal/overlay for transient UI layers.
 
+## Error boundaries and recovery
+
+```rust
+ui.error_boundary(|ui| {
+    ui.text("Protected subtree");
+});
+```
+
+Use `error_boundary` or `error_boundary_with` when you want one subtree to fail without taking down the whole app.
+This is especially useful for experimental widgets, user-generated content, or plugins.
+
+## Custom widgets: focus and interaction
+
+```rust
+let focused = ui.register_focusable();
+let response = ui.interaction();
+
+if response.hovered {
+    ui.tooltip("Hovered");
+}
+```
+
+Use `register_focusable()` when the widget needs keyboard participation.
+Use `interaction()` when the widget needs click/hover without wrapping everything in a container.
+
 ## Async background messages
 
 ```rust
@@ -113,6 +167,47 @@ tx.send("Background work done".into()).await?;
 ```
 
 Enable with the `async` feature.
+
+## Animation patterns
+
+```rust
+// Tween: smooth transition over N ticks
+let mut fade = Tween::new(0.0, 1.0, 30);
+let opacity = fade.value(ui.tick());
+
+// Spring: physics-based, responds to target changes
+let mut spring = Spring::new(0.0, 0.2, 0.85);
+if hovered { spring.set_target(1.0); } else { spring.set_target(0.0); }
+spring.tick();
+let scale = spring.value();
+
+// Stagger: offset animation across list items
+let mut stagger = Stagger::new(0.0, 1.0, 20).delay(3).items(items.len());
+for (i, item) in items.iter().enumerate() {
+    let alpha = stagger.value(ui.tick(), i);
+    ui.text(item).fg(Color::Rgb(255, 255, (alpha * 255.0) as u8));
+}
+```
+
+Animation types are standalone structs that compute values from `ui.tick()`.
+Pass computed values to style and layout methods.
+See `docs/ANIMATION.md` for the full API.
+
+## Responsive layout
+
+```rust
+match ui.breakpoint() {
+    Breakpoint::Xs | Breakpoint::Sm => {
+        ui.col(|ui| { /* stacked layout */ });
+    }
+    _ => {
+        ui.row(|ui| { /* side-by-side */ });
+    }
+};
+```
+
+Use `breakpoint()` for width-dependent layout decisions.
+ContainerBuilder also supports responsive methods: `.gap_sm(1).gap_lg(2)`.
 
 ## Custom widgets
 
@@ -167,3 +262,5 @@ assert!(backend.to_string().contains("Hello"));
 ```
 
 Use `TestBackend` for headless rendering checks and snapshot-style assertions.
+
+For deeper coverage, see `docs/TESTING.md`.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -11,11 +11,14 @@
 [![Downloads Badge]][Crate]
 [![License Badge]][License]
 
-[Crate] · [Docs] · [Examples] · [Contributing]
+[Índice de Docs] · [Inicio Rápido] · [Guía de Widgets] · [Ejemplos] · [Guía de Patrones] · [Arquitectura] · [Contribuir]
 
 [English](../README.md) · [中文](README.zh-CN.md) · **Español** · [日本語](README.ja.md) · [한국어](README.ko.md)
 
 </div>
+
+SuperLightTUI es una biblioteca TUI de modo inmediato para Rust.
+Escribes un closure, SLT lo llama en cada frame, y la biblioteca se encarga del layout, diffing, foco y renderizado.
 
 ## Galería
 
@@ -57,16 +60,22 @@ fn main() -> std::io::Result<()> {
     let mut count: i32 = 0;
 
     slt::run(|ui: &mut Context| {
-        if ui.key('q') { ui.quit(); }
-        if ui.key('k') || ui.key_code(KeyCode::Up) { count += 1; }
-        if ui.key('j') || ui.key_code(KeyCode::Down) { count -= 1; }
+        if ui.key('q') {
+            ui.quit();
+        }
+        if ui.key('k') || ui.key_code(KeyCode::Up) {
+            count += 1;
+        }
+        if ui.key('j') || ui.key_code(KeyCode::Down) {
+            count -= 1;
+        }
 
         ui.bordered(Border::Rounded).title("Counter").pad(1).gap(1).col(|ui| {
             ui.text("Counter").bold().fg(Color::Cyan);
             ui.row(|ui| {
                 ui.text("Count:");
-                let c = if count >= 0 { Color::Green } else { Color::Red };
-                ui.text(format!("{count}")).bold().fg(c);
+                let color = if count >= 0 { Color::Green } else { Color::Red };
+                ui.text(format!("{count}")).bold().fg(color);
             });
             ui.text("k +1 / j -1 / q quit").dim();
         });
@@ -78,420 +87,100 @@ El estado vive en tu closure. El layout usa `row()` y `col()`. El estilo se enca
 
 ## Por qué SLT
 
-**Tu closure ES la aplicación** — Sin estado de framework. Sin paso de mensajes. Sin implementaciones de traits. Escribes una función, SLT la llama en cada frame.
+- **Tu closure ES la aplicación** — sin estado de framework, sin implementaciones de traits, sin bucle de mensajes.
+- **Layout como CSS, sintaxis como Tailwind** — `row()`, `col()`, `gap()`, `grow()`, `spacer()`, más abreviaciones como `.p()`, `.px()`, `.m()`, `.w()`, `.max_w()`.
+- **Los widgets conectan todo automáticamente** — orden de foco, hover, clics, scroll y comportamiento de teclado vienen integrados.
+- **Núcleo pequeño, extras opcionales** — las dependencias del núcleo son `unicode-width` y `compact_str`; el I/O de terminal viene del `crossterm` opcional; async, serde, image, qrcode y resaltado de sintaxis van tras feature flags.
+- **La higiene de biblioteca importa** — cero `unsafe`, feature flags explícitos, documentación, ejemplos, tests y disciplina de releases con semver.
 
-**Todo se conecta automáticamente** — El foco cicla con Tab. El scroll funciona con la rueda del ratón. Los contenedores reportan clics y hovers. Los widgets consumen sus propios eventos.
-
-**Layout como CSS, sintaxis como Tailwind** — Flexbox con `row()`, `col()`, `grow()`, `gap()`, `spacer()`. Abreviaciones Tailwind: `.p()`, `.px()`, `.py()`, `.m()`, `.mx()`, `.my()`, `.w()`, `.h()`, `.min_w()`, `.max_w()`.
-
-```rust
-ui.container()
-    .border(Border::Rounded)
-    .p(2).mx(1).grow(1).max_w(60)
-    .col(|ui| {
-        ui.row(|ui| {
-            ui.text("left");
-            ui.spacer();
-            ui.text("right");
-        });
-    });
-```
-
-**Núcleo pequeño, extras opcionales** — el núcleo usa `unicode-width` y `compact_str`. El I/O de terminal llega por la feature `crossterm`, activada por defecto. Opcionales: `tokio` (async), `serde` (serialización), `image` (carga de imágenes), `qrcode`. Cero código `unsafe`.
-
-> **Desarrollo asistido por IA** — Usa el skill `rust-tui-development-with-slt` en [Claude Code](https://docs.anthropic.com/en/docs/claude-code) para referencia completa de API, mejores patrones y plantillas de generación de código. O diseña visualmente con [tui.builders](https://tui.builders):
-
-[![tui.builders demo](../assets/tui-builders-demo.gif)](https://tui.builders)
-
-> Arrastra widgets, configura propiedades en el inspector, exporta Rust idiomático. Gratis, sin registro, código abierto.
-
-## Widgets
-
-Amplio conjunto de widgets integrados, sin código repetitivo:
+## Superficie de API común
 
 ```rust
-ui.text_input(&mut name);                    // entrada de una línea
-ui.textarea(&mut notes, 5);                  // editor multilínea
-if ui.button("Submit").clicked { /* … */ }    // devuelve Response
-ui.checkbox("Dark mode", &mut dark);         // casilla de verificación
-ui.toggle("Notifications", &mut on);         // interruptor on/off
-ui.tabs(&mut tabs);                          // navegación por pestañas
-ui.list(&mut items);                         // lista seleccionable
-ui.select(&mut sel);                         // selector desplegable
-ui.radio(&mut radio);                        // grupo de botones de radio
-ui.multi_select(&mut multi);                 // casillas de selección múltiple
-ui.tree(&mut tree);                          // vista de árbol expandible
-ui.virtual_list(&mut list, 20, |ui, i| {}); // lista virtualizada
-ui.table(&mut data);                         // tabla de datos
-ui.spinner(&spin);                           // animación de carga
-ui.progress(0.75);                           // barra de progreso
-ui.scrollable(&mut scroll).col(|ui| { });    // contenedor con scroll
-ui.toast(&mut toasts);                       // notificaciones
-ui.separator();                              // línea horizontal
-ui.help(&[("q", "quit"), ("Tab", "focus")]); // atajos de teclado
-ui.link("Docs", "https://docs.rs/superlighttui");      // hipervínculo clicable (OSC 8)
-ui.modal(|ui| { ui.text("overlay"); });      // modal con fondo oscurecido
-ui.overlay(|ui| { ui.text("floating"); });   // capa flotante sin oscurecer
-ui.command_palette(&mut palette);            // paleta de comandos con búsqueda
-ui.markdown("# Hello **world**");            // renderizado Markdown
-ui.form_field(&mut field);                   // entrada etiquetada con validación
-ui.chart(|c| { c.line(&data); c.grid(true); }, 50, 16); // gráfico de líneas/dispersión/barras
-ui.scatter(&points, 50, 16);                 // gráfico de dispersión independiente
-ui.histogram(&values, 40, 12);               // histograma con bins automáticos
-ui.bar_chart(&data, 24);                     // barras horizontales
-ui.sparkline(&values, 16);                   // línea de tendencia ▁▂▃▅▇
-ui.canvas(40, 10, |cv| { cv.circle(20, 20, 15); }); // canvas de puntos braille
-ui.grid(3, |ui| { /* cuadrícula de 3 columnas */ }); // layout en cuadrícula
-ui.tooltip("Save the current file");         // popup de tooltip al pasar el cursor
-ui.calendar(&mut cal);                       // selector de fecha con navegación mensual
-ui.screen("home", &screens, |ui| {});        // pila de enrutamiento de pantallas
-ui.confirm("Delete?", &mut yes);             // confirmación sí/no con soporte de ratón
-```
-
-Cada widget gestiona sus propios eventos de teclado, estado de foco e interacción con el ratón.
-
-### Widgets personalizados
-
-Implementa el trait `Widget` para construir los tuyos:
-
-```rust
-use slt::{Context, Widget, Color, Style};
-
-struct Rating { value: u8, max: u8 }
-
-impl Widget for Rating {
-    type Response = bool;
-
-    fn ui(&mut self, ui: &mut Context) -> bool {
-        let focused = ui.register_focusable();
-        let mut changed = false;
-
-        if focused {
-            if ui.key('+') && self.value < self.max { self.value += 1; changed = true; }
-            if ui.key('-') && self.value > 0 { self.value -= 1; changed = true; }
-        }
-
-        let stars: String = (0..self.max)
-            .map(|i| if i < self.value { '★' } else { '☆' })
-            .collect();
-        let color = if focused { Color::Yellow } else { Color::White };
-        ui.styled(stars, Style::new().fg(color));
-        changed
-    }
-}
-
-// Uso: ui.widget(&mut rating);
-```
-
-Foco, eventos, temas, layout: todo accesible a través de `Context`. Un trait, un método.
-
-## Características
-
-<details>
-<summary><b>Layout</b></summary>
-
-| Característica | API |
-|----------------|-----|
-| Pila vertical | `ui.col(\|ui\| { })` |
-| Pila horizontal | `ui.row(\|ui\| { })` |
-| Layout en cuadrícula | `ui.grid(3, \|ui\| { })` |
-| Espacio entre hijos | `.gap(1)` |
-| Flex grow | `.grow(1)` |
-| Empujar al final | `ui.spacer()` |
-| Alineación | `.align(Align::Center)` |
-| Padding | `.p(1)`, `.px(2)`, `.py(1)` |
-| Margin | `.m(1)`, `.mx(2)`, `.my(1)` |
-| Tamaño fijo | `.w(20)`, `.h(10)` |
-| Restricciones | `.min_w(10)`, `.max_w(60)` |
-| Tamaño porcentual | `.w_pct(50)`, `.h_pct(80)` |
-| Justificación | `.space_between()`, `.space_around()`, `.space_evenly()` |
-| Ajuste de texto | `ui.text("long text...").wrap()` |
-| Bordes con títulos | `.border(Border::Rounded).title("Panel")` |
-| Bordes por lado | `.border_top(false)`, `.border_sides(BorderSides::horizontal())` |
-| Espacio responsivo | `.gap_at(Breakpoint::Md, 2)` |
-
-</details>
-
-<details>
-<summary><b>Estilos</b></summary>
-
-```rust
-ui.text("styled").bold().italic().underline().fg(Color::Cyan).bg(Color::Black);
-```
-
-16 colores con nombre · paleta de 256 colores · RGB de 24 bits · 6 modificadores · 6 estilos de borde
-
-</details>
-
-<details>
-<summary><b>Temas</b></summary>
-
-```rust
-// 7 presets integrados
-slt::run_with(RunConfig::default().theme(Theme::catppuccin()), |ui| {
-    ui.set_theme(Theme::dark()); // cambiar en tiempo de ejecución
+// Texto y layout
+ui.text("Hello").bold().fg(Color::Cyan);
+ui.row(|ui| {
+    ui.text("left");
+    ui.spacer();
+    ui.text("right");
 });
 
-// Construir temas personalizados
-let theme = Theme::builder()
-    .primary(Color::Rgb(255, 107, 107))
-    .accent(Color::Cyan)
-    .build();
-```
+// Entradas y acciones
+ui.text_input(&mut name);
+if ui.button("Save").clicked {}
+ui.checkbox("Dark mode", &mut dark);
 
-7 presets (dark, light, dracula, catppuccin, nord, solarized_dark, tokyo_night). Temas personalizados con 15 ranuras de color + flag `is_dark`. Todos los widgets heredan automáticamente.
+// Datos y navegación
+ui.tabs(&mut tabs);
+ui.list(&mut items);
+ui.table(&mut data);
+ui.command_palette(&mut palette);
 
-</details>
-
-<details>
-<summary><b>Recetas de estilo</b></summary>
-
-```rust
-use slt::{ContainerStyle, Border, Color};
-
-const CARD: ContainerStyle = ContainerStyle::new()
-    .border(Border::Rounded).p(1).bg(Color::Indexed(236));
-
-// Aplicar y componer
-ui.container().apply(&CARD).grow(1).gap(2).col(|ui| { ... });
-```
-
-Define una vez, aplica en cualquier lugar. Los estilos `const` tienen coste cero en tiempo de ejecución. Compón encadenando `.apply()`, los métodos inline siempre tienen prioridad.
-
-</details>
-
-<details>
-<summary><b>Layout responsivo</b></summary>
-
-```rust
-ui.container()
-    .w(20).md_w(40).lg_w(60)  // el ancho cambia en los breakpoints
-    .p(1).lg_p(2)
-    .col(|ui| { ... });
-```
-
-35 métodos condicionales por breakpoint (`xs_`, `sm_`, `md_`, `lg_`, `xl_` × `w`, `h`, `min_w`, `max_w`, `gap`, `p`, `grow`). Breakpoints: Xs (<40), Sm (40-79), Md (80-119), Lg (120-159), Xl (≥160).
-
-</details>
-
-<details>
-<summary><b>Hooks</b></summary>
-
-```rust
-let count = ui.use_state(|| 0i32);
-ui.text(format!("{}", count.get(ui)));
-if ui.button("+1") { *count.get_mut(ui) += 1; }
-```
-
-Estado persistente al estilo React en modo inmediato. Patrón de handle `State<T>`. Llama en el mismo orden cada frame.
-
-</details>
-
-<details>
-<summary><b>Renderizado</b></summary>
-
-- **Diff de doble buffer** — solo las celdas modificadas llegan al terminal
-- **Salida sincronizada** — DECSET 2026 previene el tearing en terminales compatibles
-- **Recorte de viewport** — los widgets fuera de pantalla se omiten completamente
-- **Límite de FPS** — `RunConfig::default().max_fps(60)` para controlar la CPU
-- **Redimensionado automático** — reflow automático al cambiar el tamaño del terminal
-- **`collect_all()`** — un único paso DFS reemplaza 7 recorridos de árbol separados (v0.9)
-
-</details>
-
-<details>
-<summary><b>Animación</b></summary>
-
-```rust
-let mut tween = Tween::new(0.0, 100.0, 60).easing(ease_out_bounce);
-let value = tween.value(ui.tick());
-
-let mut spring = Spring::new(0.0, 180.0, 12.0);
-spring.set_target(100.0);
-
-let mut kf = Keyframes::new(120)
-    .stop(0.0, 0.0).stop(0.5, 100.0).stop(1.0, 50.0)
-    .loop_mode(LoopMode::PingPong);
-```
-
-Tween con 9 funciones de easing. Física de resorte. Líneas de tiempo con keyframes y modos de bucle. Cadenas Sequence. Stagger para animaciones de listas. Todos soportan callbacks `.on_complete()`.
-
-</details>
-
-<details>
-<summary><b>Modo async</b></summary>
-
-```rust
-let tx = slt::run_async(|ui, messages: &mut Vec<String>| {
-    for msg in messages.drain(..) { ui.text(msg); }
-})?;
-tx.send("Hello from background!".into()).await?;
-```
-
-Integración opcional con tokio. Activa con `cargo add superlighttui --features async`.
-
-</details>
-
-<details>
-<summary><b>Error Boundary</b></summary>
-
-```rust
-ui.error_boundary(|ui| {
-    ui.text("If this panics, the app keeps running.");
-});
-```
-
-Captura panics de widgets sin crashear la aplicación. Los comandos parciales se revierten y se renderiza un fallback.
-
-</details>
-
-<details>
-<summary><b>Modal y Overlay</b></summary>
-
-```rust
+// Overlays y salida enriquecida
+ui.toast(&mut toasts);
 ui.modal(|ui| {
-    ui.bordered(Border::Rounded).pad(2).col(|ui| {
-        ui.text("Confirm?").bold();
-        if ui.button("OK") { show = false; }
-    });
+    ui.text("Confirm?").bold();
+});
+ui.markdown("# Hello **world**");
+
+// Visualización
+ui.chart(|c| {
+    c.line(&data);
+    c.grid(true);
+}, 50, 16);
+ui.sparkline(&values, 16);
+ui.canvas(40, 10, |cv| {
+    cv.circle(20, 20, 15);
 });
 ```
 
-`modal()` oscurece el fondo y renderiza contenido encima. `overlay()` renderiza contenido flotante sin oscurecer. Ambos soportan layout e interacción completos.
+Para la lista categorizada de widgets, consulta la [Guía de Widgets].
 
-</details>
+## Aprende la biblioteca
 
-<details>
-<summary><b>Tests de snapshot</b></summary>
+| Documento | Qué cubre |
+|-----------|-----------|
+| [Índice de Docs] | Estructura de documentación y mapa de guías |
+| [Inicio Rápido] | Instalación, primera app, contador, layout, input |
+| [Guía de Widgets] | Catálogo de widgets y APIs principales |
+| [Guía de Patrones] | Estado, formularios, overlays, async, widgets personalizados |
+| [Ejemplos] | Índice de ejemplos y comandos de ejecución |
+| [Arquitectura] | Mapa de módulos, ciclo de vida del frame |
+| [Guía de Backends] | `Backend`, `AppState`, `frame()`, modo inline |
+| [Guía de Testing] | `TestBackend`, `EventBuilder`, pruebas de interacción |
+| [Guía de Depuración] | Overlay F12, clipping, retardo de un frame |
+| [Guía AI] | Referencia rápida para agentes de código AI |
+| [Guía de Animación] | Tween, Spring, Keyframes, Sequence, Stagger |
+| [Guía de Temas] | Temas predefinidos, ThemeBuilder, temas personalizados |
+| [Guía de Características] | Feature flags, dependencias opcionales |
+| [`docs/DESIGN_PRINCIPLES.md`](DESIGN_PRINCIPLES.md) | Por qué la API tiene esta forma |
 
-```rust
-use slt::TestBackend;
+## Ejemplos destacados
 
-let mut backend = TestBackend::new(40, 10);
-backend.render(|ui| {
-    ui.bordered(Border::Rounded).pad(1).col(|ui| {
-        ui.text("Hello");
-    });
-});
-insta::assert_snapshot!(backend.to_string_trimmed());
-```
-
-Úsalo con [insta](https://crates.io/crates/insta) para tests de regresión de UI basados en snapshots.
-
-</details>
-
-<details>
-<summary><b>Renderizado de imágenes</b></summary>
-
-```sh
-cargo add superlighttui --features image
-```
-
-```rust
-use slt::HalfBlockImage;
-
-let photo = image::open("photo.png").unwrap();
-let img = HalfBlockImage::from_dynamic(&photo, 60, 30);
-ui.image(&img);
-```
-
-Renderizado de imágenes con medio bloque (▀▄). Protocolo Sixel (v0.13.2): `ui.sixel_image(&rgba, w, h, cols, rows)` para imágenes a nivel de píxel en xterm, foot, mlterm.
-
-</details>
-
-<details>
-<summary><b>Feature Flags</b></summary>
-
-| Flag | Descripción |
-|------|-------------|
-| `async` | `run_async()` con paso de mensajes basado en canales tokio |
-| `serde` | Serializar/Deserializar Style, Color, Theme y tipos de layout |
-| `image` | `HalfBlockImage::from_dynamic()` con el crate `image` |
-| `full` | Todo lo anterior |
-
-```toml
-[dependencies]
-superlighttui = { version = "0.13", features = ["full"] }
-```
-
-</details>
-
-<details>
-<summary><b>Depuración</b></summary>
-
-Pulsa **F12** en cualquier aplicación SLT para activar el overlay del depurador de layout. Muestra los límites de los contenedores, la profundidad de anidamiento y la estructura del layout.
-
-</details>
-
-## Ejemplos
-
-| Ejemplo | Comando | Qué muestra |
-|---------|---------|-------------|
-| hello | `cargo run --example hello` | Configuración mínima |
-| counter | `cargo run --example counter` | Estado + teclado |
-| demo | `cargo run --example demo` | Todos los widgets |
-| demo_dashboard | `cargo run --example demo_dashboard` | Dashboard en vivo |
+| Ejemplo | Comando | Enfoque |
+|---------|---------|---------|
+| hello | `cargo run --example hello` | La app más pequeña posible |
+| counter | `cargo run --example counter` | Estado + entrada de teclado |
+| demo | `cargo run --example demo` | Tour amplio de widgets |
+| demo_dashboard | `cargo run --example demo_dashboard` | Layout de dashboard |
 | demo_cli | `cargo run --example demo_cli` | Layout de herramienta CLI |
-| demo_spreadsheet | `cargo run --example demo_spreadsheet` | Cuadrícula de datos |
-| demo_website | `cargo run --example demo_website` | Sitio web en el terminal |
-| demo_game | `cargo run --example demo_game` | Tetris + Snake + Buscaminas |
-| demo_fire | `cargo run --release --example demo_fire` | Efecto fuego DOOM (medio bloque) |
-| demo_ime | `cargo run --example demo_ime` | Entrada IME coreano/CJK |
-| inline | `cargo run --example inline` | Modo inline |
-| anim | `cargo run --example anim` | Tween + Spring + Keyframes |
-| demo_infoviz | `cargo run --example demo_infoviz` | Visualización de datos |
-| demo_trading | `cargo run --example demo_trading` | Terminal de trading estilo exchange |
-| async_demo | `cargo run --example async_demo --features async` | Tareas en segundo plano |
+| demo_infoviz | `cargo run --example demo_infoviz` | Gráficos y visualización de datos |
+| demo_game | `cargo run --example demo_game` | Interacción en modo inmediato |
+| async_demo | `cargo run --example async_demo --features async` | Mensajes en segundo plano |
 
-## Arquitectura
+El índice categorizado completo está en [Ejemplos].
 
-```
-Closure → Context collects Commands → build_tree() → flexbox layout → diff buffer → flush
-```
+## Widgets personalizados y backends
 
-Cada frame: tu closure se ejecuta, SLT recopila lo que describiste, calcula el layout flexbox, hace diff contra el frame anterior y solo vuelca las celdas modificadas.
+- Implementa `Widget` para construir widgets reutilizables con acceso completo a foco, layout, eventos y temas.
+- Implementa `Backend` + controla `frame()` si quieres un renderer no terminal, harness de tests, o destino embebido.
+- Usa `TestBackend` para renderizado headless y aserciones estilo snapshot.
 
-Rust puro. Sin macros, sin generación de código, sin scripts de build.
-
-### Backends personalizados
-
-El renderizado de SLT está abstraído detrás del trait `Backend`, lo que permite destinos de renderizado personalizados más allá del terminal:
-
-```rust
-use slt::{Backend, AppState, Buffer, Rect, RunConfig, Context, Event};
-
-struct MyBackend { buffer: Buffer }
-
-impl Backend for MyBackend {
-    fn size(&self) -> (u32, u32) {
-        (self.buffer.area.width, self.buffer.area.height)
-    }
-    fn buffer_mut(&mut self) -> &mut Buffer { &mut self.buffer }
-    fn flush(&mut self) -> std::io::Result<()> {
-        // Renderiza self.buffer a tu destino (canvas, GPU, red, etc.)
-        Ok(())
-    }
-}
-```
-
-El trait `Backend` tiene 3 métodos: `size()`, `buffer_mut()`, `flush()`. Los backends personalizados reciben el `Buffer` completamente renderizado y pueden presentarlo como quieran: WebGL, embed de egui, túnel SSH, harness de tests, etc.
-
-### Widgets nativos para IA
-
-SLT incluye widgets diseñados específicamente para flujos de trabajo con IA/LLM:
-
-| Widget | Descripción |
-|--------|-------------|
-| `streaming_text()` | Visualización de texto token a token con cursor parpadeante |
-| `streaming_markdown()` | Markdown en streaming con encabezados, bloques de código y formato inline |
-| `tool_approval()` | Aprobación/rechazo humano de llamadas a herramientas |
-| `context_bar()` | Barra de contador de tokens mostrando fuentes de contexto activas |
-| `markdown()` | Renderizado estático de Markdown |
-| `code_block()` | Visualización de código con resaltado de sintaxis |
+Consulta [Guía de Patrones] y [Arquitectura] para los caminos más profundos.
 
 ## Contribuir
 
-Consulta [CONTRIBUTING.md](../CONTRIBUTING.md) para las directrices.
+Lee [Contribuir], luego `docs/DESIGN_PRINCIPLES.md` y [Arquitectura].
+El proceso de release y CI espera que el formato, check, clippy, tests y compilación de ejemplos estén en verde.
 
 ## Licencia
 
@@ -509,6 +198,18 @@ Consulta [CONTRIBUTING.md](../CONTRIBUTING.md) para las directrices.
 [CI]: https://github.com/subinium/SuperLightTUI/actions/workflows/ci.yml
 [Crate]: https://crates.io/crates/superlighttui
 [Docs]: https://docs.rs/superlighttui
-[Examples]: https://github.com/subinium/SuperLightTUI/tree/main/examples
-[Contributing]: https://github.com/subinium/SuperLightTUI/blob/main/CONTRIBUTING.md
+[Índice de Docs]: README.md
+[Inicio Rápido]: QUICK_START.md
+[Guía de Widgets]: WIDGETS.md
+[Ejemplos]: EXAMPLES.md
+[Guía de Patrones]: PATTERNS.md
+[Arquitectura]: ARCHITECTURE.md
+[Guía de Backends]: BACKENDS.md
+[Guía de Testing]: TESTING.md
+[Guía de Depuración]: DEBUGGING.md
+[Guía AI]: AI_GUIDE.md
+[Guía de Animación]: ANIMATION.md
+[Guía de Temas]: THEMING.md
+[Guía de Características]: FEATURES.md
+[Contribuir]: ../CONTRIBUTING.md
 [License]: ../LICENSE

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -11,11 +11,14 @@
 [![Downloads Badge]][Crate]
 [![License Badge]][License]
 
-[Crate] · [Docs] · [Examples] · [Contributing]
+[ドキュメント] · [クイックスタート] · [ウィジェットガイド] · [サンプル集] · [パターンガイド] · [アーキテクチャ] · [コントリビュート]
 
 [English](../README.md) · [中文](README.zh-CN.md) · [Español](README.es.md) · **日本語** · [한국어](README.ko.md)
 
 </div>
+
+SuperLightTUI は Rust 用のイミディエイトモード TUI ライブラリです。
+クロージャを1つ書くだけで、SLT が毎フレームそれを呼び出し、レイアウト、差分、フォーカス、レンダリングを処理します。
 
 ## ショーケース
 
@@ -57,16 +60,22 @@ fn main() -> std::io::Result<()> {
     let mut count: i32 = 0;
 
     slt::run(|ui: &mut Context| {
-        if ui.key('q') { ui.quit(); }
-        if ui.key('k') || ui.key_code(KeyCode::Up) { count += 1; }
-        if ui.key('j') || ui.key_code(KeyCode::Down) { count -= 1; }
+        if ui.key('q') {
+            ui.quit();
+        }
+        if ui.key('k') || ui.key_code(KeyCode::Up) {
+            count += 1;
+        }
+        if ui.key('j') || ui.key_code(KeyCode::Down) {
+            count -= 1;
+        }
 
         ui.bordered(Border::Rounded).title("Counter").pad(1).gap(1).col(|ui| {
             ui.text("Counter").bold().fg(Color::Cyan);
             ui.row(|ui| {
                 ui.text("Count:");
-                let c = if count >= 0 { Color::Green } else { Color::Red };
-                ui.text(format!("{count}")).bold().fg(c);
+                let color = if count >= 0 { Color::Green } else { Color::Red };
+                ui.text(format!("{count}")).bold().fg(color);
             });
             ui.text("k +1 / j -1 / q quit").dim();
         });
@@ -78,396 +87,100 @@ fn main() -> std::io::Result<()> {
 
 ## なぜ SLT か
 
-**クロージャがそのままアプリになる** — フレームワークの状態管理なし。メッセージパッシングなし。トレイト実装なし。関数を書けば、SLT が毎フレーム呼び出します。
+- **クロージャがそのままアプリになる** — フレームワークの状態管理なし、トレイト実装のボイラープレートなし、メッセージループ API なし。
+- **CSS のようなレイアウト、Tailwind のような構文** — `row()`、`col()`、`gap()`、`grow()`、`spacer()`。ショートハンド: `.p()`、`.px()`、`.m()`、`.w()`、`.max_w()`。
+- **ウィジェットが面倒な部分を自動処理** — フォーカス順序、ホバー、クリック処理、スクロール、一般的なキーボード操作が組み込み済み。
+- **小さなコア、オプションの拡張** — コア依存は `unicode-width` と `compact_str`。ターミナル I/O はオプションの `crossterm`。async、serde、image、qrcode、シンタックスハイライトはフィーチャーフラグで提供。
+- **ライブラリの品質にこだわる** — `unsafe` ゼロ、明示的なフィーチャーフラグ、ドキュメント、サンプル、テスト、semver に基づくリリース規律。
 
-**すべて自動でつながる** — Tab でフォーカスが循環。マウスホイールでスクロール。コンテナはクリックとホバーを報告。ウィジェットは自分でイベントを消費します。
-
-**CSS のようなレイアウト、Tailwind のような構文** — `row()`、`col()`、`grow()`、`gap()`、`spacer()` で Flexbox。Tailwind 風ショートハンド: `.p()`、`.px()`、`.py()`、`.m()`、`.mx()`、`.my()`、`.w()`、`.h()`、`.min_w()`、`.max_w()`。
-
-```rust
-ui.container()
-    .border(Border::Rounded)
-    .p(2).mx(1).grow(1).max_w(60)
-    .col(|ui| {
-        ui.row(|ui| {
-            ui.text("left");
-            ui.spacer();
-            ui.text("right");
-        });
-    });
-```
-
-**小さなコアと必要な分だけの拡張** — コア依存は `unicode-width` と `compact_str`。ターミナル I/O はデフォルト有効の `crossterm` feature で提供されます。オプション: 非同期に `tokio`、シリアライズに `serde`、画像読み込みに `image`、QR コードに `qrcode`。`unsafe` コードはゼロです。
-
-> **AI 支援開発** — [Claude Code](https://docs.anthropic.com/en/docs/claude-code) の `rust-tui-development-with-slt` スキルで完全な API リファレンス、ベストプラクティス、コード生成テンプレートを利用できます。または [tui.builders](https://tui.builders) でビジュアルデザインも可能です:
-
-[![tui.builders demo](../assets/tui-builders-demo.gif)](https://tui.builders)
-
-> ウィジェットをドラッグし、インスペクターでプロパティを設定して、慣用的な Rust コードをエクスポート。無料、サインアップ不要、オープンソース。
-
-## ウィジェット
-
-組み込みウィジェットは幅広く、ボイラープレートは不要です:
+## 主要 API
 
 ```rust
-ui.text_input(&mut name);                    // 単行入力
-ui.textarea(&mut notes, 5);                  // 複数行エディタ
-if ui.button("Submit").clicked { /* … */ }    // Response を返す
-ui.checkbox("Dark mode", &mut dark);         // トグルチェックボックス
-ui.toggle("Notifications", &mut on);         // オン/オフスイッチ
-ui.tabs(&mut tabs);                          // タブナビゲーション
-ui.list(&mut items);                         // 選択可能なリスト
-ui.select(&mut sel);                         // ドロップダウン選択
-ui.radio(&mut radio);                        // ラジオボタングループ
-ui.multi_select(&mut multi);                 // 複数選択チェックボックス
-ui.tree(&mut tree);                          // 展開可能なツリービュー
-ui.virtual_list(&mut list, 20, |ui, i| {}); // 仮想化リスト
-ui.table(&mut data);                         // データテーブル
-ui.spinner(&spin);                           // ローディングアニメーション
-ui.progress(0.75);                           // プログレスバー
-ui.scrollable(&mut scroll).col(|ui| { });    // スクロールコンテナ
-ui.toast(&mut toasts);                       // 通知
-ui.separator();                              // 水平線
-ui.help(&[("q", "quit"), ("Tab", "focus")]); // キーヒント
-ui.link("Docs", "https://docs.rs/superlighttui");      // クリック可能なハイパーリンク (OSC 8)
-ui.modal(|ui| { ui.text("overlay"); });      // 背景を暗くするモーダル
-ui.overlay(|ui| { ui.text("floating"); });   // 背景を暗くしないオーバーレイ
-ui.command_palette(&mut palette);            // 検索可能なコマンドパレット
-ui.markdown("# Hello **world**");            // Markdown レンダリング
-ui.form_field(&mut field);                   // バリデーション付きラベル入力
-ui.chart(|c| { c.line(&data); c.grid(true); }, 50, 16); // 折れ線/散布図/棒グラフ
-ui.scatter(&points, 50, 16);                 // 散布図
-ui.histogram(&values, 40, 12);               // 自動ビニングヒストグラム
-ui.bar_chart(&data, 24);                     // 水平棒グラフ
-ui.sparkline(&values, 16);                   // トレンドライン ▁▂▃▅▇
-ui.canvas(40, 10, |cv| { cv.circle(20, 20, 15); }); // ブレイルキャンバス
-ui.grid(3, |ui| { /* 3列グリッド */ });      // グリッドレイアウト
-ui.tooltip("Save the current file");         // ホバー時ツールチップ
-ui.calendar(&mut cal);                       // 月ナビ付き日付ピッカー
-ui.screen("home", &screens, |ui| {});        // 画面ルーティングスタック
-ui.confirm("Delete?", &mut yes);             // マウス対応の確認ダイアログ
-```
-
-すべてのウィジェットが自分でキーボードイベント、フォーカス状態、マウスインタラクションを処理します。
-
-### カスタムウィジェット
-
-`Widget` トレイトを実装して独自ウィジェットを作成できます:
-
-```rust
-use slt::{Context, Widget, Color, Style};
-
-struct Rating { value: u8, max: u8 }
-
-impl Widget for Rating {
-    type Response = bool;
-
-    fn ui(&mut self, ui: &mut Context) -> bool {
-        let focused = ui.register_focusable();
-        let mut changed = false;
-
-        if focused {
-            if ui.key('+') && self.value < self.max { self.value += 1; changed = true; }
-            if ui.key('-') && self.value > 0 { self.value -= 1; changed = true; }
-        }
-
-        let stars: String = (0..self.max)
-            .map(|i| if i < self.value { '★' } else { '☆' })
-            .collect();
-        let color = if focused { Color::Yellow } else { Color::White };
-        ui.styled(stars, Style::new().fg(color));
-        changed
-    }
-}
-
-// 使い方: ui.widget(&mut rating);
-```
-
-フォーカス、イベント、テーマ、レイアウト — すべて `Context` 経由でアクセス可能。トレイト1つ、メソッド1つ。
-
-## 機能
-
-<details>
-<summary><b>レイアウト</b></summary>
-
-| 機能 | API |
-|------|-----|
-| 縦方向スタック | `ui.col(\|ui\| { })` |
-| 横方向スタック | `ui.row(\|ui\| { })` |
-| グリッドレイアウト | `ui.grid(3, \|ui\| { })` |
-| 子要素間のギャップ | `.gap(1)` |
-| Flex grow | `.grow(1)` |
-| 末尾へ押し出し | `ui.spacer()` |
-| 整列 | `.align(Align::Center)` |
-| パディング | `.p(1)`, `.px(2)`, `.py(1)` |
-| マージン | `.m(1)`, `.mx(2)`, `.my(1)` |
-| 固定サイズ | `.w(20)`, `.h(10)` |
-| 制約 | `.min_w(10)`, `.max_w(60)` |
-| パーセント指定 | `.w_pct(50)`, `.h_pct(80)` |
-| 均等配置 | `.space_between()`, `.space_around()`, `.space_evenly()` |
-| テキスト折り返し | `ui.text("long text...").wrap()` |
-| タイトル付きボーダー | `.border(Border::Rounded).title("Panel")` |
-| 辺ごとのボーダー | `.border_top(false)`, `.border_sides(BorderSides::horizontal())` |
-| レスポンシブギャップ | `.gap_at(Breakpoint::Md, 2)` |
-
-</details>
-
-<details>
-<summary><b>スタイリング</b></summary>
-
-```rust
-ui.text("styled").bold().italic().underline().fg(Color::Cyan).bg(Color::Black);
-```
-
-16の名前付きカラー · 256色パレット · 24ビット RGB · 6つの修飾子 · 6つのボーダースタイル
-
-</details>
-
-<details>
-<summary><b>テーマ</b></summary>
-
-```rust
-// 7つの組み込みプリセット
-slt::run_with(RunConfig::default().theme(Theme::catppuccin()), |ui| {
-    ui.set_theme(Theme::dark()); // 実行時に切り替え
+// テキストとレイアウト
+ui.text("Hello").bold().fg(Color::Cyan);
+ui.row(|ui| {
+    ui.text("left");
+    ui.spacer();
+    ui.text("right");
 });
 
-// カスタムテーマの構築
-let theme = Theme::builder()
-    .primary(Color::Rgb(255, 107, 107))
-    .accent(Color::Cyan)
-    .build();
-```
+// 入力とアクション
+ui.text_input(&mut name);
+if ui.button("Save").clicked {}
+ui.checkbox("Dark mode", &mut dark);
 
-7プリセット (dark, light, dracula, catppuccin, nord, solarized_dark, tokyo_night)。15色スロット + `is_dark` フラグでカスタムテーマを作成。すべてのウィジェットが自動的に継承します。
+// データとナビゲーション
+ui.tabs(&mut tabs);
+ui.list(&mut items);
+ui.table(&mut data);
+ui.command_palette(&mut palette);
 
-</details>
+// オーバーレイとリッチ出力
+ui.toast(&mut toasts);
+ui.modal(|ui| {
+    ui.text("Confirm?").bold();
+});
+ui.markdown("# Hello **world**");
 
-<details>
-<summary><b>スタイルレシピ</b></summary>
-
-```rust
-use slt::{ContainerStyle, Border, Color};
-
-const CARD: ContainerStyle = ContainerStyle::new()
-    .border(Border::Rounded).p(1).bg(Color::Indexed(236));
-
-// 一度定義してどこでも適用
-ui.container().apply(&CARD).col(|ui| { ... });
-
-// 複数を合成 — 後から書いたものが優先
-ui.container().apply(&CARD).grow(1).gap(2).col(|ui| { ... });
-```
-
-`const` スタイルはランタイムコストゼロ。`.apply()` チェーンで合成可能。
-
-</details>
-
-<details>
-<summary><b>レスポンシブレイアウト</b></summary>
-
-```rust
-ui.container()
-    .w(20).md_w(40).lg_w(60)  // ブレークポイントで幅が変わる
-    .p(1).lg_p(2)
-    .col(|ui| { ... });
-```
-
-35のブレークポイント条件付きメソッド (`xs_`, `sm_`, `md_`, `lg_`, `xl_`)。ブレークポイント: Xs (<40), Sm (40–79), Md (80–119), Lg (120–159), Xl (≥160)。
-
-</details>
-
-<details>
-<summary><b>アニメーション</b></summary>
-
-```rust
-let mut tween = Tween::new(0.0, 100.0, 60).easing(ease_out_bounce);
-let value = tween.value(ui.tick());
-
-let mut spring = Spring::new(0.0, 180.0, 12.0);
-spring.set_target(100.0);
-
-let mut kf = Keyframes::new(120)
-    .stop(0.0, 0.0).stop(0.5, 100.0).stop(1.0, 50.0)
-    .loop_mode(LoopMode::PingPong);
-```
-
-9つのイージング関数を持つ Tween。スプリング物理演算。ループモード付きキーフレームタイムライン。Sequence チェーン。リストアニメーション用 Stagger。
-
-</details>
-
-<details>
-<summary><b>非同期 (Async)</b></summary>
-
-```rust
-let tx = slt::run_async(|ui, messages: &mut Vec<String>| {
-    for msg in messages.drain(..) { ui.text(msg); }
-})?;
-tx.send("Hello from background!".into()).await?;
-```
-
-オプションの tokio 統合。`cargo add superlighttui --features async` で有効化。
-
-</details>
-
-<details>
-<summary><b>インラインモード</b></summary>
-
-```rust
-slt::run_inline(3, |ui| {
-    ui.text("Renders below your prompt.");
-    ui.text("No alternate screen.").dim();
+// ビジュアライゼーション
+ui.chart(|c| {
+    c.line(&data);
+    c.grid(true);
+}, 50, 16);
+ui.sparkline(&values, 16);
+ui.canvas(40, 10, |cv| {
+    cv.circle(20, 20, 15);
 });
 ```
 
-ターミナルを占有せず、カーソルの下に固定高さの UI をレンダリングします。
+ウィジェットの分類一覧は [ウィジェットガイド] を参照してください。
 
-</details>
+## ライブラリガイド
 
-<details>
-<summary><b>エラーバウンダリ</b></summary>
+| ドキュメント | 内容 |
+|-------------|------|
+| [ドキュメント] | ドキュメント構造とガイドマップ |
+| [クイックスタート] | インストール、初めてのアプリ、カウンター、レイアウト |
+| [ウィジェットガイド] | ウィジェットカタログと主要 API |
+| [パターンガイド] | 状態管理、フォーム、オーバーレイ、非同期、カスタムウィジェット |
+| [サンプル集] | サンプルインデックスと実行コマンド |
+| [アーキテクチャ] | モジュールマップ、フレームライフサイクル |
+| [バックエンドガイド] | `Backend`、`AppState`、`frame()`、インラインモード |
+| [テストガイド] | `TestBackend`、`EventBuilder`、インタラクションテスト |
+| [デバッグガイド] | F12 オーバーレイ、クリッピング、1フレーム遅延 |
+| [AIガイド] | AI コーディングエージェント向けクイックリファレンス |
+| [アニメーションガイド] | Tween、Spring、Keyframes、Sequence、Stagger |
+| [テーマガイド] | テーマプリセット、ThemeBuilder、カスタムテーマ |
+| [機能フラグガイド] | フィーチャーフラグ、オプション依存関係 |
+| [`docs/DESIGN_PRINCIPLES.md`](DESIGN_PRINCIPLES.md) | API がこの形になった理由 |
 
-```rust
-ui.error_boundary(|ui| {
-    ui.text("If this panics, the app keeps running.");
-});
-```
-
-ウィジェットのパニックをキャッチしてアプリをクラッシュさせません。部分的なコマンドはロールバックされ、フォールバックがレンダリングされます。
-
-</details>
-
-<details>
-<summary><b>画像レンダリング</b></summary>
-
-```sh
-cargo add superlighttui --features image
-```
-
-```rust
-use slt::HalfBlockImage;
-
-let photo = image::open("photo.png").unwrap();
-let img = HalfBlockImage::from_dynamic(&photo, 60, 30);
-ui.image(&img);
-```
-
-ハーフブロック (▀▄) 画像レンダリング。Sixel プロトコル (v0.13.2): `ui.sixel_image()` で xterm、foot、mlterm 上のピクセルパーフェクト画像表示。
-
-</details>
-
-<details>
-<summary><b>フィーチャーフラグ</b></summary>
-
-| フラグ | 説明 |
-|--------|------|
-| `async` | tokio チャンネルベースのメッセージパッシングで `run_async()` |
-| `serde` | Style、Color、Theme、レイアウト型の Serialize/Deserialize |
-| `image` | `image` クレートで `HalfBlockImage::from_dynamic()` |
-| `full` | 上記すべて |
-
-```toml
-[dependencies]
-superlighttui = { version = "0.13", features = ["full"] }
-```
-
-</details>
-
-<details>
-<summary><b>スナップショットテスト</b></summary>
-
-```rust
-use slt::TestBackend;
-
-let mut backend = TestBackend::new(40, 10);
-backend.render(|ui| {
-    ui.bordered(Border::Rounded).pad(1).col(|ui| {
-        ui.text("Hello");
-    });
-});
-insta::assert_snapshot!(backend.to_string_trimmed());
-```
-
-[insta](https://crates.io/crates/insta) と組み合わせてスナップショットベースの UI リグレッションテストに使用できます。
-
-</details>
-
-<details>
-<summary><b>デバッグ</b></summary>
-
-SLT アプリで **F12** を押すとレイアウトデバッガーオーバーレイを切り替えられます。コンテナの境界、ネスト深度、レイアウト構造を表示します。
-
-</details>
-
-## サンプル
+## サンプルハイライト
 
 | サンプル | コマンド | 内容 |
 |---------|---------|------|
-| hello | `cargo run --example hello` | 最小構成 |
-| counter | `cargo run --example counter` | 状態 + キーボード |
-| demo | `cargo run --example demo` | 全ウィジェット |
-| demo_dashboard | `cargo run --example demo_dashboard` | ライブダッシュボード |
+| hello | `cargo run --example hello` | 最小構成のアプリ |
+| counter | `cargo run --example counter` | 状態 + キーボード入力 |
+| demo | `cargo run --example demo` | ウィジェット全体ツアー |
+| demo_dashboard | `cargo run --example demo_dashboard` | ダッシュボードレイアウト |
 | demo_cli | `cargo run --example demo_cli` | CLI ツールレイアウト |
-| demo_spreadsheet | `cargo run --example demo_spreadsheet` | データグリッド |
-| demo_website | `cargo run --example demo_website` | ターミナル内 Web サイト |
-| demo_game | `cargo run --example demo_game` | Tetris + Snake + Minesweeper |
-| demo_fire | `cargo run --release --example demo_fire` | DOOM 炎エフェクト (ハーフブロック) |
-| demo_ime | `cargo run --example demo_ime` | 韓国語/CJK IME 入力 |
-| inline | `cargo run --example inline` | インラインモード |
-| anim | `cargo run --example anim` | Tween + Spring + Keyframes |
-| demo_infoviz | `cargo run --example demo_infoviz` | データビジュアライゼーション |
-| demo_trading | `cargo run --example demo_trading` | 取引所スタイルのトレーディング端末 |
-| async_demo | `cargo run --example async_demo --features async` | バックグラウンドタスク |
+| demo_infoviz | `cargo run --example demo_infoviz` | チャートとデータビジュアライゼーション |
+| demo_game | `cargo run --example demo_game` | イミディエイトモードのインタラクション |
+| async_demo | `cargo run --example async_demo --features async` | バックグラウンドメッセージ |
 
-## アーキテクチャ
+すべてのサンプルの分類インデックスは [サンプル集] にあります。
 
-```
-Closure → Context collects Commands → build_tree() → flexbox layout → diff buffer → flush
-```
+## カスタムウィジェットとバックエンド
 
-各フレーム: クロージャが実行され、SLT が記述内容を収集し、Flexbox レイアウトを計算し、前フレームとの差分を取り、変更されたセルだけをフラッシュします。
+- `Widget` トレイトを実装して、フォーカス、レイアウト、イベント、テーマにフルアクセスできる再利用可能なウィジェットを構築できます。
+- `Backend` を実装し `frame()` を駆動すれば、ターミナル以外のレンダラー、テストハーネス、組み込みターゲットに対応できます。
+- `TestBackend` でヘッドレスレンダリングとスナップショット形式のアサーションが可能です。
 
-Pure Rust。マクロなし、コード生成なし、ビルドスクリプトなし。
-
-### カスタムバックエンド
-
-SLT のレンダリングは `Backend` トレイトで抽象化されており、ターミナル以外のカスタムレンダリングターゲットを実装できます:
-
-```rust
-use slt::{Backend, AppState, Buffer, Rect, RunConfig, Context, Event};
-
-struct MyBackend { buffer: Buffer }
-
-impl Backend for MyBackend {
-    fn size(&self) -> (u32, u32) {
-        (self.buffer.area.width, self.buffer.area.height)
-    }
-    fn buffer_mut(&mut self) -> &mut Buffer { &mut self.buffer }
-    fn flush(&mut self) -> std::io::Result<()> {
-        // self.buffer をターゲット (canvas, GPU, network など) にレンダリング
-        Ok(())
-    }
-}
-```
-
-`Backend` トレイトのメソッドは3つ: `size()`、`buffer_mut()`、`flush()`。カスタムバックエンドは完全にレンダリングされた `Buffer` を受け取り、WebGL、egui 埋め込み、SSH トンネル、テストハーネスなど好きな方法で表示できます。
-
-### AI ネイティブウィジェット
-
-SLT には AI/LLM ワークフロー向けの専用ウィジェットが含まれています:
-
-| ウィジェット | 説明 |
-|------------|------|
-| `streaming_text()` | 点滅カーソル付きトークンバイトークンテキスト表示 |
-| `streaming_markdown()` | 見出し、コードブロック、インライン書式付きストリーミング Markdown |
-| `tool_approval()` | ツール呼び出しの人間によるアプローブ/リジェクト |
-| `context_bar()` | アクティブなコンテキストソースを示すトークンカウンターバー |
-| `markdown()` | 静的 Markdown レンダリング |
-| `code_block()` | シンタックスハイライト付きコード表示 |
+詳細は [パターンガイド] と [アーキテクチャ] を参照してください。
 
 ## コントリビューション
 
-ガイドラインは [CONTRIBUTING.md](../CONTRIBUTING.md) を参照してください。
+[コントリビュート] を読んでから、`docs/DESIGN_PRINCIPLES.md` と [アーキテクチャ] を参照してください。
+リリースと CI プロセスでは、フォーマット、チェック、clippy、テスト、サンプルのコンパイルがすべて通ることが求められます。
 
 ## ライセンス
 
@@ -485,6 +198,18 @@ SLT には AI/LLM ワークフロー向けの専用ウィジェットが含ま�
 [CI]: https://github.com/subinium/SuperLightTUI/actions/workflows/ci.yml
 [Crate]: https://crates.io/crates/superlighttui
 [Docs]: https://docs.rs/superlighttui
-[Examples]: https://github.com/subinium/SuperLightTUI/tree/main/examples
-[Contributing]: https://github.com/subinium/SuperLightTUI/blob/main/CONTRIBUTING.md
+[ドキュメント]: README.md
+[クイックスタート]: QUICK_START.md
+[ウィジェットガイド]: WIDGETS.md
+[サンプル集]: EXAMPLES.md
+[パターンガイド]: PATTERNS.md
+[アーキテクチャ]: ARCHITECTURE.md
+[バックエンドガイド]: BACKENDS.md
+[テストガイド]: TESTING.md
+[デバッグガイド]: DEBUGGING.md
+[AIガイド]: AI_GUIDE.md
+[アニメーションガイド]: ANIMATION.md
+[テーマガイド]: THEMING.md
+[機能フラグガイド]: FEATURES.md
+[コントリビュート]: ../CONTRIBUTING.md
 [License]: ../LICENSE

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -11,11 +11,14 @@
 [![Downloads Badge]][Crate]
 [![License Badge]][License]
 
-[Crate] · [Docs] · [Examples] · [Contributing]
+[문서 인덱스] · [빠른 시작] · [위젯 가이드] · [예제 가이드] · [패턴 가이드] · [아키텍처 가이드] · [기여하기]
 
 [English](../README.md) · [中文](README.zh-CN.md) · [Español](README.es.md) · [日本語](README.ja.md) · **한국어**
 
 </div>
+
+SuperLightTUI는 Rust를 위한 즉시 모드(immediate-mode) TUI 라이브러리입니다.
+클로저 하나를 작성하면, SLT가 매 프레임 호출하고, 라이브러리가 레이아웃, 디핑, 포커스, 렌더링을 처리합니다.
 
 ## 쇼케이스
 
@@ -57,16 +60,22 @@ fn main() -> std::io::Result<()> {
     let mut count: i32 = 0;
 
     slt::run(|ui: &mut Context| {
-        if ui.key('q') { ui.quit(); }
-        if ui.key('k') || ui.key_code(KeyCode::Up) { count += 1; }
-        if ui.key('j') || ui.key_code(KeyCode::Down) { count -= 1; }
+        if ui.key('q') {
+            ui.quit();
+        }
+        if ui.key('k') || ui.key_code(KeyCode::Up) {
+            count += 1;
+        }
+        if ui.key('j') || ui.key_code(KeyCode::Down) {
+            count -= 1;
+        }
 
         ui.bordered(Border::Rounded).title("Counter").pad(1).gap(1).col(|ui| {
             ui.text("Counter").bold().fg(Color::Cyan);
             ui.row(|ui| {
                 ui.text("Count:");
-                let c = if count >= 0 { Color::Green } else { Color::Red };
-                ui.text(format!("{count}")).bold().fg(c);
+                let color = if count >= 0 { Color::Green } else { Color::Red };
+                ui.text(format!("{count}")).bold().fg(color);
             });
             ui.text("k +1 / j -1 / q quit").dim();
         });
@@ -78,396 +87,100 @@ fn main() -> std::io::Result<()> {
 
 ## SLT를 선택하는 이유
 
-**클로저가 곧 앱입니다** — 프레임워크 상태 없음. 메시지 패싱 없음. 트레이트 구현 없음. 함수를 작성하면 SLT가 매 프레임 호출합니다.
+- **클로저가 곧 앱입니다** — 프레임워크 상태 없음, 트레이트 구현 보일러플레이트 없음, 메시지 루프 API 없음.
+- **CSS 같은 레이아웃, Tailwind 같은 문법** — `row()`, `col()`, `gap()`, `grow()`, `spacer()`, 그리고 `.p()`, `.px()`, `.m()`, `.w()`, `.max_w()` 같은 단축 표기.
+- **위젯이 지루한 작업을 자동 처리** — 포커스 순서, 호버, 클릭 핸들링, 스크롤, 공통 키보드 동작이 내장되어 있습니다.
+- **작은 코어, 선택적 확장** — 핵심 의존성은 `unicode-width`와 `compact_str`; 터미널 I/O는 선택적 `crossterm`; async, serde, image, qrcode, 신택스 하이라이팅은 피처 플래그 뒤에 있습니다.
+- **라이브러리 위생이 중요합니다** — `unsafe` 없음, 명시적 피처 플래그, 문서, 예제, 테스트, 시맨틱 버저닝 릴리스 규율.
 
-**모든 것이 자동으로 연결됩니다** — Tab으로 포커스 순환. 마우스 휠로 스크롤. 컨테이너는 클릭과 호버를 보고합니다. 위젯은 자체적으로 이벤트를 소비합니다.
-
-**CSS 같은 레이아웃, Tailwind 같은 문법** — `row()`, `col()`, `grow()`, `gap()`, `spacer()`로 Flexbox. Tailwind 스타일 단축 표기: `.p()`, `.px()`, `.py()`, `.m()`, `.mx()`, `.my()`, `.w()`, `.h()`, `.min_w()`, `.max_w()`.
-
-```rust
-ui.container()
-    .border(Border::Rounded)
-    .p(2).mx(1).grow(1).max_w(60)
-    .col(|ui| {
-        ui.row(|ui| {
-            ui.text("left");
-            ui.spacer();
-            ui.text("right");
-        });
-    });
-```
-
-**작은 코어, 선택적 확장** — 핵심은 `unicode-width`와 `compact_str`. 터미널 I/O는 기본 활성화되는 `crossterm` 기능으로 제공됩니다. 선택적: 비동기에 `tokio`, 직렬화에 `serde`, 이미지 로딩에 `image`, QR 코드에 `qrcode`. `unsafe` 코드 없음.
-
-> **AI 지원 개발** — [Claude Code](https://docs.anthropic.com/en/docs/claude-code)의 `rust-tui-development-with-slt` 스킬로 전체 API 레퍼런스, 베스트 패턴, 코드 생성 템플릿을 활용하세요. 또는 [tui.builders](https://tui.builders)에서 시각적으로 디자인할 수도 있습니다:
-
-[![tui.builders demo](../assets/tui-builders-demo.gif)](https://tui.builders)
-
-> 위젯을 드래그하고, 인스펙터에서 속성을 설정하고, 관용적인 Rust 코드를 내보냅니다. 무료, 회원가입 불필요, 오픈소스.
-
-## 위젯
-
-다양한 내장 위젯, 보일러플레이트 없음:
+## 주요 API
 
 ```rust
-ui.text_input(&mut name);                    // 단일 행 입력
-ui.textarea(&mut notes, 5);                  // 다중 행 에디터
-if ui.button("Submit").clicked { /* … */ }    // Response 반환
-ui.checkbox("Dark mode", &mut dark);         // 토글 체크박스
-ui.toggle("Notifications", &mut on);         // 온/오프 스위치
-ui.tabs(&mut tabs);                          // 탭 네비게이션
-ui.list(&mut items);                         // 선택 가능한 리스트
-ui.select(&mut sel);                         // 드롭다운 선택
-ui.radio(&mut radio);                        // 라디오 버튼 그룹
-ui.multi_select(&mut multi);                 // 다중 선택 체크박스
-ui.tree(&mut tree);                          // 확장 가능한 트리 뷰
-ui.virtual_list(&mut list, 20, |ui, i| {}); // 가상화 리스트
-ui.table(&mut data);                         // 데이터 테이블
-ui.spinner(&spin);                           // 로딩 애니메이션
-ui.progress(0.75);                           // 프로그레스 바
-ui.scrollable(&mut scroll).col(|ui| { });    // 스크롤 컨테이너
-ui.toast(&mut toasts);                       // 알림
-ui.separator();                              // 수평선
-ui.help(&[("q", "quit"), ("Tab", "focus")]); // 키 힌트
-ui.link("Docs", "https://docs.rs/superlighttui");      // 클릭 가능한 하이퍼링크 (OSC 8)
-ui.modal(|ui| { ui.text("overlay"); });      // 배경 어둡게 하는 모달
-ui.overlay(|ui| { ui.text("floating"); });   // 배경 유지 오버레이
-ui.command_palette(&mut palette);            // 검색 가능한 커맨드 팔레트
-ui.markdown("# Hello **world**");            // Markdown 렌더링
-ui.form_field(&mut field);                   // 유효성 검사 포함 레이블 입력
-ui.chart(|c| { c.line(&data); c.grid(true); }, 50, 16); // 선/산점도/막대 차트
-ui.scatter(&points, 50, 16);                 // 산점도
-ui.histogram(&values, 40, 12);               // 자동 빈 히스토그램
-ui.bar_chart(&data, 24);                     // 수평 막대 차트
-ui.sparkline(&values, 16);                   // 트렌드 라인 ▁▂▃▅▇
-ui.canvas(40, 10, |cv| { cv.circle(20, 20, 15); }); // 브레일 캔버스
-ui.grid(3, |ui| { /* 3열 그리드 */ });       // 그리드 레이아웃
-ui.tooltip("Save the current file");         // 호버 시 툴팁 팝업
-ui.calendar(&mut cal);                       // 월 네비게이션 날짜 선택기
-ui.screen("home", &screens, |ui| {});        // 화면 라우팅 스택
-ui.confirm("Delete?", &mut yes);             // 마우스 지원 확인 다이얼로그
-```
-
-모든 위젯이 자체적으로 키보드 이벤트, 포커스 상태, 마우스 인터랙션을 처리합니다.
-
-### 커스텀 위젯
-
-`Widget` 트레이트를 구현해 직접 위젯을 만들 수 있습니다:
-
-```rust
-use slt::{Context, Widget, Color, Style};
-
-struct Rating { value: u8, max: u8 }
-
-impl Widget for Rating {
-    type Response = bool;
-
-    fn ui(&mut self, ui: &mut Context) -> bool {
-        let focused = ui.register_focusable();
-        let mut changed = false;
-
-        if focused {
-            if ui.key('+') && self.value < self.max { self.value += 1; changed = true; }
-            if ui.key('-') && self.value > 0 { self.value -= 1; changed = true; }
-        }
-
-        let stars: String = (0..self.max)
-            .map(|i| if i < self.value { '★' } else { '☆' })
-            .collect();
-        let color = if focused { Color::Yellow } else { Color::White };
-        ui.styled(stars, Style::new().fg(color));
-        changed
-    }
-}
-
-// 사용법: ui.widget(&mut rating);
-```
-
-포커스, 이벤트, 테마, 레이아웃 — 모두 `Context`를 통해 접근 가능합니다. 트레이트 하나, 메서드 하나.
-
-## 기능
-
-<details>
-<summary><b>레이아웃</b></summary>
-
-| 기능 | API |
-|------|-----|
-| 세로 스택 | `ui.col(\|ui\| { })` |
-| 가로 스택 | `ui.row(\|ui\| { })` |
-| 그리드 레이아웃 | `ui.grid(3, \|ui\| { })` |
-| 자식 요소 간 간격 | `.gap(1)` |
-| Flex grow | `.grow(1)` |
-| 끝으로 밀기 | `ui.spacer()` |
-| 정렬 | `.align(Align::Center)` |
-| 패딩 | `.p(1)`, `.px(2)`, `.py(1)` |
-| 마진 | `.m(1)`, `.mx(2)`, `.my(1)` |
-| 고정 크기 | `.w(20)`, `.h(10)` |
-| 제약 조건 | `.min_w(10)`, `.max_w(60)` |
-| 퍼센트 크기 | `.w_pct(50)`, `.h_pct(80)` |
-| 균등 배치 | `.space_between()`, `.space_around()`, `.space_evenly()` |
-| 텍스트 줄 바꿈 | `ui.text("long text...").wrap()` |
-| 타이틀 포함 보더 | `.border(Border::Rounded).title("Panel")` |
-| 면별 보더 | `.border_top(false)`, `.border_sides(BorderSides::horizontal())` |
-| 반응형 간격 | `.gap_at(Breakpoint::Md, 2)` |
-
-</details>
-
-<details>
-<summary><b>스타일링</b></summary>
-
-```rust
-ui.text("styled").bold().italic().underline().fg(Color::Cyan).bg(Color::Black);
-```
-
-16개 명명 색상 · 256색 팔레트 · 24비트 RGB · 6개 수정자 · 6개 보더 스타일
-
-</details>
-
-<details>
-<summary><b>테마</b></summary>
-
-```rust
-// 7개 내장 프리셋
-slt::run_with(RunConfig::default().theme(Theme::catppuccin()), |ui| {
-    ui.set_theme(Theme::dark()); // 런타임에 전환
+// 텍스트와 레이아웃
+ui.text("Hello").bold().fg(Color::Cyan);
+ui.row(|ui| {
+    ui.text("left");
+    ui.spacer();
+    ui.text("right");
 });
 
-// 커스텀 테마 빌드
-let theme = Theme::builder()
-    .primary(Color::Rgb(255, 107, 107))
-    .accent(Color::Cyan)
-    .build();
-```
+// 입력과 액션
+ui.text_input(&mut name);
+if ui.button("Save").clicked {}
+ui.checkbox("Dark mode", &mut dark);
 
-7개 프리셋 (dark, light, dracula, catppuccin, nord, solarized_dark, tokyo_night). 15개 색상 슬롯 + `is_dark` 플래그로 커스텀 테마 생성. 모든 위젯이 자동으로 상속합니다.
+// 데이터와 네비게이션
+ui.tabs(&mut tabs);
+ui.list(&mut items);
+ui.table(&mut data);
+ui.command_palette(&mut palette);
 
-</details>
+// 오버레이와 리치 출력
+ui.toast(&mut toasts);
+ui.modal(|ui| {
+    ui.text("Confirm?").bold();
+});
+ui.markdown("# Hello **world**");
 
-<details>
-<summary><b>스타일 레시피</b></summary>
-
-```rust
-use slt::{ContainerStyle, Border, Color};
-
-const CARD: ContainerStyle = ContainerStyle::new()
-    .border(Border::Rounded).p(1).bg(Color::Indexed(236));
-
-// 한 번 정의하고 어디서든 적용
-ui.container().apply(&CARD).col(|ui| { ... });
-
-// 여러 개 합성 — 나중에 쓴 것이 우선
-ui.container().apply(&CARD).grow(1).gap(2).col(|ui| { ... });
-```
-
-`const` 스타일은 런타임 비용 없음. `.apply()` 체이닝으로 합성 가능.
-
-</details>
-
-<details>
-<summary><b>반응형 레이아웃</b></summary>
-
-```rust
-ui.container()
-    .w(20).md_w(40).lg_w(60)  // 브레이크포인트에서 너비 변경
-    .p(1).lg_p(2)
-    .col(|ui| { ... });
-```
-
-35개 브레이크포인트 조건부 메서드 (`xs_`, `sm_`, `md_`, `lg_`, `xl_`). 브레이크포인트: Xs (<40), Sm (40–79), Md (80–119), Lg (120–159), Xl (≥160).
-
-</details>
-
-<details>
-<summary><b>애니메이션</b></summary>
-
-```rust
-let mut tween = Tween::new(0.0, 100.0, 60).easing(ease_out_bounce);
-let value = tween.value(ui.tick());
-
-let mut spring = Spring::new(0.0, 180.0, 12.0);
-spring.set_target(100.0);
-
-let mut kf = Keyframes::new(120)
-    .stop(0.0, 0.0).stop(0.5, 100.0).stop(1.0, 50.0)
-    .loop_mode(LoopMode::PingPong);
-```
-
-9개 이징 함수를 가진 Tween. 스프링 물리 연산. 루프 모드 포함 키프레임 타임라인. Sequence 체이닝. 리스트 애니메이션용 Stagger.
-
-</details>
-
-<details>
-<summary><b>비동기 (Async)</b></summary>
-
-```rust
-let tx = slt::run_async(|ui, messages: &mut Vec<String>| {
-    for msg in messages.drain(..) { ui.text(msg); }
-})?;
-tx.send("Hello from background!".into()).await?;
-```
-
-선택적 tokio 통합. `cargo add superlighttui --features async`로 활성화.
-
-</details>
-
-<details>
-<summary><b>인라인 모드</b></summary>
-
-```rust
-slt::run_inline(3, |ui| {
-    ui.text("Renders below your prompt.");
-    ui.text("No alternate screen.").dim();
+// 시각화
+ui.chart(|c| {
+    c.line(&data);
+    c.grid(true);
+}, 50, 16);
+ui.sparkline(&values, 16);
+ui.canvas(40, 10, |cv| {
+    cv.circle(20, 20, 15);
 });
 ```
 
-터미널을 점유하지 않고 커서 아래에 고정 높이 UI를 렌더링합니다.
+전체 위젯 카탈로그는 [위젯 가이드]를 참고하세요.
 
-</details>
+## 라이브러리 학습하기
 
-<details>
-<summary><b>에러 바운더리</b></summary>
+| 문서 | 내용 |
+|------|------|
+| [문서 인덱스] | 전체 문서 구조와 가이드 맵 |
+| [빠른 시작] | 설치, 첫 앱, 카운터, 레이아웃, 입력 |
+| [위젯 가이드] | 위젯 카탈로그와 주요 API |
+| [패턴 가이드] | 상태 관리, 폼, 오버레이, 비동기, 커스텀 위젯 |
+| [예제 가이드] | 예제 인덱스와 실행 명령어 |
+| [아키텍처 가이드] | 모듈 맵, 프레임 라이프사이클, 의존성 흐름 |
+| [백엔드 가이드] | `Backend`, `AppState`, `frame()`, 인라인 모드 |
+| [테스트 가이드] | `TestBackend`, `EventBuilder`, 상호작용 테스트 |
+| [디버깅 가이드] | F12 오버레이, 클리핑, 원프레임 딜레이 |
+| [AI 가이드] | AI 코딩 에이전트를 위한 빠른 참조 |
+| [애니메이션 가이드] | Tween, Spring, Keyframes, Sequence, Stagger |
+| [테마 가이드] | 테마 프리셋, ThemeBuilder, 커스텀 테마 |
+| [기능 가이드] | 피처 플래그, 선택적 의존성 |
+| [`docs/DESIGN_PRINCIPLES.md`](DESIGN_PRINCIPLES.md) | API가 이렇게 설계된 이유 |
 
-```rust
-ui.error_boundary(|ui| {
-    ui.text("If this panics, the app keeps running.");
-});
-```
-
-위젯 패닉을 잡아 앱이 크래시되지 않도록 합니다. 부분적인 커맨드는 롤백되고 폴백이 렌더링됩니다.
-
-</details>
-
-<details>
-<summary><b>이미지 렌더링</b></summary>
-
-```sh
-cargo add superlighttui --features image
-```
-
-```rust
-use slt::HalfBlockImage;
-
-let photo = image::open("photo.png").unwrap();
-let img = HalfBlockImage::from_dynamic(&photo, 60, 30);
-ui.image(&img);
-```
-
-하프블록 (▀▄) 이미지 렌더링. Sixel 프로토콜 (v0.13.2): `ui.sixel_image()`로 xterm, foot, mlterm에서 픽셀 퍼펙트 이미지 표시.
-
-</details>
-
-<details>
-<summary><b>피처 플래그</b></summary>
-
-| 플래그 | 설명 |
-|--------|------|
-| `async` | tokio 채널 기반 메시지 패싱으로 `run_async()` |
-| `serde` | Style, Color, Theme, 레이아웃 타입의 Serialize/Deserialize |
-| `image` | `image` 크레이트로 `HalfBlockImage::from_dynamic()` |
-| `full` | 위 모두 포함 |
-
-```toml
-[dependencies]
-superlighttui = { version = "0.13", features = ["full"] }
-```
-
-</details>
-
-<details>
-<summary><b>스냅샷 테스트</b></summary>
-
-```rust
-use slt::TestBackend;
-
-let mut backend = TestBackend::new(40, 10);
-backend.render(|ui| {
-    ui.bordered(Border::Rounded).pad(1).col(|ui| {
-        ui.text("Hello");
-    });
-});
-insta::assert_snapshot!(backend.to_string_trimmed());
-```
-
-[insta](https://crates.io/crates/insta)와 함께 스냅샷 기반 UI 회귀 테스트에 사용할 수 있습니다.
-
-</details>
-
-<details>
-<summary><b>디버그</b></summary>
-
-SLT 앱에서 **F12**를 누르면 레이아웃 디버거 오버레이를 토글할 수 있습니다. 컨테이너 경계, 중첩 깊이, 레이아웃 구조를 표시합니다.
-
-</details>
-
-## 예제
+## 예제 하이라이트
 
 | 예제 | 커맨드 | 내용 |
 |------|--------|------|
-| hello | `cargo run --example hello` | 최소 구성 |
-| counter | `cargo run --example counter` | 상태 + 키보드 |
-| demo | `cargo run --example demo` | 전체 위젯 |
-| demo_dashboard | `cargo run --example demo_dashboard` | 라이브 대시보드 |
-| demo_cli | `cargo run --example demo_cli` | CLI 툴 레이아웃 |
-| demo_spreadsheet | `cargo run --example demo_spreadsheet` | 데이터 그리드 |
-| demo_website | `cargo run --example demo_website` | 터미널 내 웹사이트 |
-| demo_game | `cargo run --example demo_game` | Tetris + Snake + Minesweeper |
-| demo_fire | `cargo run --release --example demo_fire` | DOOM 불꽃 효과 (하프블록) |
-| demo_ime | `cargo run --example demo_ime` | 한국어/CJK IME 입력 |
-| inline | `cargo run --example inline` | 인라인 모드 |
-| anim | `cargo run --example anim` | Tween + Spring + Keyframes |
-| demo_infoviz | `cargo run --example demo_infoviz` | 데이터 시각화 |
-| demo_trading | `cargo run --example demo_trading` | 거래소 스타일 트레이딩 터미널 |
-| async_demo | `cargo run --example async_demo --features async` | 백그라운드 태스크 |
+| hello | `cargo run --example hello` | 최소 구성 앱 |
+| counter | `cargo run --example counter` | 상태 + 키보드 입력 |
+| demo | `cargo run --example demo` | 전체 위젯 투어 |
+| demo_dashboard | `cargo run --example demo_dashboard` | 대시보드 레이아웃 |
+| demo_cli | `cargo run --example demo_cli` | CLI 도구 레이아웃 |
+| demo_infoviz | `cargo run --example demo_infoviz` | 차트와 데이터 시각화 |
+| demo_game | `cargo run --example demo_game` | 즉시 모드 인터랙션 |
+| async_demo | `cargo run --example async_demo --features async` | 백그라운드 메시지 |
 
-## 아키텍처
+전체 분류 인덱스는 [예제 가이드]를 참고하세요.
 
-```
-Closure → Context collects Commands → build_tree() → flexbox layout → diff buffer → flush
-```
+## 커스텀 위젯과 백엔드
 
-매 프레임: 클로저가 실행되고, SLT가 기술한 내용을 수집하고, Flexbox 레이아웃을 계산하고, 이전 프레임과 비교해 변경된 셀만 플러시합니다.
+- `Widget` 트레이트를 구현하면 포커스, 레이아웃, 이벤트, 테마에 완전히 접근할 수 있는 재사용 가능한 위젯을 만들 수 있습니다.
+- `Backend` 트레이트를 구현하고 `frame()`을 구동하면 비터미널 렌더러, 테스트 하네스, 임베디드 타겟을 만들 수 있습니다.
+- `TestBackend`로 헤드리스 렌더링과 스냅샷 스타일 검증을 할 수 있습니다.
 
-Pure Rust. 매크로 없음, 코드 생성 없음, 빌드 스크립트 없음.
-
-### 커스텀 백엔드
-
-SLT의 렌더링은 `Backend` 트레이트로 추상화되어 있어 터미널 외의 커스텀 렌더링 타겟을 구현할 수 있습니다:
-
-```rust
-use slt::{Backend, AppState, Buffer, Rect, RunConfig, Context, Event};
-
-struct MyBackend { buffer: Buffer }
-
-impl Backend for MyBackend {
-    fn size(&self) -> (u32, u32) {
-        (self.buffer.area.width, self.buffer.area.height)
-    }
-    fn buffer_mut(&mut self) -> &mut Buffer { &mut self.buffer }
-    fn flush(&mut self) -> std::io::Result<()> {
-        // self.buffer를 타겟 (canvas, GPU, network 등)에 렌더링
-        Ok(())
-    }
-}
-```
-
-`Backend` 트레이트의 메서드는 3개: `size()`, `buffer_mut()`, `flush()`. 커스텀 백엔드는 완전히 렌더링된 `Buffer`를 받아 WebGL, egui 임베드, SSH 터널, 테스트 하네스 등 원하는 방식으로 표시할 수 있습니다.
-
-### AI 네이티브 위젯
-
-SLT에는 AI/LLM 워크플로우를 위한 전용 위젯이 포함되어 있습니다:
-
-| 위젯 | 설명 |
-|------|------|
-| `streaming_text()` | 깜빡이는 커서와 함께 토큰 단위 텍스트 표시 |
-| `streaming_markdown()` | 제목, 코드 블록, 인라인 서식 포함 스트리밍 Markdown |
-| `tool_approval()` | 툴 호출에 대한 사람의 승인/거부 |
-| `context_bar()` | 활성 컨텍스트 소스를 보여주는 토큰 카운터 바 |
-| `markdown()` | 정적 Markdown 렌더링 |
-| `code_block()` | 신택스 하이라이팅 코드 표시 |
+자세한 내용은 [패턴 가이드]와 [아키텍처 가이드]를 참고하세요.
 
 ## 기여
 
-가이드라인은 [CONTRIBUTING.md](../CONTRIBUTING.md)를 참고하세요.
+[기여하기] 가이드를 읽은 다음 `docs/DESIGN_PRINCIPLES.md`와 [아키텍처 가이드]를 참고하세요.
+릴리스와 CI 프로세스는 포맷팅, 체크, clippy, 테스트, 예제 컴파일이 모두 통과해야 합니다.
 
 ## 라이선스
 
@@ -485,6 +198,18 @@ SLT에는 AI/LLM 워크플로우를 위한 전용 위젯이 포함되어 있습�
 [CI]: https://github.com/subinium/SuperLightTUI/actions/workflows/ci.yml
 [Crate]: https://crates.io/crates/superlighttui
 [Docs]: https://docs.rs/superlighttui
-[Examples]: https://github.com/subinium/SuperLightTUI/tree/main/examples
-[Contributing]: https://github.com/subinium/SuperLightTUI/blob/main/CONTRIBUTING.md
 [License]: ../LICENSE
+[문서 인덱스]: README.md
+[빠른 시작]: QUICK_START.md
+[위젯 가이드]: WIDGETS.md
+[예제 가이드]: EXAMPLES.md
+[패턴 가이드]: PATTERNS.md
+[아키텍처 가이드]: ARCHITECTURE.md
+[백엔드 가이드]: BACKENDS.md
+[테스트 가이드]: TESTING.md
+[디버깅 가이드]: DEBUGGING.md
+[AI 가이드]: AI_GUIDE.md
+[애니메이션 가이드]: ANIMATION.md
+[테마 가이드]: THEMING.md
+[기능 가이드]: FEATURES.md
+[기여하기]: ../CONTRIBUTING.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,17 @@ Use this directory by depth, not by file name guessing.
 - [PATTERNS.md](PATTERNS.md) - common composition patterns
 - [EXAMPLES.md](EXAMPLES.md) - runnable example index
 
+## By task
+
+- [AI_GUIDE.md](AI_GUIDE.md) - fastest path for AI-assisted builders and coding agents
+- [ANIMATION.md](ANIMATION.md) - tween, spring, keyframes, sequence, stagger
+- [BACKENDS.md](BACKENDS.md) - custom backends, inline mode, static output, `frame()`
+- [DEBUGGING.md](DEBUGGING.md) - F12 overlay, clipping, focus, previous-frame behavior
+- [FEATURES.md](FEATURES.md) - feature flags and runtime capability matrix
+- [TESTING.md](TESTING.md) - `TestBackend`, `EventBuilder`, input simulation, snapshots
+- [THEMING.md](THEMING.md) - theme struct, presets, ThemeBuilder, custom themes
+- [CHANGELOG.md](../CHANGELOG.md) - release history and migration notes
+
 ## Contributor docs
 
 - [DESIGN_PRINCIPLES.md](DESIGN_PRINCIPLES.md) - API rules and design constraints
@@ -23,3 +34,4 @@ Use this directory by depth, not by file name guessing.
 
 The root `README.md` is the landing page.
 This directory holds the deeper guides.
+Use `docs.rs` for API signatures; use the files here for architecture, patterns, examples, and contributor-facing contracts.

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -11,11 +11,14 @@
 [![Downloads Badge]][Crate]
 [![License Badge]][License]
 
-[Crate] · [Docs] · [Examples] · [Contributing]
+[文档索引] · [快速开始] · [组件指南] · [示例指南] · [模式指南] · [架构指南] · [贡献指南]
 
 [English](../README.md) · **中文** · [Español](README.es.md) · [日本語](README.ja.md) · [한국어](README.ko.md)
 
 </div>
+
+SuperLightTUI 是一个 Rust 的即时模式 TUI 库。
+你只需要写一个闭包，SLT 每帧调用它，库负责布局、差分、焦点和渲染。
 
 ## 效果展示
 
@@ -57,16 +60,22 @@ fn main() -> std::io::Result<()> {
     let mut count: i32 = 0;
 
     slt::run(|ui: &mut Context| {
-        if ui.key('q') { ui.quit(); }
-        if ui.key('k') || ui.key_code(KeyCode::Up) { count += 1; }
-        if ui.key('j') || ui.key_code(KeyCode::Down) { count -= 1; }
+        if ui.key('q') {
+            ui.quit();
+        }
+        if ui.key('k') || ui.key_code(KeyCode::Up) {
+            count += 1;
+        }
+        if ui.key('j') || ui.key_code(KeyCode::Down) {
+            count -= 1;
+        }
 
         ui.bordered(Border::Rounded).title("Counter").pad(1).gap(1).col(|ui| {
             ui.text("Counter").bold().fg(Color::Cyan);
             ui.row(|ui| {
                 ui.text("Count:");
-                let c = if count >= 0 { Color::Green } else { Color::Red };
-                ui.text(format!("{count}")).bold().fg(c);
+                let color = if count >= 0 { Color::Green } else { Color::Red };
+                ui.text(format!("{count}")).bold().fg(color);
             });
             ui.text("k +1 / j -1 / q quit").dim();
         });
@@ -78,420 +87,100 @@ fn main() -> std::io::Result<()> {
 
 ## 为什么选择 SLT
 
-**闭包即应用** — 没有框架状态，没有消息传递，没有 trait 实现。你写一个函数，SLT 每帧调用它。
+- **闭包即应用** — 没有框架状态，没有 trait 实现样板代码，没有消息循环 API。
+- **CSS 布局，Tailwind 语法** — `row()`、`col()`、`gap()`、`grow()`、`spacer()`，以及 `.p()`、`.px()`、`.m()`、`.w()`、`.max_w()` 等简写。
+- **组件自动处理繁琐部分** — 焦点顺序、悬停、点击处理、滚动和常见键盘行为全部内置。
+- **小核心，可选扩展** — 核心依赖是 `unicode-width` 和 `compact_str`；终端 I/O 由可选的 `crossterm` 提供；async、serde、image、qrcode 和语法高亮均在 feature flag 后面。
+- **库的工程素养** — 零 `unsafe`，显式 feature flag，文档、示例、测试齐全，遵循语义化版本发布纪律。
 
-**一切自动连接** — Tab 键循环焦点，鼠标滚轮滚动，容器自动上报点击和悬停事件，每个 widget 自己消费事件。
-
-**CSS 布局，Tailwind 语法** — 用 `row()`、`col()`、`grow()`、`gap()`、`spacer()` 实现 Flexbox。Tailwind 风格简写：`.p()`、`.px()`、`.py()`、`.m()`、`.mx()`、`.my()`、`.w()`、`.h()`、`.min_w()`、`.max_w()`。
-
-```rust
-ui.container()
-    .border(Border::Rounded)
-    .p(2).mx(1).grow(1).max_w(60)
-    .col(|ui| {
-        ui.row(|ui| {
-            ui.text("left");
-            ui.spacer();
-            ui.text("right");
-        });
-    });
-```
-
-**小而稳的核心，按需扩展** — 核心依赖是 `unicode-width` 和 `compact_str`。终端 I/O 由默认启用的 `crossterm` feature 提供。可选：`tokio`（异步）、`serde`（序列化）、`image`（图片加载）、`qrcode`。零 `unsafe` 代码。
-
-> **AI 辅助开发** — 在 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 中使用 `rust-tui-development-with-slt` skill，获取完整 API 参考、最佳实践和代码生成模板。或者用 [tui.builders](https://tui.builders) 可视化设计：
-
-[![tui.builders demo](../assets/tui-builders-demo.gif)](https://tui.builders)
-
-> 拖拽 widget，在检查器中设置属性，导出地道的 Rust 代码。免费，无需注册，开源。
-
-## Widgets
-
-内置 widget 覆盖面很广，零样板代码：
+## 常用 API 概览
 
 ```rust
-ui.text_input(&mut name);                    // 单行输入
-ui.textarea(&mut notes, 5);                  // 多行编辑器
-if ui.button("Submit").clicked { /* … */ }    // 返回 Response
-ui.checkbox("Dark mode", &mut dark);         // 复选框
-ui.toggle("Notifications", &mut on);         // 开关
-ui.tabs(&mut tabs);                          // 标签页导航
-ui.list(&mut items);                         // 可选列表
-ui.select(&mut sel);                         // 下拉选择
-ui.radio(&mut radio);                        // 单选按钮组
-ui.multi_select(&mut multi);                 // 多选复选框
-ui.tree(&mut tree);                          // 可展开树形视图
-ui.virtual_list(&mut list, 20, |ui, i| {}); // 虚拟化列表
-ui.table(&mut data);                         // 数据表格
-ui.spinner(&spin);                           // 加载动画
-ui.progress(0.75);                           // 进度条
-ui.scrollable(&mut scroll).col(|ui| { });    // 滚动容器
-ui.toast(&mut toasts);                       // 通知提示
-ui.separator();                              // 水平分隔线
-ui.help(&[("q", "quit"), ("Tab", "focus")]); // 快捷键提示
-ui.link("Docs", "https://docs.rs/superlighttui");      // 可点击超链接 (OSC 8)
-ui.modal(|ui| { ui.text("overlay"); });      // 带遮罩的模态框
-ui.overlay(|ui| { ui.text("floating"); });   // 无遮罩浮层
-ui.command_palette(&mut palette);            // 可搜索命令面板
-ui.markdown("# Hello **world**");            // Markdown 渲染
-ui.form_field(&mut field);                   // 带验证的标签输入
-ui.chart(|c| { c.line(&data); c.grid(true); }, 50, 16); // 折线/散点/柱状图
-ui.scatter(&points, 50, 16);                 // 独立散点图
-ui.histogram(&values, 40, 12);               // 自动分箱直方图
-ui.bar_chart(&data, 24);                     // 水平条形图
-ui.sparkline(&values, 16);                   // 趋势迷你图 ▁▂▃▅▇
-ui.canvas(40, 10, |cv| { cv.circle(20, 20, 15); }); // 盲文点阵画布
-ui.grid(3, |ui| { /* 3列网格 */ });          // 网格布局
-ui.tooltip("Save the current file");         // 悬停提示弹窗
-ui.calendar(&mut cal);                       // 带月份导航的日期选择器
-ui.screen("home", &screens, |ui| {});        // 屏幕路由栈
-ui.confirm("Delete?", &mut yes);             // 支持鼠标的确认对话框
-```
-
-每个 widget 自行处理键盘事件、焦点状态和鼠标交互。
-
-### 自定义 Widget
-
-实现 `Widget` trait 来构建你自己的 widget：
-
-```rust
-use slt::{Context, Widget, Color, Style};
-
-struct Rating { value: u8, max: u8 }
-
-impl Widget for Rating {
-    type Response = bool;
-
-    fn ui(&mut self, ui: &mut Context) -> bool {
-        let focused = ui.register_focusable();
-        let mut changed = false;
-
-        if focused {
-            if ui.key('+') && self.value < self.max { self.value += 1; changed = true; }
-            if ui.key('-') && self.value > 0 { self.value -= 1; changed = true; }
-        }
-
-        let stars: String = (0..self.max)
-            .map(|i| if i < self.value { '★' } else { '☆' })
-            .collect();
-        let color = if focused { Color::Yellow } else { Color::White };
-        ui.styled(stars, Style::new().fg(color));
-        changed
-    }
-}
-
-// 用法：ui.widget(&mut rating);
-```
-
-焦点、事件、主题、布局，全部通过 `Context` 访问。一个 trait，一个方法。
-
-## 功能特性
-
-<details>
-<summary><b>布局</b></summary>
-
-| 功能 | API |
-|------|-----|
-| 垂直堆叠 | `ui.col(\|ui\| { })` |
-| 水平堆叠 | `ui.row(\|ui\| { })` |
-| 网格布局 | `ui.grid(3, \|ui\| { })` |
-| 子元素间距 | `.gap(1)` |
-| 弹性增长 | `.grow(1)` |
-| 推到末尾 | `ui.spacer()` |
-| 对齐方式 | `.align(Align::Center)` |
-| 内边距 | `.p(1)`, `.px(2)`, `.py(1)` |
-| 外边距 | `.m(1)`, `.mx(2)`, `.my(1)` |
-| 固定尺寸 | `.w(20)`, `.h(10)` |
-| 约束 | `.min_w(10)`, `.max_w(60)` |
-| 百分比尺寸 | `.w_pct(50)`, `.h_pct(80)` |
-| 对齐分布 | `.space_between()`, `.space_around()`, `.space_evenly()` |
-| 文本换行 | `ui.text("long text...").wrap()` |
-| 带标题边框 | `.border(Border::Rounded).title("Panel")` |
-| 单侧边框 | `.border_top(false)`, `.border_sides(BorderSides::horizontal())` |
-| 响应式间距 | `.gap_at(Breakpoint::Md, 2)` |
-
-</details>
-
-<details>
-<summary><b>样式</b></summary>
-
-```rust
-ui.text("styled").bold().italic().underline().fg(Color::Cyan).bg(Color::Black);
-```
-
-16 种命名颜色 · 256 色调色板 · 24 位 RGB · 6 种修饰符 · 6 种边框样式
-
-</details>
-
-<details>
-<summary><b>主题</b></summary>
-
-```rust
-// 7 个内置预设
-slt::run_with(RunConfig::default().theme(Theme::catppuccin()), |ui| {
-    ui.set_theme(Theme::dark()); // 运行时切换
+// 文本和布局
+ui.text("Hello").bold().fg(Color::Cyan);
+ui.row(|ui| {
+    ui.text("left");
+    ui.spacer();
+    ui.text("right");
 });
 
-// 构建自定义主题
-let theme = Theme::builder()
-    .primary(Color::Rgb(255, 107, 107))
-    .accent(Color::Cyan)
-    .build();
-```
+// 输入和操作
+ui.text_input(&mut name);
+if ui.button("Save").clicked {}
+ui.checkbox("Dark mode", &mut dark);
 
-7 个预设（dark、light、dracula、catppuccin、nord、solarized_dark、tokyo_night）。自定义主题支持 15 个颜色槽 + `is_dark` 标志。所有 widget 自动继承。
+// 数据和导航
+ui.tabs(&mut tabs);
+ui.list(&mut items);
+ui.table(&mut data);
+ui.command_palette(&mut palette);
 
-</details>
-
-<details>
-<summary><b>样式复用</b></summary>
-
-```rust
-use slt::{ContainerStyle, Border, Color};
-
-const CARD: ContainerStyle = ContainerStyle::new()
-    .border(Border::Rounded).p(1).bg(Color::Indexed(236));
-
-// 应用并组合
-ui.container().apply(&CARD).grow(1).gap(2).col(|ui| { ... });
-```
-
-定义一次，随处使用。`const` 样式零运行时开销。链式 `.apply()` 组合，内联方法始终覆盖。
-
-</details>
-
-<details>
-<summary><b>响应式布局</b></summary>
-
-```rust
-ui.container()
-    .w(20).md_w(40).lg_w(60)  // 在断点处改变宽度
-    .p(1).lg_p(2)
-    .col(|ui| { ... });
-```
-
-35 个断点条件方法（`xs_`、`sm_`、`md_`、`lg_`、`xl_` × `w`、`h`、`min_w`、`max_w`、`gap`、`p`、`grow`）。断点：Xs (<40)、Sm (40-79)、Md (80-119)、Lg (120-159)、Xl (≥160)。
-
-</details>
-
-<details>
-<summary><b>Hooks</b></summary>
-
-```rust
-let count = ui.use_state(|| 0i32);
-ui.text(format!("{}", count.get(ui)));
-if ui.button("+1") { *count.get_mut(ui) += 1; }
-```
-
-即时模式下的 React 风格持久状态。`State<T>` 句柄模式，每帧按相同顺序调用。
-
-</details>
-
-<details>
-<summary><b>渲染</b></summary>
-
-- **双缓冲差分** — 只有变化的单元格才会输出到终端
-- **同步输出** — DECSET 2026 防止支持的终端出现撕裂
-- **视口裁剪** — 屏幕外的 widget 完全跳过
-- **FPS 上限** — `RunConfig::default().max_fps(60)` 控制 CPU 占用
-- **自动重排** — 终端大小变化时自动重新布局
-- **`collect_all()`** — 单次 DFS 遍历替代 7 次独立树遍历 (v0.9)
-
-</details>
-
-<details>
-<summary><b>动画</b></summary>
-
-```rust
-let mut tween = Tween::new(0.0, 100.0, 60).easing(ease_out_bounce);
-let value = tween.value(ui.tick());
-
-let mut spring = Spring::new(0.0, 180.0, 12.0);
-spring.set_target(100.0);
-
-let mut kf = Keyframes::new(120)
-    .stop(0.0, 0.0).stop(0.5, 100.0).stop(1.0, 50.0)
-    .loop_mode(LoopMode::PingPong);
-```
-
-Tween（9 种缓动函数）、弹簧物理、关键帧时间轴（含循环模式）、Sequence 链、Stagger 列表动画。全部支持 `.on_complete()` 回调。
-
-</details>
-
-<details>
-<summary><b>异步支持</b></summary>
-
-```rust
-let tx = slt::run_async(|ui, messages: &mut Vec<String>| {
-    for msg in messages.drain(..) { ui.text(msg); }
-})?;
-tx.send("Hello from background!".into()).await?;
-```
-
-可选 tokio 集成。通过 `cargo add superlighttui --features async` 启用。
-
-</details>
-
-<details>
-<summary><b>错误边界</b></summary>
-
-```rust
-ui.error_boundary(|ui| {
-    ui.text("If this panics, the app keeps running.");
-});
-```
-
-捕获 widget panic 而不崩溃整个应用。部分命令回滚，渲染降级内容。
-
-</details>
-
-<details>
-<summary><b>模态框与浮层</b></summary>
-
-```rust
+// 浮层和富文本输出
+ui.toast(&mut toasts);
 ui.modal(|ui| {
-    ui.bordered(Border::Rounded).pad(2).col(|ui| {
-        ui.text("Confirm?").bold();
-        if ui.button("OK") { show = false; }
-    });
+    ui.text("Confirm?").bold();
+});
+ui.markdown("# Hello **world**");
+
+// 数据可视化
+ui.chart(|c| {
+    c.line(&data);
+    c.grid(true);
+}, 50, 16);
+ui.sparkline(&values, 16);
+ui.canvas(40, 10, |cv| {
+    cv.circle(20, 20, 15);
 });
 ```
 
-`modal()` 遮暗背景并在顶层渲染内容。`overlay()` 渲染浮动内容但不遮暗背景。两者均支持完整布局和交互。
+完整分类组件列表请参阅 [组件指南]。
 
-</details>
+## 学习指南
 
-<details>
-<summary><b>快照测试</b></summary>
+| 文档 | 涵盖内容 |
+|------|----------|
+| [文档索引] | 完整文档结构和指南索引 |
+| [快速开始] | 安装、第一个应用、计数器、布局、输入 |
+| [组件指南] | 组件目录和主要 API |
+| [模式指南] | 状态管理、表单、覆盖层、异步、自定义组件 |
+| [示例指南] | 示例索引和运行命令 |
+| [架构指南] | 模块映射、帧生命周期、依赖流 |
+| [后端指南] | `Backend`、`AppState`、`frame()`、内联模式 |
+| [测试指南] | `TestBackend`、`EventBuilder`、交互测试 |
+| [调试指南] | F12 覆盖层、裁剪、单帧延迟 |
+| [AI 指南] | AI 编程助手快速参考 |
+| [动画指南] | Tween、Spring、Keyframes、Sequence、Stagger |
+| [主题指南] | 主题预设、ThemeBuilder、自定义主题 |
+| [特性指南] | 功能标志、可选依赖、推荐组合 |
+| [`docs/DESIGN_PRINCIPLES.md`](DESIGN_PRINCIPLES.md) | API 设计理念 |
 
-```rust
-use slt::TestBackend;
+## 示例精选
 
-let mut backend = TestBackend::new(40, 10);
-backend.render(|ui| {
-    ui.bordered(Border::Rounded).pad(1).col(|ui| {
-        ui.text("Hello");
-    });
-});
-insta::assert_snapshot!(backend.to_string_trimmed());
-```
-
-配合 [insta](https://crates.io/crates/insta) 进行基于快照的 UI 回归测试。
-
-</details>
-
-<details>
-<summary><b>图片渲染</b></summary>
-
-```sh
-cargo add superlighttui --features image
-```
-
-```rust
-use slt::HalfBlockImage;
-
-let photo = image::open("photo.png").unwrap();
-let img = HalfBlockImage::from_dynamic(&photo, 60, 30);
-ui.image(&img);
-```
-
-半块字符（▀▄）图片渲染。Sixel 协议（v0.13.2）：`ui.sixel_image(&rgba, w, h, cols, rows)` 在 xterm、foot、mlterm 上实现像素级图片。
-
-</details>
-
-<details>
-<summary><b>Feature Flags</b></summary>
-
-| Flag | 说明 |
-|------|------|
-| `async` | `run_async()`，基于 tokio channel 的消息传递 |
-| `serde` | 为 Style、Color、Theme、布局类型实现序列化/反序列化 |
-| `image` | `HalfBlockImage::from_dynamic()`，依赖 `image` crate |
-| `full` | 以上全部 |
-
-```toml
-[dependencies]
-superlighttui = { version = "0.13", features = ["full"] }
-```
-
-</details>
-
-<details>
-<summary><b>调试</b></summary>
-
-在任意 SLT 应用中按 **F12** 切换布局调试器浮层，显示容器边界、嵌套深度和布局结构。
-
-</details>
-
-## 示例
-
-| 示例 | 命令 | 展示内容 |
-|------|------|----------|
-| hello | `cargo run --example hello` | 最简配置 |
-| counter | `cargo run --example counter` | 状态 + 键盘 |
-| demo | `cargo run --example demo` | 所有 widget |
-| demo_dashboard | `cargo run --example demo_dashboard` | 实时仪表盘 |
+| 示例 | 命令 | 重点 |
+|------|------|------|
+| hello | `cargo run --example hello` | 最简应用 |
+| counter | `cargo run --example counter` | 状态 + 键盘输入 |
+| demo | `cargo run --example demo` | 全组件概览 |
+| demo_dashboard | `cargo run --example demo_dashboard` | 仪表盘布局 |
 | demo_cli | `cargo run --example demo_cli` | CLI 工具布局 |
-| demo_spreadsheet | `cargo run --example demo_spreadsheet` | 数据表格 |
-| demo_website | `cargo run --example demo_website` | 终端中的网站 |
-| demo_game | `cargo run --example demo_game` | 俄罗斯方块 + 贪吃蛇 + 扫雷 |
-| demo_fire | `cargo run --release --example demo_fire` | DOOM 火焰效果（半块字符） |
-| demo_ime | `cargo run --example demo_ime` | 韩文/CJK 输入法 |
-| inline | `cargo run --example inline` | 内联模式 |
-| anim | `cargo run --example anim` | Tween + Spring + Keyframes |
-| demo_infoviz | `cargo run --example demo_infoviz` | 数据可视化 |
-| demo_trading | `cargo run --example demo_trading` | 交易所风格终端 |
-| async_demo | `cargo run --example async_demo --features async` | 后台任务 |
+| demo_infoviz | `cargo run --example demo_infoviz` | 图表和数据可视化 |
+| demo_game | `cargo run --example demo_game` | 即时模式交互 |
+| async_demo | `cargo run --example async_demo --features async` | 后台消息 |
 
-## 架构
+完整分类索引请参阅 [示例指南]。
 
-```
-Closure → Context collects Commands → build_tree() → flexbox layout → diff buffer → flush
-```
+## 自定义组件和后端
 
-每一帧：你的闭包运行，SLT 收集你描述的内容，计算 flexbox 布局，与上一帧做差分，只刷新变化的单元格。
+- 实现 `Widget` trait 来构建可复用组件，完整支持焦点、布局、事件和主题。
+- 实现 `Backend` + 驱动 `frame()`，可用于非终端渲染器、测试工具或嵌入式目标。
+- 使用 `TestBackend` 进行无头渲染和快照式断言。
 
-纯 Rust。无宏，无代码生成，无构建脚本。
-
-### 自定义 Backend
-
-SLT 的渲染通过 `Backend` trait 抽象，支持终端以外的自定义渲染目标：
-
-```rust
-use slt::{Backend, AppState, Buffer, Rect, RunConfig, Context, Event};
-
-struct MyBackend { buffer: Buffer }
-
-impl Backend for MyBackend {
-    fn size(&self) -> (u32, u32) {
-        (self.buffer.area.width, self.buffer.area.height)
-    }
-    fn buffer_mut(&mut self) -> &mut Buffer { &mut self.buffer }
-    fn flush(&mut self) -> std::io::Result<()> {
-        // 将 self.buffer 渲染到你的目标（canvas、GPU、网络等）
-        Ok(())
-    }
-}
-```
-
-`Backend` trait 只有 3 个方法：`size()`、`buffer_mut()`、`flush()`。自定义 backend 接收完整渲染好的 `Buffer`，可以用任何方式呈现，WebGL、egui 嵌入、SSH 隧道、测试框架等皆可。
-
-### AI 原生 Widgets
-
-SLT 内置专为 AI/LLM 工作流设计的 widget：
-
-| Widget | 说明 |
-|--------|------|
-| `streaming_text()` | 逐 token 文本显示，带闪烁光标 |
-| `streaming_markdown()` | 流式 Markdown，支持标题、代码块、内联格式 |
-| `tool_approval()` | 人工审批/拒绝工具调用 |
-| `context_bar()` | 显示活跃上下文来源的 token 计数条 |
-| `markdown()` | 静态 Markdown 渲染 |
-| `code_block()` | 语法高亮代码展示 |
+更多内容请参阅 [模式指南] 和 [架构指南]。
 
 ## 贡献
 
-参见 [CONTRIBUTING.md](../CONTRIBUTING.md)。
+请先阅读 [贡献指南]，然后查看 `docs/DESIGN_PRINCIPLES.md` 和 [架构指南]。
+发布和 CI 流程要求格式化、检查、clippy、测试和示例编译保持通过。
 
 ## 许可证
 
@@ -509,6 +198,18 @@ SLT 内置专为 AI/LLM 工作流设计的 widget：
 [CI]: https://github.com/subinium/SuperLightTUI/actions/workflows/ci.yml
 [Crate]: https://crates.io/crates/superlighttui
 [Docs]: https://docs.rs/superlighttui
-[Examples]: https://github.com/subinium/SuperLightTUI/tree/main/examples
-[Contributing]: https://github.com/subinium/SuperLightTUI/blob/main/CONTRIBUTING.md
+[文档索引]: README.md
+[快速开始]: QUICK_START.md
+[组件指南]: WIDGETS.md
+[示例指南]: EXAMPLES.md
+[模式指南]: PATTERNS.md
+[架构指南]: ARCHITECTURE.md
+[后端指南]: BACKENDS.md
+[测试指南]: TESTING.md
+[调试指南]: DEBUGGING.md
+[AI 指南]: AI_GUIDE.md
+[动画指南]: ANIMATION.md
+[主题指南]: THEMING.md
+[特性指南]: FEATURES.md
+[贡献指南]: ../CONTRIBUTING.md
 [License]: ../LICENSE

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,109 @@
+# Testing Guide
+
+This guide covers the test path that AI-assisted contributors should reach for first.
+
+## Default tool: `TestBackend`
+
+`TestBackend` renders one or more frames into an in-memory buffer without a real terminal.
+
+```rust
+use slt::TestBackend;
+
+let mut tb = TestBackend::new(40, 10);
+tb.render(|ui| {
+    ui.text("Hello");
+});
+
+tb.assert_contains("Hello");
+```
+
+Use this for:
+
+- text and layout assertions
+- widget state changes
+- overlay and modal rendering checks
+- snapshot-style buffer inspection
+
+## Simulating input with `EventBuilder`
+
+```rust
+use slt::{EventBuilder, KeyCode, TestBackend};
+
+let mut tb = TestBackend::new(40, 10);
+let events = EventBuilder::new()
+    .key('h')
+    .key_code(KeyCode::Tab)
+    .click(4, 2)
+    .build();
+
+tb.run_with_events(events, |ui| {
+    ui.text("interactive");
+});
+```
+
+Use `EventBuilder` when the widget logic depends on keyboard, mouse, paste, or resize events.
+
+## `render()` vs `run_with_events()` vs `render_with_events()`
+
+| Method | Use when |
+|--------|----------|
+| `render()` | One static frame, no input needed |
+| `run_with_events()` | One frame with events, default focus state is fine |
+| `render_with_events()` | One frame with explicit events and explicit focus bookkeeping |
+
+`render_with_events()` is the lowest-level test helper. Use it when you need to control `focus_index` or `prev_focus_count` directly.
+
+## Assertions that scale well
+
+```rust
+tb.assert_contains("Saved");
+tb.assert_line(0, "Header");
+tb.assert_line_contains(3, "status");
+let snapshot = tb.to_string_trimmed();
+```
+
+The most AI-friendly pattern is:
+
+1. render one frame
+2. inspect one or two lines
+3. assert a small, stable substring
+
+Avoid asserting giant whole-screen strings unless the UI is intentionally snapshot-tested.
+
+## Testing custom widgets
+
+For custom widgets:
+
+- call `register_focusable()` if keyboard input matters
+- use `interaction()` if you need click/hover without a wrapping container
+- verify both rendering and return value semantics
+
+```rust
+let changed = ui.widget(&mut rating);
+assert!(changed);
+```
+
+## Good test targets in SLT
+
+- clipping and viewport behavior for `raw_draw`
+- focus order and Tab behavior
+- modal/overlay interaction boundaries
+- `Response.clicked`, `.changed`, `.hovered`, `.focused`
+- widget state persistence across frames
+- rendering of wrapped text, markdown, and charts
+
+## Debugging failing UI tests
+
+When a test fails:
+
+- print `tb.to_string_trimmed()` in the failure path
+- compare the expected focus/input state with the actual event sequence
+- verify whether the widget depends on previous-frame data (`prev_*` behavior)
+
+That last point matters: some interaction data only becomes visible on the next frame in immediate-mode UI.
+
+## Related docs
+
+- `docs/DEBUGGING.md` - one-frame delay, F12 overlay, clipping
+- `docs/PATTERNS.md` - custom widgets, hooks, overlays
+- `src/test_utils.rs` - canonical rustdoc for test helpers

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -1,0 +1,438 @@
+# Theming & Colors
+
+SLT's theming system flows a `Theme` through all widgets automatically. Set a theme once and every widget picks up the colors without extra wiring.
+
+## Preset Themes
+
+SLT ships with 7 built-in themes:
+
+| Theme | Constructor | Style | Primary color |
+|-------|-------------|-------|---------------|
+| **Dark** (default) | `Theme::dark()` | Dark | Cyan |
+| **Light** | `Theme::light()` | Light | Blue (RGB) |
+| **Dracula** | `Theme::dracula()` | Dark | Purple |
+| **Catppuccin** (Mocha) | `Theme::catppuccin()` | Dark | Lavender |
+| **Nord** | `Theme::nord()` | Dark | Frost blue |
+| **Solarized Dark** | `Theme::solarized_dark()` | Dark | Blue |
+| **Tokyo Night** | `Theme::tokyo_night()` | Dark | Blue |
+
+### Usage with RunConfig
+
+```rust
+use slt::{RunConfig, Theme};
+
+fn main() -> std::io::Result<()> {
+    let config = RunConfig::default().theme(Theme::dracula());
+
+    slt::run_with(config, |ui| {
+        ui.text("Styled by Dracula");
+    })
+}
+```
+
+## ThemeBuilder
+
+Build a custom theme by overriding specific fields. Unset fields fall back to `Theme::dark()` defaults.
+
+```rust
+use slt::{Color, Theme};
+
+let theme = Theme::builder()
+    .primary(Color::Rgb(255, 107, 107))
+    .accent(Color::Cyan)
+    .bg(Color::Rgb(20, 20, 30))
+    .text(Color::Rgb(220, 220, 230))
+    .is_dark(true)
+    .build();
+```
+
+### All 16 theme fields
+
+| Field | Purpose |
+|-------|---------|
+| `primary` | Focused borders, highlights |
+| `secondary` | Less prominent highlights |
+| `accent` | Decorative elements |
+| `text` | Default foreground text |
+| `text_dim` | Secondary labels, hints |
+| `border` | Unfocused container borders |
+| `bg` | Background (often `Color::Reset` to inherit terminal bg) |
+| `success` | Success states (toasts, indicators) |
+| `warning` | Warning states |
+| `error` | Error states |
+| `selected_bg` | Selected list/table row background |
+| `selected_fg` | Selected list/table row foreground |
+| `surface` | Card backgrounds, elevated containers |
+| `surface_hover` | Hover/active surface, one step brighter than `surface` |
+| `surface_text` | Text color readable on `surface` backgrounds |
+| `is_dark` | Whether this theme is dark mode |
+
+## Runtime Theme Switching
+
+Change themes and dark mode on the fly inside your render closure:
+
+```rust
+use slt::{Color, Theme};
+
+slt::run(|ui| {
+    // Switch the entire theme
+    if ui.key('t') {
+        ui.set_theme(Theme::nord());
+    }
+
+    // Toggle dark mode
+    if ui.key('d') {
+        let dark = ui.is_dark_mode();
+        ui.set_dark_mode(!dark);
+    }
+
+    // Pick a color based on current mode
+    let accent = ui.light_dark(Color::Rgb(37, 99, 235), Color::Cyan);
+    ui.text("Adaptive text").fg(accent);
+})
+```
+
+| Method | Description |
+|--------|-------------|
+| `ui.set_theme(theme)` | Replace the active theme for all subsequent widgets |
+| `ui.is_dark_mode()` | Returns `true` if dark mode is active |
+| `ui.set_dark_mode(bool)` | Enable or disable dark mode |
+| `ui.light_dark(light, dark)` | Returns `light` in light mode, `dark` in dark mode |
+
+## WidgetColors
+
+Override individual widget colors without changing the global theme. Many widgets have a `_colored` variant that accepts `WidgetColors`.
+
+```rust
+use slt::{Color, WidgetColors};
+
+let custom = WidgetColors::new()
+    .fg(Color::White)
+    .bg(Color::Rgb(30, 30, 46))
+    .border(Color::Cyan)
+    .accent(Color::Yellow);
+
+// Use the _colored variant
+ui.button_colored("Save", &custom);
+ui.list_colored(&mut list_state, &custom);
+ui.table_colored(&mut table_state, &custom);
+```
+
+### WidgetColors fields
+
+| Field | Purpose |
+|-------|---------|
+| `fg` | Foreground color override |
+| `bg` | Background color override |
+| `border` | Border color override |
+| `accent` | Accent/highlight color override |
+
+All fields are `Option<Color>` -- unset fields fall back to the active theme.
+
+### Widgets with `_colored` variants
+
+| Widget | Colored variant |
+|--------|----------------|
+| `button` | `button_colored(label, &colors)` |
+| `list` | `list_colored(&mut state, &colors)` |
+| `table` | `table_colored(&mut state, &colors)` |
+| `tabs` | `tabs_colored(&mut state, &colors)` |
+| `text_input` | `text_input_colored(&mut state, &colors)` |
+| `select` | `select_colored(&mut state, &colors)` |
+| `radio` | `radio_colored(&mut state, &colors)` |
+| `checkbox` | `checkbox_colored(label, checked, &colors)` |
+| `toggle` | `toggle_colored(label, enabled, &colors)` |
+| `separator` | `separator_colored(color)` |
+| `badge` | `badge_colored(label, color)` |
+| `stat` | `stat_colored(label, value, color)` |
+| `progress_bar` | `progress_bar_colored(ratio, width, color)` |
+| `line_chart` | `line_chart_colored(data, w, h, color)` |
+| `area_chart` | `area_chart_colored(data, w, h, color)` |
+
+## Tailwind Palette
+
+The `palette::tailwind` module provides all 22 Tailwind CSS color palettes as `const` values. Each palette has 11 shades from lightest (`c50`) to darkest (`c950`).
+
+```rust
+use slt::palette::tailwind::{BLUE, ROSE, SLATE};
+
+// Access a specific shade
+let primary = BLUE.c500;    // Rgb(59, 130, 246)
+let danger  = ROSE.c600;    // Rgb(225, 29, 72)
+let muted   = SLATE.c400;   // Rgb(148, 163, 184)
+```
+
+### Shade levels
+
+| Shade | Meaning |
+|-------|---------|
+| `c50` | Lightest |
+| `c100` | |
+| `c200` | |
+| `c300` | |
+| `c400` | |
+| `c500` | Mid / default |
+| `c600` | |
+| `c700` | |
+| `c800` | |
+| `c900` | |
+| `c950` | Darkest |
+
+### All 22 palettes
+
+**Neutrals:** `SLATE`, `GRAY`, `ZINC`, `NEUTRAL`, `STONE`
+
+**Colors:** `RED`, `ORANGE`, `AMBER`, `YELLOW`, `LIME`, `GREEN`, `EMERALD`, `TEAL`, `CYAN`, `SKY`, `BLUE`, `INDIGO`, `VIOLET`, `PURPLE`, `FUCHSIA`, `PINK`, `ROSE`
+
+### Building a theme from Tailwind palettes
+
+```rust
+use slt::{Theme, palette::tailwind::*};
+
+let theme = Theme::builder()
+    .primary(INDIGO.c500)
+    .secondary(TEAL.c500)
+    .accent(PINK.c500)
+    .text(SLATE.c50)
+    .text_dim(SLATE.c400)
+    .border(SLATE.c700)
+    .bg(SLATE.c950)
+    .success(EMERALD.c500)
+    .warning(AMBER.c500)
+    .error(RED.c500)
+    .surface(SLATE.c800)
+    .surface_hover(SLATE.c700)
+    .surface_text(SLATE.c300)
+    .is_dark(true)
+    .build();
+```
+
+## Color Utilities
+
+### Creating colors
+
+```rust
+use slt::Color;
+
+// 24-bit true color
+let coral = Color::Rgb(255, 127, 80);
+
+// 256-color palette index
+let gray = Color::Indexed(240);
+
+// Named ANSI colors
+let red = Color::Red;
+let bright = Color::LightCyan;
+
+// Reset to terminal default
+let default = Color::Reset;
+```
+
+### Named colors
+
+`Black`, `Red`, `Green`, `Yellow`, `Blue`, `Magenta`, `Cyan`, `White`, `DarkGray`, `LightRed`, `LightGreen`, `LightYellow`, `LightBlue`, `LightMagenta`, `LightCyan`, `LightWhite`, `Reset`
+
+### Blending and adjustment
+
+```rust
+use slt::Color;
+
+let white = Color::Rgb(255, 255, 255);
+let black = Color::Rgb(0, 0, 0);
+let blue = Color::Rgb(59, 130, 246);
+
+// Alpha blending: blend(other, alpha)
+// alpha=0.0 returns other, alpha=1.0 returns self
+let gray = white.blend(black, 0.5);  // ~Rgb(128, 128, 128)
+
+// Lighten toward white (0.0 = unchanged, 1.0 = white)
+let light_blue = blue.lighten(0.3);
+
+// Darken toward black (0.0 = unchanged, 1.0 = black)
+let dark_blue = blue.darken(0.3);
+```
+
+### Luminance and contrast
+
+```rust
+use slt::Color;
+
+let bg = Color::Rgb(30, 30, 46);
+
+// Perceived brightness (0.0 = darkest, 1.0 = brightest)
+let lum = bg.luminance(); // ~0.03
+
+// Automatic readable foreground for a background color
+// Returns white for dark backgrounds, black for light ones
+let fg = Color::contrast_fg(bg); // Rgb(255, 255, 255)
+```
+
+### Downsampling for terminal compatibility
+
+```rust
+use slt::{Color, ColorDepth};
+
+let color = Color::Rgb(59, 130, 246);
+
+// TrueColor: returns unchanged
+let true_c = color.downsampled(ColorDepth::TrueColor);
+
+// EightBit: converts Rgb to nearest Indexed color
+let eight = color.downsampled(ColorDepth::EightBit);
+
+// Basic: converts to nearest named ANSI color
+let basic = color.downsampled(ColorDepth::Basic);
+```
+
+## ColorDepth
+
+Represents the terminal's color capability.
+
+| Variant | Colors | Description |
+|---------|--------|-------------|
+| `TrueColor` | 16M | 24-bit RGB |
+| `EightBit` | 256 | xterm-256color palette |
+| `Basic` | 16 | Standard ANSI colors |
+
+### Automatic detection
+
+```rust
+use slt::ColorDepth;
+
+// Checks $COLORTERM for truecolor/24bit, then $TERM for 256color
+let depth = ColorDepth::detect();
+```
+
+### Setting via RunConfig
+
+```rust
+use slt::{RunConfig, ColorDepth};
+
+let config = RunConfig::default().color_depth(ColorDepth::EightBit);
+```
+
+## Style Type
+
+`Style` sets foreground, background, and text modifiers for a terminal cell.
+
+```rust
+use slt::{Style, Color, Modifiers};
+
+// Builder pattern
+let style = Style::new()
+    .fg(Color::Cyan)
+    .bg(Color::Rgb(30, 30, 46))
+    .bold()
+    .italic();
+
+// Modifiers can also be combined with |
+let mods = Modifiers::BOLD | Modifiers::UNDERLINE;
+```
+
+### Available modifiers
+
+| Modifier | Method | Constant |
+|----------|--------|----------|
+| Bold | `.bold()` | `Modifiers::BOLD` |
+| Dim | `.dim()` | `Modifiers::DIM` |
+| Italic | `.italic()` | `Modifiers::ITALIC` |
+| Underline | `.underline()` | `Modifiers::UNDERLINE` |
+| Reversed | `.reversed()` | `Modifiers::REVERSED` |
+| Strikethrough | `.strikethrough()` | `Modifiers::STRIKETHROUGH` |
+
+### Applying to text widgets
+
+```rust
+slt::run(|ui| {
+    ui.text("bold cyan").bold().fg(Color::Cyan);
+    ui.text("dimmed").dim();
+    ui.text("warning").fg(Color::Yellow).italic();
+})
+```
+
+## ContainerStyle
+
+Define reusable style recipes as `const` values and apply them to containers.
+
+```rust
+use slt::{ContainerStyle, Border, Color, Align};
+
+const CARD: ContainerStyle = ContainerStyle::new()
+    .border(Border::Rounded)
+    .p(1)
+    .bg(Color::Indexed(236));
+
+const DANGER: ContainerStyle = ContainerStyle::new()
+    .bg(Color::Red);
+
+slt::run(|ui| {
+    // Apply a single style
+    ui.container().apply(&CARD).col(|ui| {
+        ui.text("Card content");
+    });
+
+    // Compose multiple styles (last write wins)
+    ui.container().apply(&CARD).apply(&DANGER).col(|ui| {
+        ui.text("Danger card");
+    });
+})
+```
+
+### ContainerStyle fields
+
+`border`, `border_sides`, `border_style`, `bg`, `text_color`, `dark_bg`, `dark_border_style`, `padding`, `margin`, `gap`, `row_gap`, `col_gap`, `grow`, `align`, `align_self`, `justify`, `w`, `h`, `min_w`, `max_w`, `min_h`, `max_h`, `w_pct`, `h_pct`
+
+All fields are `Option` -- unset fields leave the builder's current value unchanged.
+
+## Dark Mode Patterns
+
+### Container-level dark mode overrides
+
+Use `dark_bg()` and `dark_border_style()` on `ContainerBuilder` to set styles that apply only when dark mode is active:
+
+```rust
+use slt::{Border, Color, Style};
+
+slt::run(|ui| {
+    ui.bordered(Border::Rounded)
+        .bg(Color::Rgb(248, 250, 252))           // light mode bg
+        .dark_bg(Color::Rgb(30, 30, 46))          // dark mode bg
+        .dark_border_style(Style::new().fg(Color::Rgb(88, 91, 112)))
+        .col(|ui| {
+            ui.text("Adapts to dark/light mode");
+        });
+})
+```
+
+### Using `light_dark()` for inline adaptation
+
+```rust
+use slt::Color;
+
+slt::run(|ui| {
+    let text_color = ui.light_dark(
+        Color::Rgb(15, 23, 42),   // dark text for light mode
+        Color::Rgb(205, 214, 244) // light text for dark mode
+    );
+    ui.text("Adaptive").fg(text_color);
+})
+```
+
+### ContainerStyle with dark mode
+
+```rust
+use slt::{ContainerStyle, Border, Color, Style};
+
+const PANEL: ContainerStyle = ContainerStyle::new()
+    .border(Border::Rounded)
+    .p(1)
+    .bg(Color::Rgb(241, 245, 249))
+    .dark_bg(Color::Rgb(49, 50, 68));
+```
+
+## Related Docs
+
+- [QUICK_START.md](QUICK_START.md) -- basic setup and style chaining
+- [WIDGETS.md](WIDGETS.md) -- categorized widget reference
+- [PATTERNS.md](PATTERNS.md) -- common composition patterns
+- [DESIGN_PRINCIPLES.md](DESIGN_PRINCIPLES.md) -- API philosophy

--- a/docs/WIDGETS.md
+++ b/docs/WIDGETS.md
@@ -1,139 +1,453 @@
-# Widget Guide
+# Widget API Catalog
 
-This is the high-level widget map.
-Use it to decide which part of the API to reach for before opening docs.rs or source files.
+Complete reference for every widget and public `Context` method in SLT.
+For patterns and composition, see [PATTERNS.md](PATTERNS.md). For animation, see the `anim` module.
 
-## Core rules
+---
 
-- Display-oriented methods usually return `&mut Context` for style chaining.
-- Interactive widgets usually return `Response` and keep their own `*State` in `src/widgets.rs`.
-- Layout is built with `row()`, `col()`, `grid()`, `spacer()`, `grow()`, and container builders.
+## Return type conventions
 
-## Text and display
+Every widget method on `Context` follows one of these return patterns:
+
+| Return type | Meaning | When to use |
+|---|---|---|
+| `&mut Self` | Style-chainable display element | `text`, `separator`, `progress`, `spinner`, `toast`, `spacer` |
+| `Response` | Interactive widget with click/hover/changed/focused/rect | `button`, `list`, `table`, `tabs`, `col`, `row`, `alert`, charts |
+| `ContainerBuilder<'a>` | Fluent builder — finalize with `.col()`, `.row()`, or `.draw()` | `container`, `scrollable`, `bordered`, `group` |
+| `Option<usize>` | Index of selected segment, or `None` | `breadcrumb` |
+| `()` | Fire-and-forget side-effect | `tooltip`, `scrollbar`, `notify`, `screen` |
+
+**`Response` fields:**
 
 ```rust
+pub struct Response {
+    pub clicked: bool,   // clicked this frame
+    pub hovered: bool,   // mouse hovering
+    pub changed: bool,   // value changed this frame
+    pub focused: bool,   // has keyboard focus
+    pub rect: Rect,      // layout rectangle (valid after layout pass)
+}
+```
+
+---
+
+## Text & Display
+
+All return `&mut Self` for style chaining unless noted.
+
+| Method | Description |
+|---|---|
+| `text(s)` | Render text. Chain: `.bold()`, `.italic()`, `.dim()`, `.underline()`, `.reversed()`, `.strikethrough()`, `.fg(color)`, `.bg(color)`, `.gradient(a, b)`, `.wrap()`, `.truncate()`, `.grow(n)`, `.align(a)`, `.text_center()`, `.text_right()`, `.w()`, `.h()`, `.min_w()`, `.max_w()`, `.min_h()`, `.max_h()`, `.m()`, `.mx()`, `.my()`, `.mt()`, `.mr()`, `.mb()`, `.ml()`, `.group_hover_fg()`, `.group_hover_bg()` |
+| `styled(s, style)` | Text with an explicit `Style` struct |
+| `link(text, url)` | Clickable hyperlink (OSC 8). Opens URL on Enter/Space/click |
+| `spacer()` | Invisible flex element — pushes siblings apart |
+| `separator()` | Horizontal divider line. Variant: `separator_colored(color)` |
+| `timer_display(elapsed)` | Format `Duration` as HH:MM:SS.CC |
+
+### Rich text (return `Response`)
+
+| Method | Description |
+|---|---|
+| `markdown(text)` | Render Markdown with headings, bold, italic, links, lists, code |
+| `code_block(code)` | Fenced code block. Variants: `code_block_lang(code, lang)`, `code_block_numbered(code)`, `code_block_numbered_lang(code, lang)` |
+| `big_text(s)` | 8x8 bitmap text rendered as half-block pixels (4 rows tall) |
+
+```rust
+// Typical text usage
 ui.text("Hello").bold().fg(Color::Cyan);
 ui.styled("inline", Style::new().underline());
 ui.link("Docs", "https://docs.rs/superlighttui");
-ui.markdown("# Heading\n\n**Bold** text");
-ui.code_block_lang("fn main() {}", "rust");
-ui.big_text("SLT");
-ui.timer_display(elapsed);
 ```
 
-Use these when you mostly need output, formatting, and rich text.
+---
 
-## Layout and containers
+## Status & Info
+
+All return `Response` unless noted.
+
+| Method | Description |
+|---|---|
+| `alert(message, level)` | Banner with icon. `AlertLevel`: `Info`, `Success`, `Warning`, `Error` |
+| `badge(label)` | Themed badge pill. Variant: `badge_colored(label, color)` |
+| `key_hint(key)` | Keyboard shortcut hint badge |
+| `stat(label, value)` | Label-value stat display. Variants: `stat_colored(label, value, color)`, `stat_trend(label, value, trend)` where `Trend`: `Up`, `Down` |
+| `empty_state(title, desc)` | Centered empty-state message. Variant: `empty_state_action(title, desc, action)` |
+| `divider_text(label)` | Horizontal divider with centered label |
+| `definition_list(items)` | Key-value list from `&[(&str, &str)]` |
+| `accordion(title, open, f)` | Collapsible section. `open: &mut bool` |
+| `confirm(question, result)` | Yes/No dialog. `result: &mut bool`, `Response.clicked` on answer |
+| `breadcrumb(segments)` | Clickable breadcrumb trail. Returns `Option<usize>`. Variant: `breadcrumb_with(segments, sep)` |
+| `help(bindings)` | Keybinding help bar from `&[(&str, &str)]`. Variant: `help_colored(bindings, key_color, text_color)` |
+| `help_from_keymap(keymap)` | Help bar from a `KeyMap` struct |
+
+Note: `separator()` and `separator_colored()` return `&mut Self` (listed under Text & Display).
+
+---
+
+## Layout & Containers
+
+| Method | Returns | Description |
+|---|---|---|
+| `col(f)` | `Response` | Vertical container. Variant: `col_gap(gap, f)` |
+| `row(f)` | `Response` | Horizontal container. Variant: `row_gap(gap, f)` |
+| `line(f)` | `&mut Self` | Inline rich text (zero-gap row, no interaction) |
+| `line_wrap(f)` | `&mut Self` | Wrapping inline text |
+| `grid(cols, f)` | `Response` | Fixed-column grid layout |
+| `container()` | `ContainerBuilder` | Fluent builder for borders, padding, grow, constraints, title |
+| `scrollable(state)` | `ContainerBuilder` | Scrollable container. `ScrollState` |
+| `scrollbar(state)` | `()` | Render scrollbar track for a `ScrollState` |
+| `bordered(border)` | `ContainerBuilder` | Shorthand for `container().border(border)` |
+| `modal(f)` | `Response` | Modal overlay with dimmed background |
+| `overlay(f)` | `Response` | Floating overlay (no dimming) |
+| `tooltip(text)` | `()` | Hover tooltip near cursor |
+| `group(name)` | `ContainerBuilder` | Named group for shared hover/focus styling |
+| `screen(name, screens, f)` | `()` | Conditional rendering when named screen is active. `ScreenState` |
+| `form(state, f)` | `&mut Self` | Form container. `FormState` |
+| `form_field(field)` | `&mut Self` | Single form field. `FormField` |
+| `form_submit(label)` | `Response` | Form submit button |
 
 ```rust
-ui.row(|ui| {});
-ui.col(|ui| {});
-ui.grid(3, |ui| {});
-ui.scrollable(&mut scroll).col(|ui| {});
-ui.bordered(Border::Rounded).title("Panel").p(1).col(|ui| {});
-ui.modal(|ui| {});
-ui.overlay(|ui| {});
-ui.screen("home", &screens, |ui| {});
+// Layout composition
+ui.row(|ui| {
+    ui.container()
+        .border(Border::Rounded)
+        .pad(1)
+        .grow(1)
+        .col(|ui| {
+            ui.text("Panel content");
+        });
+    ui.spacer();
+    ui.col(|ui| { ui.text("Right side"); });
+});
 ```
 
-These are the pieces that define structure, not data.
+---
 
-## Actions and form input
+## Interactive Widgets
+
+All return `Response`. Most have a `_colored(&WidgetColors)` variant.
+
+| Method | State type | Description |
+|---|---|---|
+| `button(label)` | — | Click button. Variants: `button_colored(label, colors)`, `button_with(label, variant)` where `ButtonVariant`: `Default`, `Primary`, `Danger`, `Outline` |
+| `checkbox(label, checked)` | `&mut bool` | Checkbox toggle. Variant: `checkbox_colored(...)` |
+| `toggle(label, on)` | `&mut bool` | Toggle switch. Variant: `toggle_colored(...)` |
+| `slider(label, value, range)` | `&mut f64`, `RangeInclusive<f64>` | Horizontal slider |
+| `text_input(state)` | `TextInputState` | Single-line text input. Variant: `text_input_colored(...)` |
+| `textarea(state, visible_rows)` | `TextareaState` | Multi-line text editor |
+| `select(state)` | `SelectState` | Dropdown select. Variant: `select_colored(...)` |
+| `radio(state)` | `RadioState` | Radio button group. Variant: `radio_colored(...)` |
+| `multi_select(state)` | `MultiSelectState` | Multi-select checkbox list |
+| `tabs(state)` | `TabsState` | Tab bar. Variant: `tabs_colored(...)` |
+| `list(state)` | `ListState` | Scrollable list with selection. Variant: `list_colored(...)` |
+| `table(state)` | `TableState` | Data table with sorting, pagination, filtering. Variant: `table_colored(...)` |
+| `tree(state)` | `TreeState` | Expandable tree view |
+| `directory_tree(state)` | `DirectoryTreeState` | Filesystem tree |
+| `calendar(state)` | `CalendarState` | Month calendar with date selection |
+| `file_picker(state)` | `FilePickerState` | File browser dialog |
+| `command_palette(state)` | `CommandPaletteState` | Modal fuzzy-search command palette |
+| `virtual_list(state, visible_height, f)` | `ListState` | Virtualized list — only renders visible rows |
 
 ```rust
-if ui.button("Submit").clicked {}
-ui.checkbox("Dark mode", &mut dark);
-ui.toggle("Notifications", &mut enabled);
-ui.text_input(&mut input);
-ui.textarea(&mut notes, 5);
-ui.slider("Volume", &mut volume, 0.0..=100.0);
-ui.form_field(&mut field);
-ui.confirm("Delete?", &mut yes);
+// Interactive widget with Response
+let mut tabs = TabsState::new(vec!["Overview", "Details", "Settings"]);
+if ui.tabs(&mut tabs).changed {
+    // tab switched
+}
 ```
 
-These are the widgets you reach for first in CRUD-style or command-driven UIs.
+---
 
-## Choice and navigation
+## Feedback & Progress
 
-```rust
-ui.tabs(&mut tabs);
-ui.list(&mut list);
-ui.select(&mut select);
-ui.radio(&mut radio);
-ui.multi_select(&mut multi);
-ui.tree(&mut tree);
-ui.directory_tree(&mut directory_tree);
-ui.calendar(&mut calendar);
-ui.command_palette(&mut palette);
-ui.breadcrumb(&["Home", "Settings"]);
-```
+| Method | Returns | State type | Description |
+|---|---|---|---|
+| `progress(ratio)` | `&mut Self` | — | Progress bar, `f64` 0.0..1.0 |
+| `progress_bar(ratio, width)` | `&mut Self` | — | Fixed-width progress bar. Variant: `progress_bar_colored(ratio, width, color)` |
+| `spinner(state)` | `&mut Self` | `SpinnerState` | Animated spinner (dots, line, etc.) |
+| `toast(state)` | `&mut Self` | `ToastState` | Render active toast notifications |
+| `notify(message, level)` | `()` | — | Fire-and-forget toast. `ToastLevel`: `Info`, `Success`, `Warning`, `Error` |
 
-These widgets help users move through data or switch views.
-
-## Data and feedback
-
-```rust
-ui.table(&mut table);
-ui.virtual_list(&mut list, 20, |ui, i| {});
-ui.progress(0.75);
-ui.spinner(&spinner);
-ui.toast(&mut toasts);
-ui.alert("Saved!", AlertLevel::Success);
-ui.stat("Users", "1,234");
-ui.empty_state("No results", "Try a different search");
-ui.help(&[("q", "quit")]);
-```
-
-Use these for dashboards, tools, and status-heavy UIs.
+---
 
 ## Visualization
 
+All return `Response`.
+
+| Method | Description |
+|---|---|
+| `bar_chart(data, max_width)` | Horizontal bar chart from `&[(&str, f64)]`. Variants: `bar_chart_styled(bars, max_width, direction)`, `bar_chart_with(bars, configure, max_size)` |
+| `bar_chart_grouped(groups, max_width)` | Grouped bar chart from `&[BarGroup]`. Variant: `bar_chart_grouped_with(groups, configure, max_size)` |
+| `sparkline(data, width)` | Inline sparkline from `&[f64]`. Variant: `sparkline_styled(data, width)` with per-point `Option<Color>` |
+| `line_chart(data, width, height)` | Line chart. Variant: `line_chart_colored(...)` |
+| `area_chart(data, width, height)` | Filled area chart. Variant: `area_chart_colored(...)` |
+| `scatter(data, width, height)` | Braille scatter plot from `&[(f64, f64)]` |
+| `histogram(data, width, height)` | Histogram from `&[f64]`. Variant: `histogram_with(data, configure, w, h)` |
+| `candlestick(candles, up_color, down_color)` | OHLC candlestick chart |
+| `heatmap(data, w, h, low_color, high_color)` | 2D color gradient heatmap |
+| `canvas(width, height, draw)` | Braille drawing canvas. Closure receives `&mut CanvasContext` |
+| `chart(configure, width, height)` | Multi-series chart via `ChartBuilder`. Closure receives `&mut ChartBuilder` |
+| `qr_code(data)` | QR code (requires `qrcode` feature) |
+
 ```rust
+// Multi-series chart with builder
 ui.chart(|c| {
-    c.line(&data);
+    c.line(&data1);
+    c.area(&data2);
     c.grid(true);
-}, 50, 16);
-ui.line_chart(&data, 50, 16);
-ui.area_chart(&data, 50, 16);
-ui.scatter(&points, 50, 16);
-ui.histogram(&values, 40, 12);
-ui.bar_chart(&bars, 24);
-ui.bar_chart_grouped(&groups, 24);
-ui.sparkline(&values, 16);
-ui.heatmap(&grid, 40, 10, lo, hi);
-ui.canvas(40, 10, |cv| {
-    cv.circle(20, 20, 15);
+}, 60, 20);
+
+// Braille canvas
+ui.canvas(40, 12, |cv| {
+    cv.set_color(Color::Cyan);
+    cv.circle(40, 24, 20);
+    cv.line(0, 0, 79, 47);
 });
-ui.candlestick(&candles, up_color, down_color);
 ```
 
-This is the most visualization-heavy part of the library.
+---
 
-## AI-native and rich terminal output
+## AI-Native & Rich Terminal
 
-```rust
-ui.streaming_text(&mut stream);
-ui.streaming_markdown(&mut md_stream);
-ui.tool_approval(&mut tool);
-ui.context_bar(&items);
-ui.image(&img);
-ui.sixel_image(&rgba, w, h, cols, rows);
-ui.kitty_image(&rgba, pw, ph, cols, rows);
-ui.qr_code("https://example.com");
-```
+All return `Response`.
 
-These APIs support terminals that need richer output than plain text widgets.
+| Method | State type | Description |
+|---|---|---|
+| `streaming_text(state)` | `StreamingTextState` | Incrementally rendered text stream |
+| `streaming_markdown(state)` | `StreamingMarkdownState` | Incrementally rendered Markdown stream |
+| `tool_approval(state)` | `ToolApprovalState` | Tool call approval dialog. `ApprovalAction`: `Approve`, `Deny`, `Edit` |
+| `context_bar(items)` | `&[ContextItem]` | Context display with token counts |
+| `image(img)` | `HalfBlockImage` | Half-block image rendering (2 pixels per cell) |
+| `kitty_image(rgba, pw, ph, cols, rows)` | — | Kitty graphics protocol image |
+| `kitty_image_fit(rgba, sw, sh, cols)` | — | Auto-fit Kitty image to column width |
+| `sixel_image(rgba, pw, ph, cols, rows)` | — | Sixel protocol image (requires `crossterm`) |
+| `rich_log(state)` | `RichLogState` | Scrollable styled log viewer |
+
+---
+
+## Runtime & Hooks
+
+These are not widgets but essential `Context` methods for state, input, and environment.
+
+### State management
+
+| Method | Returns | Description |
+|---|---|---|
+| `use_state(init)` | `State<T>` | Persistent state across frames. Read with `.get(ui)`, write with `.set(ui, val)` |
+| `use_memo(deps, compute)` | `&T` | Memoized computation, recomputes when `deps` changes |
+
+### Focus & interaction
+
+| Method | Returns | Description |
+|---|---|---|
+| `register_focusable()` | `bool` | Register current widget as focusable, returns whether it has focus |
+| `interaction()` | `Response` | Get click/hover Response for current interaction slot |
+| `widget(w)` | `W::Response` | Render a custom `Widget` trait implementor |
+| `error_boundary(f)` | — | Catch panics in closure, render error message. Variant: `error_boundary_with(f, fallback)` |
+| `focus_index()` | `usize` | Current focus index |
+| `set_focus_index(index)` | — | Set focus index programmatically |
+| `focus_count()` | `usize` | Total focusable widget count |
+
+### Keyboard input
+
+| Method | Returns | Description |
+|---|---|---|
+| `key(c)` | `bool` | Char key pressed (non-consuming) |
+| `key_code(code)` | `bool` | KeyCode pressed (non-consuming) |
+| `raw_key_code(code)` | `bool` | KeyCode pressed, ignoring consumed state |
+| `consume_key(c)` | `bool` | Char key pressed (marks as consumed) |
+| `consume_key_code(code)` | `bool` | KeyCode pressed (marks as consumed) |
+| `key_mod(c, mods)` | `bool` | Char + modifier (Ctrl, Alt, Shift) |
+| `raw_key_mod(c, mods)` | `bool` | Char + modifier, ignoring consumed state |
+| `key_seq(seq)` | `bool` | Multi-key sequence detection |
+| `key_release(c)` | `bool` | Char key released |
+| `key_code_release(code)` | `bool` | KeyCode released |
+
+### Mouse input
+
+| Method | Returns | Description |
+|---|---|---|
+| `mouse_down()` | `Option<(u32, u32)>` | Mouse button down position |
+| `mouse_pos()` | `Option<(u32, u32)>` | Current mouse position |
+| `scroll_up()` / `scroll_down()` | `bool` | Vertical scroll events |
+| `scroll_left()` / `scroll_right()` | `bool` | Horizontal scroll events |
+
+### Clipboard & system
+
+| Method | Returns | Description |
+|---|---|---|
+| `paste()` | `Option<&str>` | Bracketed paste content |
+| `copy_to_clipboard(text)` | — | Copy text via OSC 52 |
+| `quit()` | — | Exit the application |
+
+### Theme & environment
+
+| Method | Returns | Description |
+|---|---|---|
+| `theme()` | `&Theme` | Current theme |
+| `set_theme(theme)` | — | Change theme |
+| `is_dark_mode()` | `bool` | Terminal dark mode state |
+| `set_dark_mode(dark)` | — | Override dark mode |
+| `light_dark(light, dark)` | `Color` | Pick color based on dark mode |
+| `width()` | `u32` | Terminal width in columns |
+| `height()` | `u32` | Terminal height in rows |
+| `breakpoint()` | `Breakpoint` | Responsive breakpoint (`Xs`, `Sm`, `Md`, `Lg`, `Xl`) |
+| `tick()` | `u64` | Frame counter |
+| `debug_enabled()` | `bool` | Whether debug mode is active |
+| `set_scroll_speed(lines)` | — | Set scroll speed |
+| `scroll_speed()` | `u32` | Current scroll speed |
+
+---
+
+## State Type Quick Reference
+
+| Widget | State type | Key fields / methods |
+|---|---|---|
+| `text_input` | `TextInputState` | `.value: String`, `.cursor: usize`, `.placeholder`, `::with_placeholder(s)`, `.suggestions: Vec<String>`, `.matched_suggestions()` |
+| `textarea` | `TextareaState` | `.lines: Vec<String>`, `.cursor_row`, `.cursor_col`, `.word_wrap`, `.max_length` |
+| `select` | `SelectState` | `.options: Vec<String>`, `.selected: usize`, `.open: bool` |
+| `radio` | `RadioState` | `.options: Vec<String>`, `.selected: usize` |
+| `multi_select` | `MultiSelectState` | `.options: Vec<String>`, `.selected: HashSet<usize>` |
+| `tabs` | `TabsState` | `.labels: Vec<String>`, `.active: usize`, `::new(labels)` |
+| `list` | `ListState` | `.items: Vec<String>`, `.selected: usize`, `.scroll_offset` |
+| `table` | `TableState` | `.headers`, `.rows`, `.selected`, `.sort_column`, `.sort_ascending`, `.page`, `.page_size`, `.filter`, `::new(headers, rows)` |
+| `tree` | `TreeState` | `.nodes`, `.selected`, `.expanded: HashSet` |
+| `directory_tree` | `DirectoryTreeState` | `.root: PathBuf`, `.selected_path()` |
+| `calendar` | `CalendarState` | `.year`, `.month`, `.cursor_day`, `.selected_date()` |
+| `file_picker` | `FilePickerState` | `.current_dir`, `.selected_path()` |
+| `command_palette` | `CommandPaletteState` | `.commands: Vec<CommandItem>`, `.open`, `.input`, `.selected()` |
+| `scroll` | `ScrollState` | `.offset`, `.content_height`, `.viewport_height` |
+| `spinner` | `SpinnerState` | `::dots()`, `::line()`, `.frame(tick)` |
+| `toast` | `ToastState` | `.push(msg, level)`, `.messages`, `.cleanup(tick)` |
+| `form` | `FormState` | `.fields: Vec<FormField>`, `.submit_label` |
+| `form_field` | `FormField` | `.label`, `.value`, `.placeholder`, `.validator`, `.error` |
+| `screen` | `ScreenState` | `.current()`, `.set(name)`, `::new(initial)` |
+| `streaming_text` | `StreamingTextState` | `.push(text)`, `.text()`, `.done` |
+| `streaming_markdown` | `StreamingMarkdownState` | `.push(text)`, `.done` |
+| `tool_approval` | `ToolApprovalState` | `.tool_name`, `.description`, `.action: Option<ApprovalAction>` |
+| `rich_log` | `RichLogState` | `.push(line, style)`, `.lines`, `.scroll` |
+
+---
+
+## ContainerBuilder Quick Reference
+
+Obtained via `ui.container()`, `ui.bordered(border)`, `ui.scrollable(state)`, or `ui.group(name)`.
+Finalize with `.col(f)`, `.row(f)`, or `.draw(f)`.
+
+### Border & style
+
+| Method | Description |
+|---|---|
+| `.border(border)` | Set border type (`Border::Single`, `Rounded`, `Double`, `Heavy`, etc.) |
+| `.border_sides(sides)` | Which sides to draw. Shortcuts: `.border_x()`, `.border_y()`, `.border_top(bool)`, `.border_right(bool)`, `.border_bottom(bool)`, `.border_left(bool)` |
+| `.rounded()` | Shorthand for `.border(Border::Rounded)` |
+| `.border_style(style)` | Style for border lines |
+| `.border_fg(color)` | Border foreground color |
+| `.dark_border_style(style)` | Border style override in dark mode |
+| `.bg(color)` / `.dark_bg(color)` | Background color (with dark mode variant) |
+| `.text_color(color)` | Default text color for children |
+| `.group_hover_bg(color)` | Background on group hover |
+| `.group_hover_border_style(style)` | Border style on group hover |
+| `.title(text)` / `.title_styled(text, style)` | Title displayed in border |
+
+### Spacing
+
+| Method | Description |
+|---|---|
+| `.p(n)` / `.pad(n)` | Uniform padding |
+| `.px(n)` / `.py(n)` | Horizontal / vertical padding |
+| `.pt(n)` / `.pr(n)` / `.pb(n)` / `.pl(n)` | Individual side padding |
+| `.padding(Padding)` | Full `Padding` struct |
+| `.m(n)` | Uniform margin |
+| `.mx(n)` / `.my(n)` | Horizontal / vertical margin |
+| `.mt(n)` / `.mr(n)` / `.mb(n)` / `.ml(n)` | Individual side margin |
+| `.margin(Margin)` | Full `Margin` struct |
+| `.gap(n)` | Gap between children |
+| `.row_gap(n)` / `.col_gap(n)` | Direction-specific gap |
+
+### Size constraints
+
+| Method | Description |
+|---|---|
+| `.w(n)` / `.h(n)` | Fixed width / height |
+| `.min_w(n)` / `.max_w(n)` | Min / max width |
+| `.min_h(n)` / `.max_h(n)` | Min / max height |
+| `.w_pct(p)` / `.h_pct(p)` | Percentage of parent (`u8`, 0-100) |
+| `.constraints(Constraints)` | Full `Constraints` struct |
+
+### Layout
+
+| Method | Description |
+|---|---|
+| `.grow(n)` | Flex grow factor |
+| `.align(Align)` | Cross-axis alignment (`Start`, `Center`, `End`) |
+| `.center()` | Shorthand for `.align(Align::Center)` |
+| `.align_self(Align)` | Override parent's cross-axis alignment |
+| `.justify(Justify)` | Main-axis justification |
+| `.space_between()` / `.space_around()` / `.space_evenly()` | Justify shortcuts |
+| `.flex_center()` | `.center().justify(Justify::Center)` |
+| `.scroll_offset(n)` | Manual scroll offset |
+
+### Responsive (breakpoint variants)
+
+Most size/spacing methods have breakpoint variants: `_xs`, `_sm`, `_md`, `_lg`, `_xl`, `_at(breakpoint)`.
+Example: `.w_sm(40)` sets width to 40 only at the `Sm` breakpoint.
+
+### Finalization
+
+| Method | Description |
+|---|---|
+| `.col(f)` | Render as vertical container, returns `Response` |
+| `.row(f)` | Render as horizontal container, returns `Response` |
+| `.draw(f)` | Raw buffer access. Closure: `FnOnce(&mut Buffer, Rect) + 'static` |
+| `.apply(style)` | Apply a `ContainerStyle` struct |
+
+---
+
+## CanvasContext Quick Reference
+
+Received in `ui.canvas(w, h, |cv| { ... })`. Coordinates are in pixel space (cols*2 x rows*4 braille resolution).
+
+| Method | Description |
+|---|---|
+| `.width()` / `.height()` | Pixel dimensions |
+| `.dot(x, y)` | Set single pixel |
+| `.line(x0, y0, x1, y1)` | Bresenham line |
+| `.rect(x, y, w, h)` | Rectangle outline |
+| `.filled_rect(x, y, w, h)` | Filled rectangle |
+| `.circle(cx, cy, r)` | Circle outline |
+| `.filled_circle(cx, cy, r)` | Filled circle |
+| `.triangle(x0, y0, x1, y1, x2, y2)` | Triangle outline |
+| `.filled_triangle(x0, y0, x1, y1, x2, y2)` | Filled triangle |
+| `.points(pts)` | Multiple dots from `&[(usize, usize)]` |
+| `.polyline(pts)` | Connected line segments from `&[(usize, usize)]` |
+| `.print(x, y, text)` | Text label overlay at pixel position |
+| `.set_color(color)` / `.color()` | Set/get drawing color |
+| `.layer()` | Start a new z-layer (later layers overlay earlier ones) |
+
+---
 
 ## Where to look in the codebase
 
-- `src/context/widgets_display.rs` - display/layout facade
-- `src/context/widgets_display/` - text, rich output, status, layout/container subfiles
-- `src/context/widgets_input.rs` - input facade
-- `src/context/widgets_input/` - text input, feedback, textarea/progress subfiles
-- `src/context/widgets_interactive.rs` - interactive facade
-- `src/context/widgets_interactive/` - collections, selection, rich markdown, events, tree widget subfiles
-- `src/context/widgets_viz.rs` - chart and visualization widgets
-- `src/widgets.rs` - public state catalog facade
-- `src/widgets/` - grouped `*State` definitions
+| Path | Contents |
+|---|---|
+| `src/context/widgets_display.rs` | Display/layout module root |
+| `src/context/widgets_display/text.rs` | `text`, `styled`, `link`, `spacer`, `timer_display`, `help_from_keymap` |
+| `src/context/widgets_display/status.rs` | `alert`, `badge`, `stat`, `breadcrumb`, `accordion`, `code_block`, `divider_text`, `definition_list`, `empty_state`, `confirm`, `key_hint` |
+| `src/context/widgets_display/rich_output.rs` | `big_text`, `image`, `kitty_image`, `sixel_image`, `streaming_text`, `streaming_markdown`, `tool_approval`, `context_bar` |
+| `src/context/widgets_display/layout.rs` | `col`, `row`, `line`, `line_wrap`, `grid`, `modal`, `overlay`, `tooltip`, `group`, `container`, `scrollable`, `scrollbar`, `bordered`, `screen`, `form`, `form_field`, `form_submit` |
+| `src/context/widgets_input/text_input.rs` | `text_input`, `text_input_colored` |
+| `src/context/widgets_input/textarea_progress.rs` | `textarea`, `progress`, `progress_bar` |
+| `src/context/widgets_input/feedback.rs` | `spinner`, `toast`, `slider`, `notify` |
+| `src/context/widgets_interactive/selection.rs` | `table`, `tabs`, `button`, `checkbox`, `toggle`, `select`, `radio`, `multi_select` |
+| `src/context/widgets_interactive/collections.rs` | `list`, `calendar`, `file_picker` |
+| `src/context/widgets_interactive/tree_widgets.rs` | `tree`, `directory_tree` |
+| `src/context/widgets_interactive/rich_markdown.rs` | `markdown`, `virtual_list`, `command_palette`, `rich_log`, `key_seq` |
+| `src/context/widgets_interactive/events.rs` | Key/mouse input, clipboard, theme, environment queries, `help`, `help_colored` |
+| `src/context/runtime.rs` | `use_state`, `use_memo`, `register_focusable`, `widget`, `error_boundary`, `notify`, `light_dark`, focus/scroll management |
+| `src/context/container.rs` | `ContainerBuilder`, `CanvasContext` |
+| `src/context/state.rs` | `Response`, `State<T>` |
+| `src/widgets.rs` | All `*State` types (facade) |
+| `src/widgets/` | Grouped state definitions: `input.rs`, `collections.rs`, `feedback.rs`, `selection.rs`, `commanding.rs` |
 
-If you are contributing a new widget, read `CONTRIBUTING.md`, `docs/DESIGN_PRINCIPLES.md`, and `docs/ARCHITECTURE.md` first.
+If you are contributing a new widget, read [CONTRIBUTING.md](../CONTRIBUTING.md), [DESIGN_PRINCIPLES.md](DESIGN_PRINCIPLES.md), and [ARCHITECTURE.md](ARCHITECTURE.md) first.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -191,7 +191,7 @@ impl Buffer {
     /// Panics if `(x, y)` is out of bounds.
     #[inline]
     pub fn get(&self, x: u32, y: u32) -> &Cell {
-        debug_assert!(
+        assert!(
             self.in_bounds(x, y),
             "Buffer::get({x}, {y}) out of bounds for area {:?}",
             self.area
@@ -204,7 +204,7 @@ impl Buffer {
     /// Panics if `(x, y)` is out of bounds.
     #[inline]
     pub fn get_mut(&mut self, x: u32, y: u32) -> &mut Cell {
-        debug_assert!(
+        assert!(
             self.in_bounds(x, y),
             "Buffer::get_mut({x}, {y}) out of bounds for area {:?}",
             self.area

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -37,6 +37,9 @@ impl<T: 'static> State<T> {
 ///
 /// Container methods return a [`Response`]. Check `.clicked`, `.changed`, etc.
 /// to react to user interactions.
+/// `rect` is meaningful after the widget has participated in layout.
+/// Container responses describe the container's own interaction area, not
+/// automatically the focus state of every child widget.
 ///
 /// # Examples
 ///

--- a/src/context/widget.rs
+++ b/src/context/widget.rs
@@ -2,6 +2,9 @@
 ///
 /// Implement this trait to build reusable, composable widgets with full access
 /// to the [`Context`] API — focus, events, theming, layout, and mouse interaction.
+/// Choose `Self::Response` based on what the widget needs to report:
+/// `()` for pure display, `bool` for simple changed/not-changed signals,
+/// or [`Response`] for click/hover/focus-aware interaction.
 ///
 /// # Examples
 ///

--- a/src/context/widgets_display/layout.rs
+++ b/src/context/widgets_display/layout.rs
@@ -66,6 +66,9 @@ impl Context {
     /// Unlike [`row`](Context::row), `line()` is designed for rich text —
     /// children are rendered as continuous inline text without gaps.
     ///
+    /// It intentionally returns `&mut Self` instead of [`Response`] so you can
+    /// keep chaining display-oriented modifiers after composing the inline run.
+    ///
     /// # Example
     ///
     /// ```no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 
 //! # SLT — Super Light TUI
 //!
-//! Immediate-mode terminal UI for Rust. Two dependencies. Zero `unsafe`.
+//! Immediate-mode terminal UI for Rust. Small core. Zero `unsafe`.
 //!
 //! SLT gives you an egui-style API for terminals: your closure runs each frame,
 //! you describe your UI, and SLT handles layout, diffing, and rendering.
@@ -47,8 +47,20 @@
 //!
 //! | Flag | Description |
 //! |------|-------------|
+//! | `crossterm` | Built-in terminal runtime (`run`, `run_inline`, clipboard query helpers). Enabled by default. |
 //! | `async` | Enable `run_async()` with tokio channel-based message passing |
 //! | `serde` | Enable Serialize/Deserialize for Style, Color, Theme, and layout types |
+//! | `image` | Enable image-loading helpers for terminal image widgets |
+//! | `qrcode` | Enable `ui.qr_code(...)` |
+//! | `syntax` / `syntax-*` | Enable tree-sitter syntax highlighting |
+//!
+//! ## Learn More
+//!
+//! - Guides index: <https://github.com/subinium/SuperLightTUI/blob/main/docs/README.md>
+//! - Quick start: <https://github.com/subinium/SuperLightTUI/blob/main/docs/QUICK_START.md>
+//! - Backends and run loops: <https://github.com/subinium/SuperLightTUI/blob/main/docs/BACKENDS.md>
+//! - Testing: <https://github.com/subinium/SuperLightTUI/blob/main/docs/TESTING.md>
+//! - Debugging: <https://github.com/subinium/SuperLightTUI/blob/main/docs/DEBUGGING.md>
 
 pub mod anim;
 pub mod buffer;
@@ -258,6 +270,10 @@ impl Default for AppState {
 /// * `events` — Input events for this frame (keyboard, mouse, resize)
 /// * `f` — Your UI closure, called once per frame
 ///
+/// Build a fresh event slice each frame in your outer loop, then pass it here.
+/// `frame()` reads from that slice but does not own your event source.
+/// Reuse the same [`AppState`] for the lifetime of the session.
+///
 /// # Example
 ///
 /// ```ignore
@@ -276,7 +292,7 @@ pub fn frame(
     events: &[Event],
     f: &mut impl FnMut(&mut Context),
 ) -> io::Result<bool> {
-    run_frame(backend, &mut state.inner, config, events, f)
+    run_frame(backend, &mut state.inner, config, events.to_vec(), f)
 }
 
 #[cfg(feature = "crossterm")]
@@ -333,6 +349,7 @@ fn install_panic_hook() {
 ///
 /// Pass to [`run_with`] or [`run_inline_with`] to customize behavior.
 /// Use [`Default::default()`] for sensible defaults (16ms tick / 60fps, no mouse, dark theme).
+/// This type is `#[non_exhaustive]`, so prefer builder methods instead of struct literals.
 ///
 /// # Example
 ///
@@ -572,54 +589,20 @@ pub fn run_with(config: RunConfig, mut f: impl FnMut(&mut Context)) -> io::Resul
             continue;
         }
 
-        if !run_frame(&mut term, &mut state, &config, &events, &mut f)? {
+        if !run_frame(
+            &mut term,
+            &mut state,
+            &config,
+            std::mem::take(&mut events),
+            &mut f,
+        )? {
             break;
         }
 
-        events.clear();
-        if crossterm::event::poll(config.tick_rate)? {
-            let raw = crossterm::event::read()?;
-            if let Some(ev) = event::from_crossterm(raw) {
-                if is_ctrl_c(&ev) {
-                    break;
-                }
-                if let Event::Resize(_, _) = &ev {
-                    term.handle_resize()?;
-                }
-                events.push(ev);
-            }
-
-            while crossterm::event::poll(Duration::ZERO)? {
-                let raw = crossterm::event::read()?;
-                if let Some(ev) = event::from_crossterm(raw) {
-                    if is_ctrl_c(&ev) {
-                        return Ok(());
-                    }
-                    if let Event::Resize(_, _) = &ev {
-                        term.handle_resize()?;
-                    }
-                    events.push(ev);
-                }
-            }
-
-            for ev in &events {
-                if matches!(
-                    ev,
-                    Event::Key(event::KeyEvent {
-                        code: KeyCode::F(12),
-                        kind: event::KeyEventKind::Press,
-                        ..
-                    })
-                ) {
-                    state.debug_mode = !state.debug_mode;
-                }
-            }
-        }
-
-        update_last_mouse_pos(&mut state, &events);
-
-        if events.iter().any(|e| matches!(e, Event::Resize(_, _))) {
-            clear_frame_layout_cache(&mut state);
+        if !poll_events(&mut events, &mut state, config.tick_rate, &mut || {
+            term.handle_resize()
+        })? {
+            break;
         }
 
         sleep_for_fps_cap(config.max_fps, frame_start);
@@ -713,40 +696,21 @@ fn run_async_loop<M: Send + 'static>(
         let mut render = |ctx: &mut Context| {
             f(ctx, &mut messages);
         };
-        if !run_frame(&mut term, &mut state, &config, &events, &mut render)? {
+        if !run_frame(
+            &mut term,
+            &mut state,
+            &config,
+            std::mem::take(&mut events),
+            &mut render,
+        )? {
             break;
         }
 
-        events.clear();
-        if crossterm::event::poll(config.tick_rate)? {
-            let raw = crossterm::event::read()?;
-            if let Some(ev) = event::from_crossterm(raw) {
-                if is_ctrl_c(&ev) {
-                    break;
-                }
-                if let Event::Resize(_, _) = &ev {
-                    term.handle_resize()?;
-                    clear_frame_layout_cache(&mut state);
-                }
-                events.push(ev);
-            }
-
-            while crossterm::event::poll(Duration::ZERO)? {
-                let raw = crossterm::event::read()?;
-                if let Some(ev) = event::from_crossterm(raw) {
-                    if is_ctrl_c(&ev) {
-                        return Ok(());
-                    }
-                    if let Event::Resize(_, _) = &ev {
-                        term.handle_resize()?;
-                        clear_frame_layout_cache(&mut state);
-                    }
-                    events.push(ev);
-                }
-            }
+        if !poll_events(&mut events, &mut state, config.tick_rate, &mut || {
+            term.handle_resize()
+        })? {
+            break;
         }
-
-        update_last_mouse_pos(&mut state, &events);
 
         sleep_for_fps_cap(config.max_fps, frame_start);
     }
@@ -759,6 +723,9 @@ fn run_async_loop<M: Send + 'static>(
 /// Renders `height` rows directly below the current cursor position without
 /// entering alternate screen mode. Useful for CLI tools that want a small
 /// interactive widget below the prompt.
+///
+/// `height` is the reserved inline render area in terminal rows.
+/// The rest of the terminal stays in normal scrollback mode.
 ///
 /// # Example
 ///
@@ -806,54 +773,20 @@ pub fn run_inline_with(
             continue;
         }
 
-        if !run_frame(&mut term, &mut state, &config, &events, &mut f)? {
+        if !run_frame(
+            &mut term,
+            &mut state,
+            &config,
+            std::mem::take(&mut events),
+            &mut f,
+        )? {
             break;
         }
 
-        events.clear();
-        if crossterm::event::poll(config.tick_rate)? {
-            let raw = crossterm::event::read()?;
-            if let Some(ev) = event::from_crossterm(raw) {
-                if is_ctrl_c(&ev) {
-                    break;
-                }
-                if let Event::Resize(_, _) = &ev {
-                    term.handle_resize()?;
-                }
-                events.push(ev);
-            }
-
-            while crossterm::event::poll(Duration::ZERO)? {
-                let raw = crossterm::event::read()?;
-                if let Some(ev) = event::from_crossterm(raw) {
-                    if is_ctrl_c(&ev) {
-                        return Ok(());
-                    }
-                    if let Event::Resize(_, _) = &ev {
-                        term.handle_resize()?;
-                    }
-                    events.push(ev);
-                }
-            }
-
-            for ev in &events {
-                if matches!(
-                    ev,
-                    Event::Key(event::KeyEvent {
-                        code: KeyCode::F(12),
-                        kind: event::KeyEventKind::Press,
-                        ..
-                    })
-                ) {
-                    state.debug_mode = !state.debug_mode;
-                }
-            }
-        }
-
-        update_last_mouse_pos(&mut state, &events);
-
-        if events.iter().any(|e| matches!(e, Event::Resize(_, _))) {
-            clear_frame_layout_cache(&mut state);
+        if !poll_events(&mut events, &mut state, config.tick_rate, &mut || {
+            term.handle_resize()
+        })? {
+            break;
         }
 
         sleep_for_fps_cap(config.max_fps, frame_start);
@@ -867,6 +800,8 @@ pub fn run_inline_with(
 /// Static lines written through [`StaticOutput`] are printed into terminal
 /// scrollback, while the interactive UI stays rendered in a fixed-height inline
 /// area at the bottom.
+///
+/// Use this when you want a log-style output stream above a live inline UI.
 #[cfg(feature = "crossterm")]
 pub fn run_static(
     output: &mut StaticOutput,
@@ -904,54 +839,20 @@ pub fn run_static(
         let new_lines = output.drain_new();
         write_static_lines(&new_lines)?;
 
-        if !run_frame(&mut term, &mut state, &config, &events, &mut f)? {
+        if !run_frame(
+            &mut term,
+            &mut state,
+            &config,
+            std::mem::take(&mut events),
+            &mut f,
+        )? {
             break;
         }
 
-        events.clear();
-        if crossterm::event::poll(config.tick_rate)? {
-            let raw = crossterm::event::read()?;
-            if let Some(ev) = event::from_crossterm(raw) {
-                if is_ctrl_c(&ev) {
-                    break;
-                }
-                if let Event::Resize(_, _) = &ev {
-                    term.handle_resize()?;
-                }
-                events.push(ev);
-            }
-
-            while crossterm::event::poll(Duration::ZERO)? {
-                let raw = crossterm::event::read()?;
-                if let Some(ev) = event::from_crossterm(raw) {
-                    if is_ctrl_c(&ev) {
-                        return Ok(());
-                    }
-                    if let Event::Resize(_, _) = &ev {
-                        term.handle_resize()?;
-                    }
-                    events.push(ev);
-                }
-            }
-
-            for ev in &events {
-                if matches!(
-                    ev,
-                    Event::Key(event::KeyEvent {
-                        code: KeyCode::F(12),
-                        kind: event::KeyEventKind::Press,
-                        ..
-                    })
-                ) {
-                    state.debug_mode = !state.debug_mode;
-                }
-            }
-        }
-
-        update_last_mouse_pos(&mut state, &events);
-
-        if events.iter().any(|e| matches!(e, Event::Resize(_, _))) {
-            clear_frame_layout_cache(&mut state);
+        if !poll_events(&mut events, &mut state, config.tick_rate, &mut || {
+            term.handle_resize()
+        })? {
+            break;
         }
 
         sleep_for_fps_cap(config.max_fps, frame_start);
@@ -974,16 +875,73 @@ fn write_static_lines(lines: &[String]) -> io::Result<()> {
     stdout.flush()
 }
 
+/// Poll for terminal events, handling resize, Ctrl-C, F12 debug toggle,
+/// and layout cache invalidation. Returns `Ok(false)` when the loop should exit.
+#[cfg(feature = "crossterm")]
+fn poll_events(
+    events: &mut Vec<Event>,
+    state: &mut FrameState,
+    tick_rate: Duration,
+    on_resize: &mut impl FnMut() -> io::Result<()>,
+) -> io::Result<bool> {
+    if crossterm::event::poll(tick_rate)? {
+        let raw = crossterm::event::read()?;
+        if let Some(ev) = event::from_crossterm(raw) {
+            if is_ctrl_c(&ev) {
+                return Ok(false);
+            }
+            if matches!(ev, Event::Resize(_, _)) {
+                on_resize()?;
+            }
+            events.push(ev);
+        }
+
+        while crossterm::event::poll(Duration::ZERO)? {
+            let raw = crossterm::event::read()?;
+            if let Some(ev) = event::from_crossterm(raw) {
+                if is_ctrl_c(&ev) {
+                    return Ok(false);
+                }
+                if matches!(ev, Event::Resize(_, _)) {
+                    on_resize()?;
+                }
+                events.push(ev);
+            }
+        }
+
+        for ev in events.iter() {
+            if matches!(
+                ev,
+                Event::Key(event::KeyEvent {
+                    code: KeyCode::F(12),
+                    kind: event::KeyEventKind::Press,
+                    ..
+                })
+            ) {
+                state.debug_mode = !state.debug_mode;
+            }
+        }
+    }
+
+    update_last_mouse_pos(state, events);
+
+    if events.iter().any(|e| matches!(e, Event::Resize(_, _))) {
+        clear_frame_layout_cache(state);
+    }
+
+    Ok(true)
+}
+
 fn run_frame(
     term: &mut impl Backend,
     state: &mut FrameState,
     config: &RunConfig,
-    events: &[event::Event],
+    events: Vec<event::Event>,
     f: &mut impl FnMut(&mut context::Context),
 ) -> io::Result<bool> {
     let frame_start = Instant::now();
     let (w, h) = term.size();
-    let mut ctx = Context::new(events.to_vec(), w, h, state, config.theme);
+    let mut ctx = Context::new(events, w, h, state, config.theme);
     ctx.is_real_terminal = true;
     ctx.set_scroll_speed(config.scroll_speed);
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -137,144 +137,168 @@ fn get_config(lang: &str) -> Option<&'static HighlightConfiguration> {
     match lang {
         #[cfg(feature = "syntax-rust")]
         "rust" | "rs" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_rust::LANGUAGE.into(),
                     "rust",
                     tree_sitter_rust::HIGHLIGHTS_QUERY,
                     tree_sitter_rust::INJECTIONS_QUERY,
                     "",
                 )
-                .expect("valid rust highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-python")]
         "python" | "py" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_python::LANGUAGE.into(),
                     "python",
                     tree_sitter_python::HIGHLIGHTS_QUERY,
                     "",
                     "",
                 )
-                .expect("valid python highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-javascript")]
         "javascript" | "js" | "jsx" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_javascript::LANGUAGE.into(),
                     "javascript",
                     tree_sitter_javascript::HIGHLIGHT_QUERY,
                     tree_sitter_javascript::INJECTIONS_QUERY,
                     tree_sitter_javascript::LOCALS_QUERY,
                 )
-                .expect("valid javascript highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-go")]
         "go" | "golang" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_go::LANGUAGE.into(),
                     "go",
                     tree_sitter_go::HIGHLIGHTS_QUERY,
                     "",
                     "",
                 )
-                .expect("valid go highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-bash")]
         "bash" | "sh" | "shell" | "zsh" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_bash::LANGUAGE.into(),
                     "bash",
                     tree_sitter_bash::HIGHLIGHT_QUERY,
                     "",
                     "",
                 )
-                .expect("valid bash highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-json")]
         "json" | "jsonc" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_json::LANGUAGE.into(),
                     "json",
                     tree_sitter_json::HIGHLIGHTS_QUERY,
                     "",
                     "",
                 )
-                .expect("valid json highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-toml")]
         "toml" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_toml_ng::LANGUAGE.into(),
                     "toml",
                     tree_sitter_toml_ng::HIGHLIGHTS_QUERY,
                     "",
                     "",
                 )
-                .expect("valid toml highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-c")]
         "c" | "h" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_c::LANGUAGE.into(),
                     "c",
                     tree_sitter_c::HIGHLIGHT_QUERY,
                     "",
                     "",
                 )
-                .expect("valid c highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-cpp")]
         "cpp" | "c++" | "cxx" | "cc" | "hpp" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
                 #[cfg(feature = "syntax-c")]
                 let highlights = {
                     let mut combined = String::with_capacity(
@@ -290,136 +314,160 @@ fn get_config(lang: &str) -> Option<&'static HighlightConfiguration> {
                 #[cfg(not(feature = "syntax-c"))]
                 let highlights = tree_sitter_cpp::HIGHLIGHT_QUERY.to_string();
 
-                let mut c = HighlightConfiguration::new(
+                HighlightConfiguration::new(
                     tree_sitter_cpp::LANGUAGE.into(),
                     "cpp",
                     &highlights,
                     "",
                     "",
                 )
-                .expect("valid cpp highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-typescript")]
         "typescript" | "ts" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
                     "typescript",
                     tree_sitter_typescript::HIGHLIGHTS_QUERY,
                     tree_sitter_typescript::LOCALS_QUERY,
                     "",
                 )
-                .expect("valid typescript highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-typescript")]
         "tsx" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_typescript::LANGUAGE_TSX.into(),
                     "tsx",
                     tree_sitter_typescript::HIGHLIGHTS_QUERY,
                     tree_sitter_typescript::LOCALS_QUERY,
                     "",
                 )
-                .expect("valid tsx highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-java")]
         "java" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_java::LANGUAGE.into(),
                     "java",
                     tree_sitter_java::HIGHLIGHTS_QUERY,
                     "",
                     "",
                 )
-                .expect("valid java highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-ruby")]
         "ruby" | "rb" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_ruby::LANGUAGE.into(),
                     "ruby",
                     tree_sitter_ruby::HIGHLIGHTS_QUERY,
                     tree_sitter_ruby::LOCALS_QUERY,
                     "",
                 )
-                .expect("valid ruby highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-css")]
         "css" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_css::LANGUAGE.into(),
                     "css",
                     tree_sitter_css::HIGHLIGHTS_QUERY,
                     "",
                     "",
                 )
-                .expect("valid css highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-html")]
         "html" | "htm" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_html::LANGUAGE.into(),
                     "html",
                     tree_sitter_html::HIGHLIGHTS_QUERY,
                     tree_sitter_html::INJECTIONS_QUERY,
                     "",
                 )
-                .expect("valid html highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         #[cfg(feature = "syntax-yaml")]
         "yaml" | "yml" => {
-            static CFG: OnceLock<HighlightConfiguration> = OnceLock::new();
-            Some(CFG.get_or_init(|| {
-                let mut c = HighlightConfiguration::new(
+            static CFG: OnceLock<Option<HighlightConfiguration>> = OnceLock::new();
+            CFG.get_or_init(|| {
+                HighlightConfiguration::new(
                     tree_sitter_yaml::LANGUAGE.into(),
                     "yaml",
                     tree_sitter_yaml::HIGHLIGHTS_QUERY,
                     "",
                     "",
                 )
-                .expect("valid yaml highlight config");
-                c.configure(HIGHLIGHT_NAMES);
-                c
-            }))
+                .ok()
+                .map(|mut c| {
+                    c.configure(HIGHLIGHT_NAMES);
+                    c
+                })
+            })
+            .as_ref()
         }
 
         _ => None,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -19,6 +19,12 @@ use crate::buffer::{Buffer, KittyPlacement};
 use crate::rect::Rect;
 use crate::style::{Color, ColorDepth, Modifiers, Style};
 
+/// Saturating cast from `u32` to `u16` — clamps to `u16::MAX` instead of truncating.
+#[inline]
+fn sat_u16(v: u32) -> u16 {
+    v.min(u16::MAX as u32) as u16
+}
+
 // ---------------------------------------------------------------------------
 // Kitty graphics protocol image manager
 // ---------------------------------------------------------------------------
@@ -138,7 +144,7 @@ impl KittyImageManager {
         placement_id: u32,
         p: &KittyPlacement,
     ) -> io::Result<()> {
-        queue!(stdout, cursor::MoveTo(p.x as u16, p.y as u16))?;
+        queue!(stdout, cursor::MoveTo(sat_u16(p.x), sat_u16(p.y)))?;
 
         let mut cmd = format!(
             "\x1b_Ga=p,i={},p={},c={},r={},C=1,q=2",
@@ -342,7 +348,7 @@ impl Terminal {
 
                 let need_move = last_pos.map_or(true, |(lx, ly)| ly != y || lx != x);
                 if need_move {
-                    queue!(self.stdout, cursor::MoveTo(x as u16, y as u16))?;
+                    queue!(self.stdout, cursor::MoveTo(sat_u16(x), sat_u16(y)))?;
                 }
 
                 if cur.style != last_style {
@@ -394,7 +400,7 @@ impl Terminal {
         // Raw sequences (sixel, other passthrough) — simple diff
         if self.current.raw_sequences != self.previous.raw_sequences {
             for (x, y, seq) in &self.current.raw_sequences {
-                queue!(self.stdout, cursor::MoveTo(*x as u16, *y as u16))?;
+                queue!(self.stdout, cursor::MoveTo(sat_u16(*x), sat_u16(*y)))?;
                 queue!(self.stdout, Print(seq))?;
             }
         }
@@ -408,7 +414,7 @@ impl Terminal {
                     queue!(self.stdout, cursor::Show)?;
                     self.cursor_visible = true;
                 }
-                queue!(self.stdout, cursor::MoveTo(cx as u16, cy as u16))?;
+                queue!(self.stdout, cursor::MoveTo(sat_u16(cx), sat_u16(cy)))?;
             }
             None => {
                 if self.cursor_visible {
@@ -508,9 +514,9 @@ impl InlineTerminal {
             self.reserved = true;
 
             let (_, rows) = terminal::size()?;
-            let bottom = self.start_row + self.height as u16;
+            let bottom = self.start_row.saturating_add(sat_u16(self.height));
             if bottom > rows {
-                self.start_row = rows.saturating_sub(self.height as u16);
+                self.start_row = rows.saturating_sub(sat_u16(self.height));
             }
         }
 
@@ -532,7 +538,7 @@ impl InlineTerminal {
                 let abs_y = self.start_row as u32 + y;
                 let need_move = last_pos.map_or(true, |(lx, ly)| ly != abs_y || lx != x);
                 if need_move {
-                    queue!(self.stdout, cursor::MoveTo(x as u16, abs_y as u16))?;
+                    queue!(self.stdout, cursor::MoveTo(sat_u16(x), sat_u16(abs_y)))?;
                 }
 
                 if cell.style != last_style {
@@ -595,7 +601,7 @@ impl InlineTerminal {
         if self.current.raw_sequences != self.previous.raw_sequences {
             for (x, y, seq) in &self.current.raw_sequences {
                 let abs_y = self.start_row as u32 + *y;
-                queue!(self.stdout, cursor::MoveTo(*x as u16, abs_y as u16))?;
+                queue!(self.stdout, cursor::MoveTo(sat_u16(*x), sat_u16(abs_y)))?;
                 queue!(self.stdout, Print(seq))?;
             }
         }
@@ -610,14 +616,16 @@ impl InlineTerminal {
                     queue!(self.stdout, cursor::Show)?;
                     self.cursor_visible = true;
                 }
-                queue!(self.stdout, cursor::MoveTo(cx as u16, abs_cy as u16))?;
+                queue!(self.stdout, cursor::MoveTo(sat_u16(cx), sat_u16(abs_cy)))?;
             }
             None => {
                 if self.cursor_visible {
                     queue!(self.stdout, cursor::Hide)?;
                     self.cursor_visible = false;
                 }
-                let end_row = self.start_row + self.height.saturating_sub(1) as u16;
+                let end_row = self
+                    .start_row
+                    .saturating_add(sat_u16(self.height.saturating_sub(1)));
                 queue!(self.stdout, cursor::MoveTo(0, end_row))?;
             }
         }

--- a/src/terminal/selection.rs
+++ b/src/terminal/selection.rs
@@ -120,7 +120,7 @@ pub(crate) fn apply_selection_overlay(
             } else {
                 true
             };
-            if in_sel {
+            if in_sel && buffer.in_bounds(x, y) {
                 let cell = buffer.get_mut(x, y);
                 cell.style.modifiers |= Modifiers::REVERSED;
             }
@@ -158,7 +158,7 @@ pub(crate) fn extract_selection_text(
             rect.right().saturating_sub(1)
         };
         for x in x_lo..=x_hi {
-            if is_border_cell(x, y, content_map) {
+            if is_border_cell(x, y, content_map) || !buffer.in_bounds(x, y) {
                 continue;
             }
             let sym = &buffer.get(x, y).symbol;


### PR DESCRIPTION
## Summary

- **7 new documentation guides**: Animation, Theming, Backends, Testing, Debugging, Features, AI Guide
- **WIDGETS.md rewritten** as complete API catalog (~290 lines covering every widget, state type, ContainerBuilder, CanvasContext)
- **4 translations synced** (ko, zh-CN, ja, es) with current English README structure
- **Buffer bounds safety**: `debug_assert!` → `assert!` in release builds + selection overlay guards
- **F12 bug fix**: async run loop was missing debug toggle
- **Events clone eliminated**: `std::mem::take` ownership transfer instead of per-frame `to_vec()`
- **Run loop dedup**: `poll_events()` extracted from 4 duplicated loops (~160 LOC reduction)
- **Saturating u16 casts**: all `as u16` in terminal.rs replaced with `sat_u16()` helper
- **Syntax graceful degradation**: tree-sitter config failures return `None` instead of panicking

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo check --all-features`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --all-features` (56 doc + 213 unit/integration, 0 failures)
- [x] `cargo check --examples --all-features`
- [x] `cargo check -p superlighttui --no-default-features`
- [x] `cargo check -p slt-wasm --target wasm32-unknown-unknown`
- [x] `typos`
- [ ] CI pipeline (cargo-hack, cargo-audit, cargo-deny)

🤖 Generated with [Claude Code](https://claude.com/claude-code)