### PR TITLE
release: v0.19.0 — component DX (provide / use_context / use_state_named / with_if)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+## [0.19.0] — 2026-04-21
+
+### Features
+
+- **`ui.provide(value, |ui| ...)` + `ui.use_context::<T>()` + `ui.try_use_context::<T>()`** — scoped context injection for values that cross 3+ scope levels (theme, user, feature flags). No more threading `&Theme`, `&mut ToastState`, `tick` through every `render_*` parameter. Nested `provide` of the same type shadows outer (LIFO). Panic-safe pop via `std::panic::catch_unwind` + `AssertUnwindSafe`; `ContextCheckpoint` also tracks `context_stack_len` so `error_boundary` correctly unwinds partially-pushed context values. Closes #66.
+- **`ui.use_state_named(id)` + `ui.use_state_named_with(id, init)`** — component-local state keyed by a stable `&'static str` id. Safe inside conditional rendering (unlike order-based `use_state`). Reusable component functions can now own internal state (expand/collapse, pagination cursor, filter mode) without requiring the caller to allocate a state struct. State handle is the existing `State<T>` type via an internal `StateKey::Named(&'static str)` discriminant — no new public type. Closes #71.
+- **`.with_if(cond, modifier)` + `.with(modifier)`** — fluent conditional styling on text and `ContainerBuilder`. Compresses the 8-line `if cond { t.bold(); t.fg(Color::Red); }` pattern into one chained call. Two signatures: text uses `FnOnce(&mut Self)` (mutable-handle style to match existing text modifiers), container uses `FnOnce(Self) -> Self` (by-value to match existing builder idiom). Closes #68.
+
+### Documentation
+
+- **`docs/PATTERNS.md`** — new `## Components` section (~250 lines) covering "Components as Functions" (canonical pattern), "Component-local State with `use_state_named`", "Context Injection with `ui.provide` / `ui.use_context`", "Conditional Styling with `.with_if`", plus a `When to use which` comparison table and an `Anti-patterns` closer. Cross-links to COOKBOOK.md, STATE_APIS.md, COMPLETE_REFERENCE.md. Closes #72.
+- **`examples/demo_website.rs`** — refactored to showcase the new APIs. Root closure calls `ui.provide(AppState { theme, tick }, |ui| ...)`; `render_home` / `render_docs` / etc. read theme and tick via `ui.use_context::<AppState>()` instead of receiving them as parameters. Mutation-heavy sections retain explicit `&mut` params for clarity (context for reads, explicit params for writes). Closes #75.
+
+### Tests
+
+- `tests/context_provider.rs` (8 tests) — round-trip, nested same-type shadowing, two different types coexisting, `try_use_context` None/Some, `use_context` panics when missing, stack pops after closure returns, `provide` returns body's value.
+- `tests/use_state_named.rs` (6 tests) — persistence across frames, independent state for different ids, same-id sharing semantics, `Default::default()` init path, type-mismatch panic, safe inside conditional rendering.
+- `tests/with_if.rs` (8 tests) — true/false branches on text and container, chained composition, `.with` unconditional variant.
+- `tests/v0_19_api_integration.rs` (10 tests) — end-to-end combinations of all three APIs together.
+
+### Semver
+
+Additive only; no breaking changes. `cargo-semver-checks` verifies compatibility.
+
 ## [0.18.2] — 2026-04-21
 
 ### Performance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slt-wasm"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "js-sys",
  "superlighttui",
@@ -1052,7 +1052,7 @@ checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "superlighttui"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "compact_str",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/slt-wasm"]
 
 [package]
 name = "superlighttui"
-version = "0.18.2"
+version = "0.19.0"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/crates/slt-wasm/Cargo.toml
+++ b/crates/slt-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slt-wasm"
-version = "0.18.2"
+version = "0.19.0"
 edition = "2021"
 description = "WASM/browser backend for SuperLightTUI"
 license = "MIT"
@@ -9,7 +9,7 @@ homepage = "https://github.com/subinium/SuperLightTUI"
 documentation = "https://docs.rs/slt-wasm"
 
 [dependencies]
-superlighttui = { version = "0.18.2", path = "../..", default-features = false }
+superlighttui = { version = "0.19.0", path = "../..", default-features = false }
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = [
     "CssStyleDeclaration",

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -119,6 +119,261 @@ fn panel(ui: &mut Context, title: &str, f: impl FnOnce(&mut Context)) {
 
 This keeps the chaining style but moves the repetition out of the screen body.
 
+## Components
+
+A "component" in SLT is not a framework concept. There is no `Component` trait, no virtual DOM, no lifecycle hooks beyond the few state primitives you already know. A component is whatever helper function you find yourself extracting when the same shape repeats.
+
+This section walks the four building blocks that make components ergonomic:
+
+1. Functions for the shape itself
+2. `use_state_named` for state that survives across frames inside the component
+3. `provide` / `use_context` for values that propagate through deep trees
+4. `.with` / `.with_if` for conditional styling
+
+The order matters. Reach for the simpler tool first.
+
+### Components as Functions (the canonical pattern)
+
+The simplest reusable component is a free function that takes `&mut Context` and any explicit state it needs. No framework magic, no registration step.
+
+```rust
+use slt::{Border, Context, Trend};
+
+fn metric_card(ui: &mut Context, label: &str, value: f64, trend: Trend) {
+    let _ = ui.bordered(Border::Single).pad(1).col(|ui| {
+        ui.text(label).dim();
+        ui.text(format!("{:.1}", value)).bold();
+        let arrow = match trend {
+            Trend::Up => "▲",
+            Trend::Down => "▼",
+            Trend::Flat => "—",
+        };
+        ui.text(arrow);
+    });
+}
+```
+
+Usage from a screen:
+
+```rust
+fn render_dashboard(ui: &mut Context, app: &App) {
+    ui.row(|ui| {
+        metric_card(ui, "Revenue", app.revenue, Trend::Up);
+        metric_card(ui, "Latency p99", app.p99_ms, Trend::Down);
+        metric_card(ui, "Active users", app.users, Trend::Flat);
+    });
+}
+```
+
+Trade-offs:
+
+- Fully explicit. Rust's ownership tells you exactly who reads and who mutates what.
+- Type-safe. The compiler enforces parameter shapes at every call site.
+- No hidden state. The function only renders; it does not remember anything between frames.
+
+The cost is parameter count. When a component grows past four or five arguments, group related values into a small struct and pass `&Props` instead of repeating five-arg signatures across the codebase.
+
+```rust
+struct MetricCardProps<'a> {
+    label: &'a str,
+    value: f64,
+    trend: Trend,
+    accent: Color,
+}
+
+fn metric_card(ui: &mut Context, p: &MetricCardProps<'_>) {
+    // ...
+}
+```
+
+This is still "just a function." No ceremony.
+
+### Component-local State with `use_state_named`
+
+Sometimes a component needs state that must survive across frames but does not belong to the caller. A collapsible panel knows whether it is expanded. A pagination control knows the current page. Threading those values up through every call site pollutes the caller's API.
+
+`use_state_named` is the answer. It is `use_state`, but keyed by an explicit `&'static str` instead of by hook call order:
+
+```rust
+use slt::{Border, Context};
+
+fn expandable_card(
+    ui: &mut Context,
+    id: &'static str,
+    title: &str,
+    body: impl FnOnce(&mut Context),
+) {
+    let expanded = ui.use_state_named::<bool>(id);
+    let _ = ui.bordered(Border::Single).col(|ui| {
+        let label = if *expanded.get(ui) { "▼" } else { "▶" };
+        if ui.button(label).clicked {
+            let v = *expanded.get(ui);
+            *expanded.get_mut(ui) = !v;
+        }
+        ui.text(title).bold();
+        if *expanded.get(ui) {
+            body(ui);
+        }
+    });
+}
+```
+
+Usage:
+
+```rust
+expandable_card(ui, "card.networking", "Networking", |ui| {
+    ui.text("eth0  192.168.1.42");
+    ui.text("wlan0 10.0.0.7");
+});
+
+expandable_card(ui, "card.disks", "Disks", |ui| {
+    ui.text("nvme0n1  931 GiB");
+});
+```
+
+When you need a default different from `Default::default()`, use `use_state_named_with`:
+
+```rust
+let page = ui.use_state_named_with::<usize>("pager", || 1);
+```
+
+Rules of the road:
+
+- IDs are `&'static str`. Pick something descriptive — `"card.networking"`, `"pager.users"`, not `"x"`.
+- Two calls with the same id at the same scope share state. This is sometimes what you want (siblings agreeing on a value) and sometimes a bug (two unrelated cards collapsing together). When in doubt, suffix with the data key: `"card.disks"` vs `"card.networking"`.
+- Unlike positional `use_state`, named state does not depend on call order. You can branch around a named-state read without losing the value next frame.
+- For the full method surface on the returned `State<T>`, see `STATE_APIS.md`.
+
+### Context Injection with `ui.provide` / `ui.use_context`
+
+Some values want to propagate through a deep tree without being passed to every function. The classic examples are theme, the current user, and feature flags. Threading them through ten render helpers is parameter-drilling, and it makes refactoring painful.
+
+`provide` makes a value available inside a closure. Anything inside that closure can read it via `use_context`:
+
+```rust
+use slt::{Color, Context};
+
+struct AppContext {
+    username: String,
+    show_debug: bool,
+}
+
+fn main() -> std::io::Result<()> {
+    slt::run(|ui| {
+        let app = AppContext {
+            username: "sb".into(),
+            show_debug: true,
+        };
+        ui.provide(app, |ui| {
+            render_home(ui);
+        });
+    })
+}
+
+fn render_home(ui: &mut Context) {
+    let app = ui.use_context::<AppContext>();
+    ui.text(format!("Hello, {}", app.username));
+    if app.show_debug {
+        ui.text("debug mode on").dim();
+    }
+}
+```
+
+How it behaves:
+
+- **Scoped.** The value is alive only inside the body closure passed to `provide`. Outside that closure, `use_context::<AppContext>()` panics — there is no value.
+- **Shadowing.** Nested `provide` calls of the same type shadow the outer one for the duration of the inner closure. Think of it as a LIFO stack, one stack per `TypeId`.
+- **Optional reads.** `try_use_context::<T>() -> Option<&T>` returns `None` instead of panicking. Use it when a component should work both inside and outside the provider.
+
+```rust
+fn render_footer(ui: &mut Context) {
+    if let Some(app) = ui.try_use_context::<AppContext>() {
+        ui.text(format!("logged in as {}", app.username)).dim();
+    } else {
+        ui.text("anonymous").dim();
+    }
+}
+```
+
+When *not* to use context:
+
+- The value lives in your top-level app struct and you already pass `&mut App` around. Do not duplicate it into context.
+- The value is needed by exactly one render helper that is two scope levels away. A parameter is clearer.
+
+A good heuristic: reach for `provide` when the same value is needed by three or more render helpers across two or more scope levels.
+
+### Conditional Styling with `.with_if`
+
+Conditional styling is everywhere — a row that highlights when selected, a label that turns red when invalid, a button that dims when disabled. Without help, this clutters the call site:
+
+```rust
+let mut t = ui.text("Status");
+if is_error {
+    t = t.bold().fg(Color::Red);
+}
+if is_selected {
+    t = t.bg(Color::DarkGray);
+}
+```
+
+`.with_if(cond, modifier)` compresses that into a chain that reads top-to-bottom:
+
+```rust
+ui.text("Status")
+    .with_if(is_error, |t| {
+        t.bold().fg(Color::Red);
+    })
+    .with_if(is_selected, |t| {
+        t.bg(Color::DarkGray);
+    });
+```
+
+The closure runs only when the condition is true. The modifier receives a mutable handle to the same builder, so you can chain any styling method inside.
+
+For unconditional grouping — factoring shared modifier blocks out of multiple call sites — use `.with(modifier)`:
+
+```rust
+fn dim_label(t: &mut TextBuilder<'_>) {
+    t.dim().italic();
+}
+
+ui.text("uptime: 3d 4h").with(dim_label);
+ui.text("region: us-west-2").with(dim_label);
+```
+
+Both `.with` and `.with_if` are available on text and on container builders, so the same idiom works for `bordered`, `row`, `col`, etc.:
+
+```rust
+ui.bordered(Border::Single)
+    .with_if(panel_focused, |c| {
+        c.title("(focused)").pad(2);
+    })
+    .col(|ui| {
+        // ...
+    });
+```
+
+### When to use which
+
+| Pattern | Use when | Example scenarios |
+|---|---|---|
+| Function + explicit args | Small components, fewer than 3-4 params | `metric_card`, `header_row`, `kv_pair` |
+| `use_state_named` | Component has LOCAL state that should survive across frames | collapsible panel, pagination cursor, sort direction |
+| `provide` / `use_context` | Values cross 3+ scope levels | theme, logged-in user, feature flags, request id |
+| `.with_if` | Styling depends on a runtime condition | selected row, error text, disabled state, focused panel |
+| `.with` | Factor shared style blocks out of multiple call sites | "dim label", "code-style text", "subtle border" |
+
+### Anti-patterns
+
+These look tempting but make code harder, not easier:
+
+- **Reaching for context when a parameter is clearer.** If a value is used in one helper, just pass it. Context is for values that propagate, not for "I do not feel like typing the parameter."
+- **Using `use_state_named` for app-level state.** Page-level state, selected tab, current user — these belong in your top-level `App` struct so that tests, persistence, and refactors stay sane. Named state is for state that is genuinely local to a component instance.
+- **Reusing the same id by accident.** `expandable_card(ui, "card", ...)` called five times shares one boolean across all five cards. Pick ids that name the *instance*, not the *kind*.
+- **Nesting `provide` purely to "override defaults."** If you find yourself wrapping every render helper in a fresh `provide`, the value should probably be a parameter or a method argument instead.
+
+For full working apps that combine these patterns, see `COOKBOOK.md`. For the per-method reference on `State<T>` and friends, see `STATE_APIS.md`. For the single-file AI-oriented reference, see `COMPLETE_REFERENCE.md`.
+
 ## Split big screens into render helpers
 
 ```rust

--- a/examples/demo_website.rs
+++ b/examples/demo_website.rs
@@ -1,7 +1,31 @@
+//! demo_website — showcase example.
+//!
+//! Refactored in v0.19.0 to demonstrate:
+//!   - `ui.provide` / `ui.use_context::<T>()` for app-wide state injection
+//!   - `.with_if(cond, modifier)` for fluent conditional styling
+//!
+//! Mutation-heavy sections still receive explicit `&mut` params for clarity
+//! (hybrid approach): context for reads (`theme`, `tick`), explicit params
+//! for writes (toasts, form state, navigation intents, modal flags).
+
 use slt::{
     Border, ButtonVariant, Color, Context, FormField, FormState, KeyCode, Padding, ScrollState,
     Style, TabsState, Theme, ToastState,
 };
+
+/// App-wide read-only state provided at the root of every frame.
+///
+/// Any helper or `render_*` function can pull these values with
+/// `ui.use_context::<AppState>()`, so they no longer need to thread
+/// `theme: &Theme` / `tick: u64` through their parameter lists.
+///
+/// Both fields are `Copy`, so callers snapshot them into locals before
+/// reaching for `&mut Context` again.
+#[derive(Clone, Copy)]
+struct AppState {
+    theme: Theme,
+    tick: u64,
+}
 
 fn main() -> std::io::Result<()> {
     let mut nav = TabsState::new(vec!["Home", "Docs", "Blog", "Pricing", "Contact"]);
@@ -68,95 +92,115 @@ fn main() -> std::io::Result<()> {
             scroll = ScrollState::new();
         }
 
-        let _ = ui.container().grow(1).col(|ui| {
-            let theme = *ui.theme();
+        // Inject AppState for the rest of the frame. Every render_* helper
+        // below reads `theme`/`tick` via `ui.use_context::<AppState>()`.
+        let app = AppState {
+            theme: *ui.theme(),
+            tick,
+        };
+        ui.provide(app, |ui| {
+            let theme = app.theme;
 
-            // ── navbar ──
-            let _ = ui
-                .container()
-                .bg(theme.surface)
-                .padding(Padding::xy(2, 0))
-                .col(|ui| {
-                    let _ = ui.row(|ui| {
-                        ui.text("SLT").bold().fg(theme.primary);
-                        ui.text(" ").fg(theme.text_dim);
-                        ui.spacer();
-                        let _ = ui.tabs(&mut nav);
-                        ui.styled(
-                            format!(" {} ", theme_names[theme_idx]),
-                            Style::new().fg(theme.text).bg(theme.surface_hover),
-                        );
-                    });
-                });
-
-            let selected = nav.selected;
-            let _ = ui.scrollable(&mut scroll).grow(1).col(|ui| {
-                match selected {
-                    0 => render_home(
-                        ui,
-                        &mut email,
-                        &mut nav_target,
-                        &mut toasts,
-                        &mut subscribed,
-                        tick,
-                    ),
-                    1 => render_docs(ui),
-                    2 => render_blog(ui, &mut blog_view),
-                    3 => render_pricing(ui, &mut toasts, tick, &mut show_modal, &mut selected_plan),
-                    _ => render_contact(ui, &mut nav_target, &mut contact_form, &mut toasts, tick),
-                }
-
-                // ── footer ──
+            let _ = ui.container().grow(1).col(|ui| {
+                // ── navbar ──
                 let _ = ui
                     .container()
                     .bg(theme.surface)
-                    .padding(Padding::xy(2, 1))
+                    .padding(Padding::xy(2, 0))
                     .col(|ui| {
                         let _ = ui.row(|ui| {
                             ui.text("SLT").bold().fg(theme.primary);
-                            ui.text("Framework").fg(theme.surface_text);
+                            ui.text(" ").fg(theme.text_dim);
                             ui.spacer();
-                            ui.text("MIT License").fg(theme.surface_text);
-                        });
-                        ui.text("");
-                        let _ = ui.row(|ui| {
-                            ui.link("GitHub", "https://github.com/subinium/SuperLightTUI");
-                            ui.link("Docs", "https://docs.rs/superlighttui");
-                            ui.link("Discord", "https://discord.gg/slt");
-                            ui.spacer();
-                            ui.text("v0.5.0").fg(theme.surface_text);
+                            let _ = ui.tabs(&mut nav);
+                            ui.styled(
+                                format!(" {} ", theme_names[theme_idx]),
+                                Style::new().fg(theme.text).bg(theme.surface_hover),
+                            );
                         });
                     });
+
+                let selected = nav.selected;
+                let _ = ui.scrollable(&mut scroll).grow(1).col(|ui| {
+                    match selected {
+                        0 => render_home(
+                            ui,
+                            &mut email,
+                            &mut nav_target,
+                            &mut toasts,
+                            &mut subscribed,
+                        ),
+                        1 => render_docs(ui),
+                        2 => render_blog(ui, &mut blog_view),
+                        3 => render_pricing(ui, &mut toasts, &mut show_modal, &mut selected_plan),
+                        _ => render_contact(ui, &mut nav_target, &mut contact_form, &mut toasts),
+                    }
+
+                    // ── footer ──
+                    let _ = ui
+                        .container()
+                        .bg(theme.surface)
+                        .padding(Padding::xy(2, 1))
+                        .col(|ui| {
+                            let _ = ui.row(|ui| {
+                                ui.text("SLT").bold().fg(theme.primary);
+                                ui.text("Framework").fg(theme.surface_text);
+                                ui.spacer();
+                                ui.text("MIT License").fg(theme.surface_text);
+                            });
+                            ui.text("");
+                            let _ = ui.row(|ui| {
+                                ui.link("GitHub", "https://github.com/subinium/SuperLightTUI");
+                                ui.link("Docs", "https://docs.rs/superlighttui");
+                                ui.link("Discord", "https://discord.gg/slt");
+                                ui.spacer();
+                                ui.text("v0.5.0").fg(theme.surface_text);
+                            });
+                        });
+                });
+
+                ui.toast(&mut toasts);
+
+                let _ = ui.help(&[
+                    ("Ctrl+Q", "quit"),
+                    ("Ctrl+T", "theme"),
+                    ("1-5", "tabs"),
+                    ("Esc", "back"),
+                    ("Tab", "focus"),
+                ]);
             });
-
-            ui.toast(&mut toasts);
-
-            let _ = ui.help(&[
-                ("Ctrl+Q", "quit"),
-                ("Ctrl+T", "theme"),
-                ("1-5", "tabs"),
-                ("Esc", "back"),
-                ("Tab", "focus"),
-            ]);
         });
     })
 }
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // Markdown-like rendering helpers
+//
+// All of these used to take `theme: &Theme` as a parameter. In v0.19.0 we
+// pull it from the ambient `AppState` instead, so callers stay terse.
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-fn md_h1(ui: &mut Context, theme: &Theme, text: &str) {
+/// Snapshot the currently provided `AppState`. Both fields are `Copy`, so
+/// the returned value is owned and can coexist with subsequent `&mut ui`
+/// calls without fighting the borrow checker.
+fn app(ui: &Context) -> AppState {
+    *ui.use_context::<AppState>()
+}
+
+fn md_h1(ui: &mut Context, text: &str) {
+    let theme = app(ui).theme;
     ui.text(text).bold().fg(theme.primary);
     ui.text("");
 }
 
-fn md_h2(ui: &mut Context, theme: &Theme, text: &str) {
+fn md_h2(ui: &mut Context, text: &str) {
+    let theme = app(ui).theme;
     ui.text(text).bold().fg(theme.primary);
     ui.text("");
 }
 
-fn md_h3(ui: &mut Context, theme: &Theme, text: &str) {
+fn md_h3(ui: &mut Context, text: &str) {
+    let theme = app(ui).theme;
     ui.text(text).bold().fg(theme.secondary);
     ui.text("");
 }
@@ -165,11 +209,13 @@ fn md_p(ui: &mut Context, text: &str) {
     ui.text(text).wrap();
 }
 
-fn md_p_dim(ui: &mut Context, theme: &Theme, text: &str) {
+fn md_p_dim(ui: &mut Context, text: &str) {
+    let theme = app(ui).theme;
     ui.text(text).fg(theme.text_dim).wrap();
 }
 
-fn md_blockquote(ui: &mut Context, theme: &Theme, text: &str) {
+fn md_blockquote(ui: &mut Context, text: &str) {
+    let theme = app(ui).theme;
     for line in text.lines() {
         let _ = ui.row(|ui| {
             ui.text(" ▎ ").fg(theme.primary);
@@ -179,7 +225,8 @@ fn md_blockquote(ui: &mut Context, theme: &Theme, text: &str) {
     ui.text("");
 }
 
-fn md_bullet(ui: &mut Context, theme: &Theme, items: &[&str]) {
+fn md_bullet(ui: &mut Context, items: &[&str]) {
+    let theme = app(ui).theme;
     for item in items {
         let _ = ui.row(|ui| {
             ui.text("  • ").fg(theme.primary);
@@ -189,7 +236,8 @@ fn md_bullet(ui: &mut Context, theme: &Theme, items: &[&str]) {
     ui.text("");
 }
 
-fn md_numbered(ui: &mut Context, theme: &Theme, items: &[&str]) {
+fn md_numbered(ui: &mut Context, items: &[&str]) {
+    let theme = app(ui).theme;
     for (i, item) in items.iter().enumerate() {
         let _ = ui.row(|ui| {
             ui.styled(
@@ -202,7 +250,8 @@ fn md_numbered(ui: &mut Context, theme: &Theme, items: &[&str]) {
     ui.text("");
 }
 
-fn md_code_block(ui: &mut Context, theme: &Theme, lang: &str, code: &str) {
+fn md_code_block(ui: &mut Context, lang: &str, code: &str) {
+    let theme = app(ui).theme;
     let _ = ui.container().bg(theme.surface).p(1).col(|ui| {
         ui.text(lang).fg(theme.surface_text);
         for line in code.lines() {
@@ -212,7 +261,8 @@ fn md_code_block(ui: &mut Context, theme: &Theme, lang: &str, code: &str) {
     ui.text("");
 }
 
-fn md_inline_code(ui: &mut Context, theme: &Theme, text: &str) {
+fn md_inline_code(ui: &mut Context, text: &str) {
+    let theme = app(ui).theme;
     ui.styled(
         format!(" {text} "),
         Style::new().fg(theme.warning).bg(theme.surface),
@@ -228,14 +278,16 @@ fn md_hr(ui: &mut Context) {
     ui.text("");
 }
 
-fn md_tag(ui: &mut Context, theme: &Theme, tag: &str, color: Color) {
+fn md_tag(ui: &mut Context, tag: &str, color: Color) {
+    let theme = app(ui).theme;
     ui.styled(
         format!(" {tag} "),
         Style::new().fg(color).bg(theme.surface).bold(),
     );
 }
 
-fn md_meta(ui: &mut Context, theme: &Theme, date: &str, reading_time: &str) {
+fn md_meta(ui: &mut Context, date: &str, reading_time: &str) {
+    let theme = app(ui).theme;
     let _ = ui.row(|ui| {
         ui.text(date).fg(theme.text_dim);
         ui.text(" · ").fg(theme.text_dim);
@@ -253,9 +305,8 @@ fn render_home(
     nav_target: &mut Option<usize>,
     toasts: &mut ToastState,
     subscribed: &mut bool,
-    tick: u64,
 ) {
-    let theme = *ui.theme();
+    let AppState { theme, tick } = app(ui);
 
     let _ = ui.container().px(2).py(1).col(|ui| {
         let art = [
@@ -274,7 +325,7 @@ fn render_home(
             .fg(theme.text_dim);
         ui.text("");
         let _ = ui.row(|ui| {
-            md_inline_code(ui, &theme, "cargo add superlighttui");
+            md_inline_code(ui, "cargo add superlighttui");
         });
         ui.text("");
         let _ = ui.row(|ui| {
@@ -316,7 +367,7 @@ fn render_home(
 
     // quick start guide
     let _ = ui.container().padding(Padding::xy(2, 1)).col(|ui| {
-        md_h2(ui, &theme, "Quick Start");
+        md_h2(ui, "Quick Start");
 
         md_p(
             ui,
@@ -326,7 +377,6 @@ fn render_home(
 
         md_code_block(
             ui,
-            &theme,
             "rust",
             "fn main() -> std::io::Result<()> {\n\
              \x20   slt::run(|ui: &mut slt::Context| {\n\
@@ -346,7 +396,7 @@ fn render_home(
 
     // why SLT
     let _ = ui.container().padding(Padding::xy(2, 1)).col(|ui| {
-        md_h2(ui, &theme, "Why SLT?");
+        md_h2(ui, "Why SLT?");
 
         md_p(
             ui,
@@ -359,13 +409,11 @@ fn render_home(
         let _ = ui.row(|ui| {
             feature_card(
                 ui,
-                &theme,
                 "Immediate Mode",
                 "No retained state. Your closure IS the UI. Like egui, but for terminals.",
             );
             feature_card(
                 ui,
-                &theme,
                 "Flexbox Layout",
                 "row() and col() with gap, grow, align. CSS Flexbox semantics without the CSS.",
             );
@@ -373,13 +421,11 @@ fn render_home(
         let _ = ui.row(|ui| {
             feature_card(
                 ui,
-                &theme,
                 "Auto Everything",
                 "Focus cycling, scroll, hit testing, event consumption. Zero boilerplate.",
             );
             feature_card(
                 ui,
-                &theme,
                 "Two Dependencies",
                 "crossterm + unicode-width. No OpenSSL, no system libs, compiles everywhere.",
             );
@@ -390,18 +436,13 @@ fn render_home(
 
     // newsletter
     let _ = ui.container().px(2).py(1).col(|ui| {
-        md_h2(ui, &theme, "Stay Updated");
+        md_h2(ui, "Stay Updated");
         if *subscribed {
             ui.text("Subscribed!").bold().fg(theme.success);
-            md_p_dim(
-                ui,
-                &theme,
-                "You'll receive updates at the address you provided.",
-            );
+            md_p_dim(ui, "You'll receive updates at the address you provided.");
         } else {
             md_p_dim(
                 ui,
-                &theme,
                 "Get notified about new releases, tutorials, and community highlights.",
             );
             let _ = ui.row(|ui| {
@@ -431,39 +472,36 @@ fn render_home(
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 fn render_docs(ui: &mut Context) {
-    let theme = *ui.theme();
-
     let _ = ui.container().padding(Padding::xy(2, 1)).col(|ui| {
-        md_h1(ui, &theme, "Documentation");
+        md_h1(ui, "Documentation");
 
         // ── Getting Started ──
-        md_h2(ui, &theme, "Getting Started");
+        md_h2(ui, "Getting Started");
         md_p(ui, "Add SLT to your project:");
-        md_code_block(ui, &theme, "sh", "cargo add superlighttui");
+        md_code_block(ui, "sh", "cargo add superlighttui");
         md_p(
             ui,
             "The crate re-exports everything under `slt`, so you can write:",
         );
-        md_code_block(ui, &theme, "rust", "use slt::*;");
+        md_code_block(ui, "rust", "use slt::*;");
 
         md_hr(ui);
 
         // ── Layout System ──
-        md_h2(ui, &theme, "Layout System");
+        md_h2(ui, "Layout System");
         md_p(
             ui,
             "SLT uses a flexbox-inspired layout. Every container is either a column (vertical) \
                    or a row (horizontal). Children are placed in order along the main axis.",
         );
 
-        md_h3(ui, &theme, "Columns and Rows");
+        md_h3(ui, "Columns and Rows");
         md_p(
             ui,
             "Use `col()` for vertical stacking and `row()` for horizontal placement:",
         );
         md_code_block(
             ui,
-            &theme,
             "rust",
             "ui.col(|ui| {\n\
              \x20   ui.text(\"top\");\n\
@@ -476,14 +514,13 @@ fn render_docs(ui: &mut Context) {
              });",
         );
 
-        md_h3(ui, &theme, "Growing and Spacing");
+        md_h3(ui, "Growing and Spacing");
         md_p(
             ui,
             "Use `grow()` to distribute remaining space. `spacer()` pushes siblings apart:",
         );
         md_code_block(
             ui,
-            &theme,
             "rust",
             "ui.row(|ui| {\n\
              \x20   ui.text(\"left\");\n\
@@ -496,11 +533,10 @@ fn render_docs(ui: &mut Context) {
              });",
         );
 
-        md_h3(ui, &theme, "Gap, Padding, Margin");
+        md_h3(ui, "Gap, Padding, Margin");
         md_p(ui, "Chain layout modifiers on containers:");
         md_code_block(
             ui,
-            &theme,
             "rust",
             "ui.container()\n\
              \x20   .gap(1)                // space between children\n\
@@ -513,14 +549,13 @@ fn render_docs(ui: &mut Context) {
         md_hr(ui);
 
         // ── Styling ──
-        md_h2(ui, &theme, "Styling");
+        md_h2(ui, "Styling");
         md_p(
             ui,
             "Style text by chaining methods. Colors support named, 256-indexed, and RGB:",
         );
         md_code_block(
             ui,
-            &theme,
             "rust",
             "let theme = *ui.theme();\n\
              ui.text(\"Primary\").bold().fg(theme.primary);\n\
@@ -529,11 +564,10 @@ fn render_docs(ui: &mut Context) {
              ui.text(\"Accent\").fg(theme.accent);",
         );
 
-        md_h3(ui, &theme, "Borders and Titles");
+        md_h3(ui, "Borders and Titles");
         md_p(ui, "Containers can have borders with optional titles:");
         md_code_block(
             ui,
-            &theme,
             "rust",
             "ui.bordered(Border::Rounded)\n\
              \x20   .title(\"My Section\")\n\
@@ -543,11 +577,10 @@ fn render_docs(ui: &mut Context) {
              \x20   });",
         );
 
-        md_h3(ui, &theme, "Themes");
+        md_h3(ui, "Themes");
         md_p(ui, "Switch the entire color scheme in one call:");
         md_code_block(
             ui,
-            &theme,
             "rust",
             "// In your run loop:\n\
              ui.set_theme(Theme::dark());   // or Theme::light()\n\
@@ -563,56 +596,51 @@ fn render_docs(ui: &mut Context) {
         md_hr(ui);
 
         // ── Widgets Reference ──
-        md_h2(ui, &theme, "Widget Reference");
+        md_h2(ui, "Widget Reference");
         md_p(
             ui,
             "SLT ships 14 widgets. All handle their own keyboard/mouse events. \
                    Focus cycling via Tab/Shift+Tab is automatic.",
         );
 
-        md_h3(ui, &theme, "Text Input");
+        md_h3(ui, "Text Input");
         md_code_block(
             ui,
-            &theme,
             "rust",
             "let mut state = TextInputState::with_placeholder(\"Email...\");\n\
              ui.text_input(&mut state);\n\
              // state.value() returns the current text",
         );
 
-        md_h3(ui, &theme, "Textarea");
+        md_h3(ui, "Textarea");
         md_code_block(
             ui,
-            &theme,
             "rust",
             "let mut state = TextareaState::new();\n\
              ui.textarea(&mut state, 5);  // 5 visible rows",
         );
 
-        md_h3(ui, &theme, "Button");
+        md_h3(ui, "Button");
         md_code_block(
             ui,
-            &theme,
             "rust",
             "if ui.button(\"Submit\").clicked {\n\
              \x20   // clicked!\n\
              }",
         );
 
-        md_h3(ui, &theme, "Checkbox & Toggle");
+        md_h3(ui, "Checkbox & Toggle");
         md_code_block(
             ui,
-            &theme,
             "rust",
             "let mut dark = true;\n\
              ui.checkbox(\"Dark mode\", &mut dark);\n\
              ui.toggle(\"Notifications\", &mut enabled);",
         );
 
-        md_h3(ui, &theme, "Tabs");
+        md_h3(ui, "Tabs");
         md_code_block(
             ui,
-            &theme,
             "rust",
             "let mut tabs = TabsState::new(vec![\"Home\", \"Settings\"]);\n\
              ui.tabs(&mut tabs);\n\
@@ -622,10 +650,9 @@ fn render_docs(ui: &mut Context) {
              }",
         );
 
-        md_h3(ui, &theme, "List & Table");
+        md_h3(ui, "List & Table");
         md_code_block(
             ui,
-            &theme,
             "rust",
             "let mut list = ListState::new(vec![\"Alpha\", \"Beta\"]);\n\
              ui.list(&mut list);\n\
@@ -637,14 +664,13 @@ fn render_docs(ui: &mut Context) {
              ui.table(&mut table);",
         );
 
-        md_h3(ui, &theme, "Scrollable");
+        md_h3(ui, "Scrollable");
         md_p(
             ui,
             "Wraps any content in a scrollable viewport. Handles mouse wheel and drag-to-scroll:",
         );
         md_code_block(
             ui,
-            &theme,
             "rust",
             "let mut scroll = ScrollState::new();\n\
              ui.scrollable(&mut scroll).grow(1).col(|ui| {\n\
@@ -654,10 +680,9 @@ fn render_docs(ui: &mut Context) {
              });",
         );
 
-        md_h3(ui, &theme, "Spinner, Progress, Toast");
+        md_h3(ui, "Spinner, Progress, Toast");
         md_code_block(
             ui,
-            &theme,
             "rust",
             "let spinner = SpinnerState::dots();\n\
              ui.spinner(&spinner);\n\
@@ -671,7 +696,7 @@ fn render_docs(ui: &mut Context) {
         md_hr(ui);
 
         // ── Events ──
-        md_h2(ui, &theme, "Event Handling");
+        md_h2(ui, "Event Handling");
         md_p(
             ui,
             "Events are checked per-frame. Widgets auto-consume their events so you \
@@ -680,7 +705,6 @@ fn render_docs(ui: &mut Context) {
 
         md_code_block(
             ui,
-            &theme,
             "rust",
             "if ui.key('q') { ui.quit(); }\n\
              if ui.key('j') { scroll_down(); }\n\
@@ -691,13 +715,12 @@ fn render_docs(ui: &mut Context) {
         md_hr(ui);
 
         // ── Advanced ──
-        md_h2(ui, &theme, "Advanced Topics");
+        md_h2(ui, "Advanced Topics");
 
-        md_h3(ui, &theme, "Animation");
+        md_h3(ui, "Animation");
         md_p(ui, "Tween and Spring primitives for smooth transitions:");
         md_code_block(
             ui,
-            &theme,
             "rust",
             "let mut tween = Tween::new(0.0, 100.0, 60);\n\
              let value = tween.value(ui.tick());\n\
@@ -706,36 +729,30 @@ fn render_docs(ui: &mut Context) {
              spring.set_target(50.0);",
         );
 
-        md_h3(ui, &theme, "Inline Mode");
+        md_h3(ui, "Inline Mode");
         md_p(
             ui,
             "Render below the prompt without entering the alternate screen:",
         );
         md_code_block(
             ui,
-            &theme,
             "rust",
             "slt::run_inline(3, |ui| {\n\
              \x20   ui.text(\"No alt screen!\");\n\
              });",
         );
 
-        md_h3(ui, &theme, "Async");
+        md_h3(ui, "Async");
         md_p(ui, "Optional tokio integration for background data:");
         md_code_block(
             ui,
-            &theme,
             "rust",
             "let tx = slt::run_async(|ui, msgs: &mut Vec<String>| {\n\
              \x20   for m in msgs.drain(..) { ui.text(m); }\n\
              })?;\n\
              tx.send(\"hello\".into()).await?;",
         );
-        md_p_dim(
-            ui,
-            &theme,
-            "Requires: cargo add superlighttui --features async",
-        );
+        md_p_dim(ui, "Requires: cargo add superlighttui --features async");
     });
 }
 
@@ -749,7 +766,7 @@ struct BlogPost {
     reading_time: &'static str,
     tags: &'static [(&'static str, TagTone)],
     excerpt: &'static str,
-    render: fn(&mut Context, &Theme),
+    render: fn(&mut Context),
 }
 
 #[derive(Clone, Copy)]
@@ -817,7 +834,7 @@ const BLOG_POSTS: &[BlogPost] = &[
 ];
 
 fn render_blog(ui: &mut Context, blog_view: &mut Option<usize>) {
-    let theme = *ui.theme();
+    let theme = app(ui).theme;
 
     let _ = ui.container().padding(Padding::xy(2, 1)).col(|ui| {
         if let Some(idx) = *blog_view {
@@ -833,14 +850,13 @@ fn render_blog(ui: &mut Context, blog_view: &mut Option<usize>) {
                     ui.spacer();
                 });
                 ui.text("");
-                (post.render)(ui, &theme);
+                (post.render)(ui);
             }
         } else {
             // ── Blog listing ──
-            md_h1(ui, &theme, "Blog");
+            md_h1(ui, "Blog");
             md_p_dim(
                 ui,
-                &theme,
                 "Thoughts on terminal UI design, Rust patterns, and building tools that developers actually enjoy using.",
             );
 
@@ -855,7 +871,7 @@ fn render_blog(ui: &mut Context, blog_view: &mut Option<usize>) {
                     let _ = ui.row(|ui| {
                         for (tag, tone) in post.tags {
                             let color = tag_tone_color(&theme, *tone);
-                            md_tag(ui, &theme, tag, color);
+                            md_tag(ui, tag, color);
                             ui.text(" ");
                         }
                     });
@@ -875,9 +891,9 @@ fn render_blog(ui: &mut Context, blog_view: &mut Option<usize>) {
 
 // ── Blog Post: Announcing SLT v0.1.0 ──
 
-fn render_post_announcement(ui: &mut Context, theme: &Theme) {
-    md_h1(ui, theme, "Announcing SLT v0.1.0");
-    md_meta(ui, theme, "2025-03-10", "5 min read");
+fn render_post_announcement(ui: &mut Context) {
+    md_h1(ui, "Announcing SLT v0.1.0");
+    md_meta(ui, "2025-03-10", "5 min read");
     ui.text("");
 
     md_p(
@@ -887,7 +903,7 @@ fn render_post_announcement(ui: &mut Context, theme: &Theme) {
               we're headed.",
     );
 
-    md_h2(ui, theme, "What is SLT?");
+    md_h2(ui, "What is SLT?");
     md_p(
         ui,
         "SLT is an immediate-mode terminal UI framework for Rust. If you've used egui for \
@@ -898,14 +914,12 @@ fn render_post_announcement(ui: &mut Context, theme: &Theme) {
 
     md_blockquote(
         ui,
-        theme,
         "The name is longer than your hello world.\nThat's the point.",
     );
 
-    md_h2(ui, theme, "Design Principles");
+    md_h2(ui, "Design Principles");
     md_numbered(
         ui,
-        theme,
         &[
             "Minimal API surface: learn 5 methods, build anything.",
             "Zero boilerplate: no App struct, no Model/Update/View, no trait impls.",
@@ -915,11 +929,10 @@ fn render_post_announcement(ui: &mut Context, theme: &Theme) {
         ],
     );
 
-    md_h2(ui, theme, "Hello World");
+    md_h2(ui, "Hello World");
     md_p(ui, "The smallest SLT program is genuinely 5 lines:");
     md_code_block(
         ui,
-        theme,
         "rust",
         "fn main() -> std::io::Result<()> {\n\
          \x20   slt::run(|ui: &mut slt::Context| {\n\
@@ -933,8 +946,8 @@ fn render_post_announcement(ui: &mut Context, theme: &Theme) {
               State lives in your closure's scope as regular Rust variables.",
     );
 
-    md_h2(ui, theme, "What's Included in v0.1.0");
-    md_bullet(ui, theme, &[
+    md_h2(ui, "What's Included in v0.1.0");
+    md_bullet(ui, &[
         "14 widgets: TextInput, Textarea, Button, Checkbox, Toggle, Tabs, List, Table, Spinner, Progress, Scrollable, Toast, Separator, HelpBar",
         "Flexbox layout engine with row/col, gap, grow, shrink, alignment",
         "Double-buffer diff rendering (only changed cells hit the terminal)",
@@ -947,11 +960,10 @@ fn render_post_announcement(ui: &mut Context, theme: &Theme) {
         "Layout debugger (F12)",
     ]);
 
-    md_h2(ui, theme, "What's Next");
+    md_h2(ui, "What's Next");
     md_p(ui, "v0.2.0 will focus on:");
     md_bullet(
         ui,
-        theme,
         &[
             "Custom widget API for third-party extensions",
             "Color palette presets (Catppuccin, Dracula, Nord, etc.)",
@@ -966,7 +978,6 @@ fn render_post_announcement(ui: &mut Context, theme: &Theme) {
     );
     md_code_block(
         ui,
-        theme,
         "sh",
         "cargo add superlighttui\ncargo run --example demo",
     );
@@ -974,9 +985,9 @@ fn render_post_announcement(ui: &mut Context, theme: &Theme) {
 
 // ── Blog Post: Why Immediate Mode? ──
 
-fn render_post_immediate_mode(ui: &mut Context, theme: &Theme) {
-    md_h1(ui, theme, "Why Immediate Mode for TUIs?");
-    md_meta(ui, theme, "2025-03-08", "8 min read");
+fn render_post_immediate_mode(ui: &mut Context) {
+    md_h1(ui, "Why Immediate Mode for TUIs?");
+    md_meta(ui, "2025-03-08", "8 min read");
     ui.text("");
 
     md_p(
@@ -993,7 +1004,7 @@ fn render_post_immediate_mode(ui: &mut Context, theme: &Theme) {
               You simply describe what should be on screen right now.",
     );
 
-    md_h2(ui, theme, "The Problem with Retained Mode");
+    md_h2(ui, "The Problem with Retained Mode");
     md_p(
         ui,
         "Retained-mode TUI frameworks inherit a problem from GUI frameworks: state \
@@ -1004,7 +1015,6 @@ fn render_post_immediate_mode(ui: &mut Context, theme: &Theme) {
 
     md_code_block(
         ui,
-        theme,
         "rust",
         "// Retained mode: state lives in two places\n\
          struct App {\n\
@@ -1030,7 +1040,7 @@ fn render_post_immediate_mode(ui: &mut Context, theme: &Theme) {
               The entire Elm/MVU architecture exists to manage this complexity.",
     );
 
-    md_h2(ui, theme, "Immediate Mode: No Sync Required");
+    md_h2(ui, "Immediate Mode: No Sync Required");
     md_p(
         ui,
         "In immediate mode, there is no framework state to sync. Your closure runs \
@@ -1039,7 +1049,6 @@ fn render_post_immediate_mode(ui: &mut Context, theme: &Theme) {
 
     md_code_block(
         ui,
-        theme,
         "rust",
         "// Immediate mode: state lives in one place\n\
          let mut items = vec![\"alpha\", \"beta\"];\n\
@@ -1057,11 +1066,10 @@ fn render_post_immediate_mode(ui: &mut Context, theme: &Theme) {
 
     md_blockquote(
         ui,
-        theme,
         "Your UI is always a pure function of your state.\nThere is nothing to get out of sync.",
     );
 
-    md_h2(ui, theme, "Performance Concerns");
+    md_h2(ui, "Performance Concerns");
     md_p(
         ui,
         "The common objection: doesn't re-describing the entire UI every frame waste \
@@ -1078,11 +1086,10 @@ fn render_post_immediate_mode(ui: &mut Context, theme: &Theme) {
               full redraws, which is what most TUI frameworks actually do.",
     );
 
-    md_h2(ui, theme, "When Retained Mode Wins");
+    md_h2(ui, "When Retained Mode Wins");
     md_p(ui, "Retained mode is better when:");
     md_bullet(
         ui,
-        theme,
         &[
             "You have thousands of widgets (terminal UIs rarely do)",
             "Widget construction is expensive (network calls, etc.)",
@@ -1099,9 +1106,9 @@ fn render_post_immediate_mode(ui: &mut Context, theme: &Theme) {
 
 // ── Blog Post: Dashboard Tutorial ──
 
-fn render_post_dashboard_tutorial(ui: &mut Context, theme: &Theme) {
-    md_h1(ui, theme, "Building a Dashboard in 50 Lines");
-    md_meta(ui, theme, "2025-03-05", "4 min read");
+fn render_post_dashboard_tutorial(ui: &mut Context) {
+    md_h1(ui, "Building a Dashboard in 50 Lines");
+    md_meta(ui, "2025-03-05", "4 min read");
     ui.text("");
 
     md_p(
@@ -1110,7 +1117,7 @@ fn render_post_dashboard_tutorial(ui: &mut Context, theme: &Theme) {
               memory, a process table, and a log stream. The whole thing fits in 50 lines.",
     );
 
-    md_h2(ui, theme, "Step 1: Scaffold");
+    md_h2(ui, "Step 1: Scaffold");
     md_p(
         ui,
         "Start with the standard SLT boilerplate. We need mouse support for our table:",
@@ -1118,7 +1125,6 @@ fn render_post_dashboard_tutorial(ui: &mut Context, theme: &Theme) {
 
     md_code_block(
         ui,
-        theme,
         "rust",
         "use slt::*;\n\
          \n\
@@ -1135,7 +1141,7 @@ fn render_post_dashboard_tutorial(ui: &mut Context, theme: &Theme) {
          }",
     );
 
-    md_h2(ui, theme, "Step 2: Metrics Row");
+    md_h2(ui, "Step 2: Metrics Row");
     md_p(
         ui,
         "Use `row()` with `grow(1)` containers to create evenly spaced metric cards:",
@@ -1143,7 +1149,6 @@ fn render_post_dashboard_tutorial(ui: &mut Context, theme: &Theme) {
 
     md_code_block(
         ui,
-        theme,
         "rust",
         "ui.row(|ui| {\n\
          \x20   ui.bordered(Border::Rounded).grow(1).pad(1).col(|ui| {\n\
@@ -1159,7 +1164,7 @@ fn render_post_dashboard_tutorial(ui: &mut Context, theme: &Theme) {
          });",
     );
 
-    md_h2(ui, theme, "Step 3: Process Table");
+    md_h2(ui, "Step 3: Process Table");
     md_p(
         ui,
         "SLT's Table widget handles headers, selection, and column sizing:",
@@ -1167,7 +1172,6 @@ fn render_post_dashboard_tutorial(ui: &mut Context, theme: &Theme) {
 
     md_code_block(
         ui,
-        theme,
         "rust",
         "let mut table = TableState::new(\n\
          \x20   vec![\"PID\", \"Name\", \"CPU\", \"Memory\"],\n\
@@ -1179,7 +1183,7 @@ fn render_post_dashboard_tutorial(ui: &mut Context, theme: &Theme) {
          ui.table(&mut table);",
     );
 
-    md_h2(ui, theme, "Step 4: Log Stream");
+    md_h2(ui, "Step 4: Log Stream");
     md_p(
         ui,
         "Wrap logs in a scrollable container. New entries push older ones up:",
@@ -1187,7 +1191,6 @@ fn render_post_dashboard_tutorial(ui: &mut Context, theme: &Theme) {
 
     md_code_block(
         ui,
-        theme,
         "rust",
         "ui.scrollable(&mut scroll).max_height(10).col(|ui| {\n\
          \x20   for log in &logs {\n\
@@ -1204,16 +1207,15 @@ fn render_post_dashboard_tutorial(ui: &mut Context, theme: &Theme) {
 
     md_blockquote(
         ui,
-        theme,
         "The full example is 120 lines including simulated data.\n50 lines is just the UI code.",
     );
 }
 
 // ── Blog Post: u32 Coordinates ──
 
-fn render_post_u32(ui: &mut Context, theme: &Theme) {
-    md_h1(ui, theme, "The Case for u32 Coordinates");
-    md_meta(ui, theme, "2025-03-01", "3 min read");
+fn render_post_u32(ui: &mut Context) {
+    md_h1(ui, "The Case for u32 Coordinates");
+    md_meta(ui, "2025-03-01", "3 min read");
     ui.text("");
 
     md_p(
@@ -1223,7 +1225,7 @@ fn render_post_u32(ui: &mut Context, theme: &Theme) {
               like more than enough — no terminal is 65K columns wide. So why does SLT use u32?",
     );
 
-    md_h2(ui, theme, "The Overflow Bug");
+    md_h2(ui, "The Overflow Bug");
     md_p(
         ui,
         "The problem isn't the terminal size. It's arithmetic. When you compute layouts, \
@@ -1233,7 +1235,6 @@ fn render_post_u32(ui: &mut Context, theme: &Theme) {
 
     md_code_block(
         ui,
-        theme,
         "rust",
         "// Ratatui-style u16 arithmetic:\n\
          let total_width: u16 = col_count * col_width + (col_count - 1) * gap;\n\
@@ -1244,11 +1245,10 @@ fn render_post_u32(ui: &mut Context, theme: &Theme) {
          let total_width: u32 = col_count * col_width + (col_count - 1) * gap;",
     );
 
-    md_h2(ui, theme, "Real-World Triggers");
+    md_h2(ui, "Real-World Triggers");
     md_p(ui, "This isn't theoretical. It triggers in practice:");
     md_bullet(
         ui,
-        theme,
         &[
             "Scrollable containers with large content (1000+ rows)",
             "Tables with many columns and wide data",
@@ -1257,9 +1257,9 @@ fn render_post_u32(ui: &mut Context, theme: &Theme) {
         ],
     );
 
-    md_h2(ui, theme, "Why Not Just Use i32 or usize?");
+    md_h2(ui, "Why Not Just Use i32 or usize?");
     md_p(ui, "We considered all options:");
-    md_bullet(ui, theme, &[
+    md_bullet(ui, &[
         "i32: Negative coordinates are meaningless for layout. Wastes a sign bit and allows invalid states.",
         "usize: 64-bit on most platforms. Wastes memory in the character buffer (millions of cells).",
         "u32: 4 billion max. More than enough for intermediate arithmetic. Same size as u16 after padding on most structs.",
@@ -1274,9 +1274,11 @@ fn render_post_u32(ui: &mut Context, theme: &Theme) {
 
 // ── Blog Post: Flexbox for Terminals ──
 
-fn render_post_flexbox(ui: &mut Context, theme: &Theme) {
-    md_h1(ui, theme, "Flexbox for Terminals");
-    md_meta(ui, theme, "2025-02-25", "6 min read");
+fn render_post_flexbox(ui: &mut Context) {
+    let theme = app(ui).theme;
+
+    md_h1(ui, "Flexbox for Terminals");
+    md_meta(ui, "2025-02-25", "6 min read");
     ui.text("");
 
     md_p(
@@ -1286,7 +1288,7 @@ fn render_post_flexbox(ui: &mut Context, theme: &Theme) {
               SLT layout works. This post maps CSS concepts to SLT API calls.",
     );
 
-    md_h2(ui, theme, "The Mapping");
+    md_h2(ui, "The Mapping");
 
     let _ = ui.bordered(Border::Rounded).pad(1).col(|ui| {
         let _ = ui.row(|ui| {
@@ -1324,15 +1326,15 @@ fn render_post_flexbox(ui: &mut Context, theme: &Theme) {
     });
     ui.text("");
 
-    md_h2(ui, theme, "How Layout Works Internally");
+    md_h2(ui, "How Layout Works Internally");
     md_p(ui, "SLT's layout algorithm runs in two passes:");
 
-    md_numbered(ui, theme, &[
+    md_numbered(ui, &[
         "Measure pass: each node computes its minimum size. Text measures its string width. Containers sum their children (column = sum heights, row = sum widths).",
         "Layout pass: starting from the root (terminal size), each container distributes space to children. Fixed-size children get their minimum. Remaining space goes to children with grow > 0, proportional to their grow factor.",
     ]);
 
-    md_h2(ui, theme, "Where We Diverge from CSS");
+    md_h2(ui, "Where We Diverge from CSS");
     md_p(
         ui,
         "SLT intentionally simplifies Flexbox in places that don't matter for terminals:",
@@ -1340,7 +1342,6 @@ fn render_post_flexbox(ui: &mut Context, theme: &Theme) {
 
     md_bullet(
         ui,
-        theme,
         &[
             "No flex-wrap: terminal rows don't wrap. Use nested row/col instead.",
             "No order property: children render in declaration order. Always.",
@@ -1355,7 +1356,7 @@ fn render_post_flexbox(ui: &mut Context, theme: &Theme) {
               covering 95% of real-world terminal layouts.",
     );
 
-    md_h2(ui, theme, "A Complete Example");
+    md_h2(ui, "A Complete Example");
     md_p(
         ui,
         "Here's a typical dashboard layout using the flexbox primitives:",
@@ -1363,7 +1364,6 @@ fn render_post_flexbox(ui: &mut Context, theme: &Theme) {
 
     md_code_block(
         ui,
-        theme,
         "rust",
         "ui.col(|ui| {\n\
          \x20   // Top bar: logo left, nav right\n\
@@ -1401,17 +1401,15 @@ fn render_post_flexbox(ui: &mut Context, theme: &Theme) {
 fn render_pricing(
     ui: &mut Context,
     toasts: &mut ToastState,
-    tick: u64,
     show_modal: &mut bool,
     selected_plan: &mut String,
 ) {
-    let theme = *ui.theme();
+    let AppState { theme, tick } = app(ui);
 
     let _ = ui.container().padding(Padding::xy(2, 1)).col(|ui| {
-        md_h1(ui, &theme, "Pricing");
+        md_h1(ui, "Pricing");
         md_p_dim(
             ui,
-            &theme,
             "SLT is free and open source forever. Sponsorship helps us ship faster.",
         );
 
@@ -1438,7 +1436,6 @@ fn render_pricing(
                 ],
                 theme.success,
                 false,
-                &theme,
                 show_modal,
                 selected_plan,
             );
@@ -1461,7 +1458,6 @@ fn render_pricing(
                     ],
                     theme.primary,
                     true,
-                    &theme,
                     show_modal,
                     selected_plan,
                 );
@@ -1481,7 +1477,6 @@ fn render_pricing(
                 ],
                 theme.accent,
                 false,
-                &theme,
                 show_modal,
                 selected_plan,
             );
@@ -1489,23 +1484,20 @@ fn render_pricing(
 
         ui.text("");
 
-        md_h2(ui, &theme, "FAQ");
+        md_h2(ui, "FAQ");
         faq_item(
             ui,
-            &theme,
             "Is SLT really free?",
             "Yes. MIT licensed. Use it in commercial products, modify it, redistribute it. No strings.",
         );
         faq_item(
             ui,
-            &theme,
             "What does sponsorship fund?",
             "Full-time development, CI infrastructure, documentation, and community management. \
              Every dollar goes directly into making SLT better.",
         );
         faq_item(
             ui,
-            &theme,
             "Can I use SLT in production?",
             "Yes. The API is pre-1.0 so breaking changes may happen, but the core is stable \
              and well-tested. Pin your version and you'll be fine.",
@@ -1620,19 +1612,17 @@ fn render_contact(
     nav_target: &mut Option<usize>,
     contact_form: &mut FormState,
     toasts: &mut ToastState,
-    tick: u64,
 ) {
-    let theme = *ui.theme();
+    let AppState { theme, tick } = app(ui);
 
     let _ = ui.container().padding(Padding::xy(2, 1)).col(|ui| {
-        md_h1(ui, &theme, "Contact & Community");
+        md_h1(ui, "Contact & Community");
 
         md_p(ui, "SLT is built in the open. Here's how to get involved:");
 
-        md_h2(ui, &theme, "Get Help");
+        md_h2(ui, "Get Help");
         md_bullet(
             ui,
-            &theme,
             &[
                 "GitHub Issues — Bug reports and feature requests",
                 "GitHub Discussions — Questions and community help",
@@ -1640,7 +1630,7 @@ fn render_contact(
             ],
         );
 
-        md_h2(ui, &theme, "Links");
+        md_h2(ui, "Links");
         md_link(
             ui,
             "GitHub Repository",
@@ -1663,7 +1653,7 @@ fn render_contact(
         });
 
         ui.text("");
-        md_h2(ui, &theme, "Send a Message");
+        md_h2(ui, "Send a Message");
         ui.form(contact_form, |ui, form| {
             for field in form.fields.iter_mut() {
                 ui.form_field(field);
@@ -1677,12 +1667,15 @@ fn render_contact(
                 toasts.error("Please fix the form errors", tick);
             }
         }
-        if contact_form.submitted {
-            ui.text("Message received.").fg(theme.success).bold();
-        }
+        // Demonstrate `.with_if`: conditional style attached to the last text
+        // chain without an `if { ... }` wrapper.
+        ui.text("Message received.")
+            .with_if(contact_form.submitted, |t| {
+                t.fg(theme.success).bold();
+            });
 
         ui.text("");
-        md_h2(ui, &theme, "Contributing");
+        md_h2(ui, "Contributing");
         md_p(
             ui,
             "We welcome contributions of all kinds: bug fixes, new widgets, documentation \
@@ -1691,7 +1684,6 @@ fn render_contact(
 
         md_numbered(
             ui,
-            &theme,
             &[
                 "Fork the repository on GitHub",
                 "Create a feature branch: git checkout -b feat/my-widget",
@@ -1701,14 +1693,14 @@ fn render_contact(
             ],
         );
 
-        md_h2(ui, &theme, "Code of Conduct");
+        md_h2(ui, "Code of Conduct");
         md_p(
             ui,
             "We follow the Rust community's Code of Conduct. Be kind, be constructive, \
                    and assume good intent. We're all here to build great terminal UIs.",
         );
 
-        md_h2(ui, &theme, "Maintainers");
+        md_h2(ui, "Maintainers");
         let _ = ui.container().bg(theme.surface).p(1).col(|ui| {
             let _ = ui.row(|ui| {
                 ui.text("@subinium").bold().fg(theme.primary);
@@ -1718,11 +1710,10 @@ fn render_contact(
         });
 
         ui.text("");
-        md_h2(ui, &theme, "Acknowledgements");
+        md_h2(ui, "Acknowledgements");
         md_p(ui, "SLT wouldn't exist without the Rust TUI ecosystem:");
         md_bullet(
             ui,
-            &theme,
             &[
                 "crossterm — The rock-solid terminal abstraction we build on",
                 "ratatui — Proved that Rust TUIs can be production-quality",
@@ -1738,7 +1729,8 @@ fn render_contact(
 // Shared Components
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-fn feature_card(ui: &mut Context, theme: &Theme, title: &str, desc: &str) {
+fn feature_card(ui: &mut Context, title: &str, desc: &str) {
+    let theme = app(ui).theme;
     let _ = ui.container().bg(theme.surface).p(1).grow(1).col(|ui| {
         ui.text(format!("◆ {title}")).bold().fg(theme.primary);
         ui.text(desc).fg(theme.surface_text).wrap();
@@ -1754,10 +1746,10 @@ fn price_card(
     features: &[&str],
     color: Color,
     highlight: bool,
-    theme: &Theme,
     show_modal: &mut bool,
     selected_plan: &mut String,
 ) {
+    let theme = app(ui).theme;
     let cta_label = if highlight {
         "Get Sponsor"
     } else if tier == "Enterprise" {
@@ -1770,45 +1762,41 @@ fn price_card(
     } else {
         ButtonVariant::Outline
     };
-    let mut card_content = |ui: &mut Context| {
-        ui.text(tier).bold().fg(color);
-        ui.text("");
-        let _ = ui.row(|ui| {
-            ui.text(price).bold().fg(color);
-            ui.text(format!(" {period}")).fg(theme.surface_text);
-        });
-        ui.separator();
-        ui.text("");
-        for feat in features {
-            let _ = ui.row(|ui| {
-                ui.text("✓ ").fg(theme.success);
-                ui.text(*feat).fg(theme.text);
-            });
-        }
-        ui.text("");
-        if ui.button_with(cta_label, cta_variant).clicked {
-            *show_modal = true;
-            *selected_plan = tier.to_string();
-        }
-    };
 
-    if highlight {
-        let _ = ui
-            .bordered(Border::Rounded)
-            .bg(theme.surface)
-            .pad(1)
-            .grow(1)
-            .col(|ui| {
-                card_content(ui);
+    // `.with_if` collapses the `if highlight { bordered } else { container }`
+    // fork into a single fluent chain. The closure only runs when `highlight`
+    // is true, adding a rounded border to an otherwise-identical card.
+    let _ = ui
+        .container()
+        .with_if(highlight, |c| c.border(Border::Rounded))
+        .bg(theme.surface)
+        .pad(1)
+        .grow(1)
+        .col(|ui| {
+            ui.text(tier).bold().fg(color);
+            ui.text("");
+            let _ = ui.row(|ui| {
+                ui.text(price).bold().fg(color);
+                ui.text(format!(" {period}")).fg(theme.surface_text);
             });
-    } else {
-        let _ = ui.container().bg(theme.surface).pad(1).grow(1).col(|ui| {
-            card_content(ui);
+            ui.separator();
+            ui.text("");
+            for feat in features {
+                let _ = ui.row(|ui| {
+                    ui.text("✓ ").fg(theme.success);
+                    ui.text(*feat).fg(theme.text);
+                });
+            }
+            ui.text("");
+            if ui.button_with(cta_label, cta_variant).clicked {
+                *show_modal = true;
+                *selected_plan = tier.to_string();
+            }
         });
-    }
 }
 
-fn faq_item(ui: &mut Context, theme: &Theme, question: &str, answer: &str) {
+fn faq_item(ui: &mut Context, question: &str, answer: &str) {
+    let theme = app(ui).theme;
     let _ = ui.container().padding(Padding::xy(1, 0)).col(|ui| {
         ui.text(question).bold().fg(theme.primary);
         let _ = ui.container().padding(Padding::xy(2, 0)).col(|ui| {

--- a/src/context/container.rs
+++ b/src/context/container.rs
@@ -1128,6 +1128,62 @@ impl<'a> ContainerBuilder<'a> {
         self
     }
 
+    // ── conditional / grouped builder helpers ───────────────────────
+
+    /// Apply `f` only if `cond` is true. Returns the builder for chaining.
+    ///
+    /// Use this to attach a block of builder modifiers without breaking the
+    /// fluent chain. The closure takes the builder by value and must return
+    /// it (matching the rest of `ContainerBuilder`'s by-value API), so any
+    /// builder method (`.border()`, `.title()`, `.bg()`, etc.) can be chained
+    /// inside.
+    ///
+    /// Zero allocation: the closure is inlined and skipped entirely when
+    /// `cond` is `false`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # slt::run(|ui: &mut slt::Context| {
+    /// use slt::Border;
+    /// let highlighted = true;
+    /// ui.container()
+    ///     .pad(1)
+    ///     .with_if(highlighted, |c| c.border(Border::Single).title("Active"))
+    ///     .col(|ui| {
+    ///         ui.text("body");
+    ///     });
+    /// # });
+    /// ```
+    pub fn with_if(self, cond: bool, f: impl FnOnce(Self) -> Self) -> Self {
+        if cond {
+            f(self)
+        } else {
+            self
+        }
+    }
+
+    /// Apply `f` unconditionally. Useful for factoring out a block of builder
+    /// modifier calls while keeping the fluent chain intact.
+    ///
+    /// The closure takes the builder by value and must return it.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # slt::run(|ui: &mut slt::Context| {
+    /// use slt::Border;
+    /// ui.container()
+    ///     .with(|c| c.border(Border::Rounded).pad(1))
+    ///     .col(|ui| {
+    ///         ui.text("body");
+    ///     });
+    /// # });
+    /// ```
+    pub fn with(self, f: impl FnOnce(Self) -> Self) -> Self {
+        f(self)
+    }
+
     // ── internal ─────────────────────────────────────────────────────
 
     /// Set the vertical scroll offset in rows. Used internally by [`Context::scrollable`].

--- a/src/context/core.rs
+++ b/src/context/core.rs
@@ -25,6 +25,8 @@ pub struct Context {
     pub(crate) tick: u64,
     pub(crate) focus_index: usize,
     pub(crate) hook_states: Vec<Box<dyn std::any::Any>>,
+    pub(crate) named_states: std::collections::HashMap<&'static str, Box<dyn std::any::Any>>,
+    pub(crate) context_stack: Vec<Box<dyn std::any::Any>>,
     pub(crate) prev_focus_count: usize,
     pub(crate) prev_modal_focus_start: usize,
     pub(crate) prev_modal_focus_count: usize,
@@ -79,6 +81,7 @@ pub(super) struct ContextCheckpoint {
     commands_len: usize,
     hook_states_len: usize,
     deferred_draws_len: usize,
+    context_stack_len: usize,
     rollback: ContextRollbackState,
 }
 
@@ -88,6 +91,7 @@ impl ContextCheckpoint {
             commands_len: ctx.commands.len(),
             hook_states_len: ctx.hook_states.len(),
             deferred_draws_len: ctx.deferred_draws.len(),
+            context_stack_len: ctx.context_stack.len(),
             rollback: ctx.rollback.clone(),
         }
     }
@@ -96,6 +100,7 @@ impl ContextCheckpoint {
         ctx.commands.truncate(self.commands_len);
         ctx.hook_states.truncate(self.hook_states_len);
         ctx.deferred_draws.truncate(self.deferred_draws_len);
+        ctx.context_stack.truncate(self.context_stack_len);
         ctx.rollback = self.rollback.clone();
     }
 }

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -9,6 +9,7 @@ impl Context {
         theme: Theme,
     ) -> Self {
         let hook_states = &mut state.hook_states;
+        let named_states = std::mem::take(&mut state.named_states);
         let screen_hook_map = std::mem::take(&mut state.screen_hook_map);
         let focus = &mut state.focus;
         let layout_feedback = &mut state.layout_feedback;
@@ -52,6 +53,8 @@ impl Context {
             tick: diagnostics.tick,
             focus_index,
             hook_states: std::mem::take(hook_states),
+            named_states,
+            context_stack: Vec::new(),
             prev_focus_count: focus.prev_focus_count,
             prev_modal_focus_start: focus.prev_modal_focus_start,
             prev_modal_focus_count: focus.prev_modal_focus_count,
@@ -484,6 +487,122 @@ impl Context {
         }
 
         State::from_idx(idx)
+    }
+
+    /// Component-local persistent state keyed by a stable id.
+    ///
+    /// Unlike [`use_state`](Self::use_state), this is **not order-dependent** —
+    /// the value is looked up by `id` instead of call position. Safe to call
+    /// inside conditional branches or reusable component functions.
+    ///
+    /// Returns a `State<T>` handle. Access with `state.get(ui)` /
+    /// `state.get_mut(ui)`. Persists across frames.
+    ///
+    /// # Scoping
+    ///
+    /// Keys are `&'static str` and live in a single global namespace per
+    /// `Context` (no automatic per-component scoping). Two calls with the same
+    /// `id` in the same frame share the same value, regardless of where they
+    /// occur in the tree. Pick unique ids — for example, prefix with a
+    /// component name (`"counter::value"`).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// fn counter(ui: &mut slt::Context) {
+    ///     let count = ui.use_state_named_with("counter::value", || 0i32);
+    ///     ui.text(format!("Count: {}", count.get(ui)));
+    ///     if ui.button("+1").clicked {
+    ///         *count.get_mut(ui) += 1;
+    ///     }
+    /// }
+    /// ```
+    pub fn use_state_named_with<T: 'static>(
+        &mut self,
+        id: &'static str,
+        init: impl FnOnce() -> T,
+    ) -> State<T> {
+        if !self.named_states.contains_key(id) {
+            self.named_states.insert(id, Box::new(init()));
+        }
+        State::from_named(id)
+    }
+
+    /// Like [`use_state_named_with`](Self::use_state_named_with), but uses
+    /// [`Default::default()`] to initialize the value on first call.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let value = ui.use_state_named::<i32>("counter::value");
+    /// ```
+    pub fn use_state_named<T: 'static + Default>(&mut self, id: &'static str) -> State<T> {
+        self.use_state_named_with(id, T::default)
+    }
+
+    /// Push a value onto the context stack for the duration of `body`.
+    ///
+    /// Inside `body`, child widgets can call
+    /// [`use_context::<T>()`](Self::use_context) or
+    /// [`try_use_context::<T>()`](Self::try_use_context) to look up the
+    /// nearest provided value of type `T`. Provides cascade in LIFO order:
+    /// nested calls with the same `T` shadow outer ones.
+    ///
+    /// The value is automatically popped when `body` returns — including on
+    /// panic, so the context stack is always restored.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// struct Theme { accent: slt::Color }
+    /// ui.provide(Theme { accent: slt::Color::Red }, |ui| {
+    ///     // Any widget here can `let theme = ui.use_context::<Theme>();`
+    ///     render_button(ui);
+    /// });
+    /// ```
+    pub fn provide<T: 'static, R>(&mut self, value: T, body: impl FnOnce(&mut Context) -> R) -> R {
+        self.context_stack
+            .push(Box::new(value) as Box<dyn std::any::Any>);
+
+        // catch_unwind ensures the entry is popped even if `body` panics, so
+        // the context stack is never left with leaked frames. We re-panic
+        // afterwards so the panic propagates normally to outer scopes.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| body(self)));
+
+        // Pop in both success and panic paths.
+        self.context_stack.pop();
+
+        match result {
+            Ok(value) => value,
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
+    }
+
+    /// Look up the nearest provided value of type `T` on the context stack.
+    ///
+    /// Searches from the top of the stack (most-recent
+    /// [`provide`](Self::provide)) downward. Returns the first match.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no value of type `T` is currently provided. Use
+    /// [`try_use_context`](Self::try_use_context) for a non-panicking variant.
+    pub fn use_context<T: 'static>(&self) -> &T {
+        self.try_use_context::<T>().unwrap_or_else(|| {
+            panic!(
+                "no context of type {} was provided; use ui.provide(value, |ui| ...) in a parent scope",
+                std::any::type_name::<T>()
+            )
+        })
+    }
+
+    /// Like [`use_context`](Self::use_context), but returns `None` instead of
+    /// panicking when no value of type `T` is on the stack.
+    pub fn try_use_context<T: 'static>(&self) -> Option<&T> {
+        self.context_stack
+            .iter()
+            .rev()
+            .find_map(|entry| entry.downcast_ref::<T>())
     }
 
     /// Memoize a computed value. Recomputes only when `deps` changes.

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -1,44 +1,100 @@
 use super::*;
 
+/// Internal discriminator for [`State<T>`] handles.
+///
+/// `Indexed` refers to a slot in `Context::hook_states` (positional, used by
+/// [`Context::use_state`] / [`Context::use_memo`]). `Named` refers to a key in
+/// `Context::named_states` (used by [`Context::use_state_named`]).
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum StateKey {
+    Indexed(usize),
+    Named(&'static str),
+}
+
 /// Handle to state created by `use_state()`. Access via `.get(ui)` / `.get_mut(ui)`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct State<T> {
-    idx: usize,
+    key: StateKey,
     _marker: std::marker::PhantomData<T>,
 }
 
 impl<T: 'static> State<T> {
     pub(crate) fn from_idx(idx: usize) -> Self {
         Self {
-            idx,
+            key: StateKey::Indexed(idx),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub(crate) fn from_named(id: &'static str) -> Self {
+        Self {
+            key: StateKey::Named(id),
             _marker: std::marker::PhantomData,
         }
     }
 
     /// Read the current value.
     pub fn get<'a>(&self, ui: &'a Context) -> &'a T {
-        ui.hook_states[self.idx]
-            .downcast_ref::<T>()
-            .unwrap_or_else(|| {
-                panic!(
-                    "use_state type mismatch at hook index {} — expected {}",
-                    self.idx,
-                    std::any::type_name::<T>()
-                )
-            })
+        match self.key {
+            StateKey::Indexed(idx) => {
+                ui.hook_states[idx].downcast_ref::<T>().unwrap_or_else(|| {
+                    panic!(
+                        "use_state type mismatch at hook index {} — expected {}",
+                        idx,
+                        std::any::type_name::<T>()
+                    )
+                })
+            }
+            StateKey::Named(id) => ui
+                .named_states
+                .get(id)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "use_state_named: no entry for id {:?} — was use_state_named called?",
+                        id
+                    )
+                })
+                .downcast_ref::<T>()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "use_state_named type mismatch for id {:?} — expected {}",
+                        id,
+                        std::any::type_name::<T>()
+                    )
+                }),
+        }
     }
 
     /// Mutably access the current value.
     pub fn get_mut<'a>(&self, ui: &'a mut Context) -> &'a mut T {
-        ui.hook_states[self.idx]
-            .downcast_mut::<T>()
-            .unwrap_or_else(|| {
-                panic!(
-                    "use_state type mismatch at hook index {} — expected {}",
-                    self.idx,
-                    std::any::type_name::<T>()
-                )
-            })
+        match self.key {
+            StateKey::Indexed(idx) => {
+                ui.hook_states[idx].downcast_mut::<T>().unwrap_or_else(|| {
+                    panic!(
+                        "use_state type mismatch at hook index {} — expected {}",
+                        idx,
+                        std::any::type_name::<T>()
+                    )
+                })
+            }
+            StateKey::Named(id) => ui
+                .named_states
+                .get_mut(id)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "use_state_named: no entry for id {:?} — was use_state_named called?",
+                        id
+                    )
+                })
+                .downcast_mut::<T>()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "use_state_named type mismatch for id {:?} — expected {}",
+                        id,
+                        std::any::type_name::<T>()
+                    )
+                }),
+        }
     }
 }
 

--- a/src/context/widgets_display/text.rs
+++ b/src/context/widgets_display/text.rs
@@ -481,4 +481,57 @@ impl Context {
         self.rollback.last_text_idx = None;
         self
     }
+
+    // ── conditional / grouped style helpers ─────────────────────────
+
+    /// Apply `f` only if `cond` is true. Returns `self` so chaining continues.
+    ///
+    /// Use this to attach a block of style modifiers to the last rendered text
+    /// without breaking the fluent chain. The closure receives the same
+    /// `&mut Context`, so any style-chain method (`.bold()`, `.fg()`, etc.)
+    /// applies to the most recent text element.
+    ///
+    /// Zero allocation: the closure is inlined and skipped entirely when
+    /// `cond` is `false`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # slt::run(|ui: &mut slt::Context| {
+    /// use slt::Color;
+    /// let is_error = true;
+    /// let is_selected = false;
+    /// ui.text("Status")
+    ///     .with_if(is_error, |t| {
+    ///         t.bold().fg(Color::Red);
+    ///     })
+    ///     .with_if(is_selected, |t| {
+    ///         t.bg(Color::DarkGray);
+    ///     });
+    /// # });
+    /// ```
+    pub fn with_if(&mut self, cond: bool, f: impl FnOnce(&mut Self)) -> &mut Self {
+        if cond {
+            f(self);
+        }
+        self
+    }
+
+    /// Apply `f` unconditionally. Useful for factoring out a block of modifier
+    /// calls that should always run, while keeping the fluent chain intact.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # slt::run(|ui: &mut slt::Context| {
+    /// use slt::Color;
+    /// ui.text("hi").with(|t| {
+    ///     t.bold().fg(Color::Cyan);
+    /// });
+    /// # });
+    /// ```
+    pub fn with(&mut self, f: impl FnOnce(&mut Self)) -> &mut Self {
+        f(self);
+        self
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,6 +517,7 @@ pub(crate) struct DiagnosticsState {
 #[derive(Default)]
 pub(crate) struct FrameState {
     pub hook_states: Vec<Box<dyn std::any::Any>>,
+    pub named_states: std::collections::HashMap<&'static str, Box<dyn std::any::Any>>,
     pub screen_hook_map: std::collections::HashMap<String, (usize, usize)>,
     pub focus: FocusState,
     pub layout_feedback: LayoutFeedbackState,
@@ -1003,6 +1004,7 @@ pub(crate) fn run_frame_kernel(
 
     if ctx.should_quit {
         state.hook_states = ctx.hook_states;
+        state.named_states = ctx.named_states;
         state.screen_hook_map = ctx.screen_hook_map;
         state.diagnostics.notification_queue = ctx.rollback.notification_queue;
         #[cfg(feature = "crossterm")]
@@ -1112,6 +1114,7 @@ pub(crate) fn run_frame_kernel(
         "kitty_clip_info_stack must be empty at end of frame"
     );
     state.hook_states = ctx.hook_states;
+    state.named_states = ctx.named_states;
     state.screen_hook_map = ctx.screen_hook_map;
     state.diagnostics.notification_queue = ctx.rollback.notification_queue;
 

--- a/tests/context_provider.rs
+++ b/tests/context_provider.rs
@@ -1,0 +1,99 @@
+//! Tests for `Context::provide` / `Context::use_context` /
+//! `Context::try_use_context` (Issue #66).
+
+use slt::TestBackend;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ThemeAccent(&'static str);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UserName(String);
+
+#[test]
+fn provide_and_use_context_round_trip() {
+    let mut backend = TestBackend::new(40, 4);
+    backend.render(|ui| {
+        ui.provide(ThemeAccent("red"), |ui| {
+            let theme = ui.use_context::<ThemeAccent>();
+            assert_eq!(theme.0, "red");
+            ui.text(format!("accent={}", theme.0));
+        });
+    });
+    assert!(backend.to_string_trimmed().contains("accent=red"));
+}
+
+#[test]
+fn nested_provide_inner_shadows_outer_for_same_type() {
+    let mut backend = TestBackend::new(40, 4);
+    backend.render(|ui| {
+        ui.provide(ThemeAccent("outer"), |ui| {
+            assert_eq!(ui.use_context::<ThemeAccent>().0, "outer");
+            ui.provide(ThemeAccent("inner"), |ui| {
+                assert_eq!(ui.use_context::<ThemeAccent>().0, "inner");
+            });
+            // After inner pops, outer is visible again.
+            assert_eq!(ui.use_context::<ThemeAccent>().0, "outer");
+        });
+    });
+}
+
+#[test]
+fn two_different_types_coexist_on_stack() {
+    let mut backend = TestBackend::new(40, 4);
+    backend.render(|ui| {
+        ui.provide(ThemeAccent("blue"), |ui| {
+            ui.provide(UserName("alice".to_string()), |ui| {
+                assert_eq!(ui.use_context::<ThemeAccent>().0, "blue");
+                assert_eq!(ui.use_context::<UserName>().0, "alice");
+            });
+        });
+    });
+}
+
+#[test]
+fn try_use_context_returns_none_when_not_provided() {
+    let mut backend = TestBackend::new(40, 4);
+    backend.render(|ui| {
+        assert!(ui.try_use_context::<ThemeAccent>().is_none());
+    });
+}
+
+#[test]
+fn try_use_context_returns_some_when_provided() {
+    let mut backend = TestBackend::new(40, 4);
+    backend.render(|ui| {
+        ui.provide(ThemeAccent("ok"), |ui| {
+            assert_eq!(ui.try_use_context::<ThemeAccent>().map(|t| t.0), Some("ok"));
+        });
+    });
+}
+
+#[test]
+#[should_panic(expected = "no context of type")]
+fn use_context_panics_when_not_provided() {
+    let mut backend = TestBackend::new(40, 4);
+    backend.render(|ui| {
+        let _ = ui.use_context::<ThemeAccent>();
+    });
+}
+
+#[test]
+fn context_stack_pops_after_provide_returns() {
+    let mut backend = TestBackend::new(40, 4);
+    backend.render(|ui| {
+        ui.provide(ThemeAccent("temp"), |ui| {
+            assert!(ui.try_use_context::<ThemeAccent>().is_some());
+        });
+        // Outside the provide closure, the value must be gone.
+        assert!(ui.try_use_context::<ThemeAccent>().is_none());
+    });
+}
+
+#[test]
+fn provide_returns_body_value() {
+    let mut backend = TestBackend::new(40, 4);
+    backend.render(|ui| {
+        let doubled = ui.provide(42i32, |ui| *ui.use_context::<i32>() * 2);
+        assert_eq!(doubled, 84);
+    });
+}

--- a/tests/use_state_named.rs
+++ b/tests/use_state_named.rs
@@ -1,0 +1,113 @@
+//! Tests for `Context::use_state_named` /
+//! `Context::use_state_named_with` (Issue #71).
+
+use slt::TestBackend;
+
+#[test]
+fn named_state_persists_across_frames() {
+    let mut backend = TestBackend::new(40, 4);
+
+    // Frame 1: initialize, then mutate to 5.
+    backend.render(|ui| {
+        let v = ui.use_state_named_with::<i32>("counter::value", || 0);
+        let cur = *v.get(ui);
+        if cur < 5 {
+            *v.get_mut(ui) = 5;
+        }
+        ui.text(format!("v={}", v.get(ui)));
+    });
+    assert!(backend.to_string_trimmed().contains("v=5"));
+
+    // Frame 2: should still be 5 (init closure must NOT re-run).
+    backend.render(|ui| {
+        let v = ui.use_state_named_with::<i32>("counter::value", || 99);
+        ui.text(format!("v={}", v.get(ui)));
+    });
+    assert!(
+        backend.to_string_trimmed().contains("v=5"),
+        "expected persisted v=5 in frame 2, got: {:?}",
+        backend.to_string_trimmed()
+    );
+}
+
+#[test]
+fn two_different_ids_have_independent_state() {
+    let mut backend = TestBackend::new(40, 4);
+    backend.render(|ui| {
+        let a = ui.use_state_named_with::<i32>("widget::a", || 1);
+        let b = ui.use_state_named_with::<i32>("widget::b", || 2);
+        assert_eq!(*a.get(ui), 1);
+        assert_eq!(*b.get(ui), 2);
+        *a.get_mut(ui) = 100;
+        assert_eq!(*a.get(ui), 100);
+        // Mutating a must not affect b.
+        assert_eq!(*b.get(ui), 2);
+    });
+}
+
+#[test]
+fn same_id_in_same_scope_is_shared() {
+    // Documented behavior: two calls with the same id share storage.
+    let mut backend = TestBackend::new(40, 4);
+    backend.render(|ui| {
+        let first = ui.use_state_named_with::<i32>("shared", || 7);
+        // Init closure ignored on second call because the id already exists.
+        let second = ui.use_state_named_with::<i32>("shared", || 999);
+        assert_eq!(*first.get(ui), 7);
+        assert_eq!(*second.get(ui), 7);
+        *first.get_mut(ui) = 42;
+        assert_eq!(*second.get(ui), 42);
+    });
+}
+
+#[test]
+fn use_state_named_default_uses_default_impl() {
+    let mut backend = TestBackend::new(40, 4);
+    backend.render(|ui| {
+        let v = ui.use_state_named::<i32>("default::int");
+        assert_eq!(*v.get(ui), 0);
+        let s = ui.use_state_named::<String>("default::str");
+        assert!(s.get(ui).is_empty());
+    });
+}
+
+#[test]
+#[should_panic(expected = "use_state_named type mismatch")]
+fn type_mismatch_on_get_panics() {
+    // First create an i32 entry, then ask for a String at the same id.
+    // The handle returned by the second call carries `String` as its type
+    // tag, so `.get(ui)` will fail to downcast and panic with a clear message.
+    let mut backend = TestBackend::new(40, 4);
+    backend.render(|ui| {
+        let _ = ui.use_state_named_with::<i32>("collide", || 5);
+        let s = ui.use_state_named_with::<String>("collide", String::new);
+        let _ = s.get(ui);
+    });
+}
+
+#[test]
+fn safe_inside_conditional_unlike_use_state() {
+    // Demonstrates the key advantage over `use_state`: safe even when the
+    // call is gated behind a runtime condition that flips between frames.
+    let mut backend = TestBackend::new(40, 4);
+
+    // Frame 1: branch taken, initialize to 10 then mutate to 42.
+    backend.render(|ui| {
+        let v = ui.use_state_named_with::<i32>("conditional::v", || 10);
+        *v.get_mut(ui) = 42;
+        ui.text("frame 1");
+    });
+
+    // Frame 2: branch NOT taken — no call to use_state_named at all.
+    backend.render(|ui| {
+        ui.text("frame 2");
+    });
+
+    // Frame 3: branch taken again, must observe the persisted 42.
+    backend.render(|ui| {
+        let v = ui.use_state_named_with::<i32>("conditional::v", || 99);
+        ui.text(format!("v={}", v.get(ui)));
+    });
+    let out = backend.to_string_trimmed();
+    assert!(out.contains("v=42"), "expected v=42, got: {out:?}");
+}

--- a/tests/v0_19_api_integration.rs
+++ b/tests/v0_19_api_integration.rs
@@ -1,0 +1,207 @@
+//! Integration tests for v0.19.0 component DX APIs.
+//!
+//! Exercises `provide` / `use_context` / `try_use_context`, the named
+//! variants of `use_state` (`use_state_named` / `use_state_named_with`),
+//! and the `with_if` conditional modifier together in realistic
+//! combinations. Complements the unit-style tests in
+//! `tests/context_provider.rs`, `tests/use_state_named.rs`, and
+//! `tests/with_if.rs`.
+
+#![allow(unused_must_use)]
+
+use slt::{Color, Context, TestBackend};
+
+/// 1. `provide` + `use_context` end-to-end. A consumer pulls the value out
+///    of the surrounding context and uses it to style a text element. The
+///    color is copied out before the text call so the shared borrow on
+///    `ui` ends before the mutable borrow chain starts.
+#[test]
+fn provide_and_use_context_render_integration() {
+    struct Theme {
+        primary: Color,
+    }
+
+    let mut tb = TestBackend::new(40, 6);
+    tb.render(|ui: &mut Context| {
+        ui.provide(
+            Theme {
+                primary: Color::Cyan,
+            },
+            |ui| {
+                let primary = ui.use_context::<Theme>().primary;
+                ui.text("Hello").fg(primary);
+            },
+        );
+    });
+    assert!(tb.line(0).contains("Hello"));
+}
+
+/// 2. Nested `provide`: an inner provider for the same type shadows the
+///    outer one for the lifetime of its closure.
+#[test]
+fn nested_provide_shadows_outer() {
+    let mut tb = TestBackend::new(40, 6);
+    tb.render(|ui| {
+        ui.provide("outer", |ui| {
+            ui.provide("inner", |ui| {
+                let s = *ui.use_context::<&str>();
+                ui.text(s);
+            });
+        });
+    });
+    assert!(tb.line(0).contains("inner"));
+}
+
+/// 3. `try_use_context` returns `None` when the requested type was never
+///    provided. The branch is observable through what gets rendered.
+#[test]
+fn try_use_context_missing_is_none() {
+    struct Missing;
+
+    let mut tb = TestBackend::new(40, 6);
+    tb.render(|ui| {
+        let m: Option<&Missing> = ui.try_use_context::<Missing>();
+        if m.is_none() {
+            ui.text("none");
+        } else {
+            ui.text("some");
+        }
+    });
+    assert!(tb.line(0).contains("none"));
+}
+
+/// 4. `use_state_named` persists across frames the same way `use_state`
+///    does, but addressed by string id rather than positional hook order.
+#[test]
+fn use_state_named_persists() {
+    let mut tb = TestBackend::new(40, 6);
+    tb.render(|ui| {
+        let counter = ui.use_state_named::<i32>("counter");
+        *counter.get_mut(ui) += 1;
+    });
+    tb.render(|ui| {
+        let counter = ui.use_state_named::<i32>("counter");
+        *counter.get_mut(ui) += 1;
+        let n = *counter.get(ui);
+        ui.text(format!("count={n}"));
+    });
+    assert!(tb.line(0).contains("count=2"));
+}
+
+/// 5. Sibling named-state ids are independent — writing one does not
+///    perturb the other, even when both are read in the same frame.
+#[test]
+fn use_state_named_siblings_are_independent() {
+    let mut tb = TestBackend::new(40, 6);
+    tb.render(|ui| {
+        let a = ui.use_state_named_with::<i32>("a", || 10);
+        let b = ui.use_state_named_with::<i32>("b", || 20);
+        let av = *a.get(ui);
+        let bv = *b.get(ui);
+        ui.text(format!("{av}/{bv}"));
+    });
+    assert!(tb.line(0).contains("10/20"));
+}
+
+/// 6. `with_if(true, ...)` runs the closure; the text still renders.
+///    `TestBackend` does not expose per-cell style assertions in its
+///    public API, so we only verify content was emitted. Style coverage
+///    lives in the dedicated `tests/with_if.rs` file (which can poke the
+///    buffer's cells directly via `tb.buffer()` if needed).
+#[test]
+fn with_if_true_applies_bold() {
+    let mut tb = TestBackend::new(40, 6);
+    tb.render(|ui| {
+        ui.text("hi").with_if(true, |t| {
+            t.bold();
+        });
+    });
+    assert!(tb.line(0).contains("hi"));
+}
+
+/// 7. `with_if(false, ...)` skips the closure entirely. Verifies the
+///    chain is non-fatal when the predicate is `false` and the unmodified
+///    text still appears.
+#[test]
+fn with_if_false_skips_closure() {
+    let mut tb = TestBackend::new(40, 6);
+    tb.render(|ui| {
+        ui.text("plain").with_if(false, |t| {
+            t.bold();
+        });
+    });
+    assert!(tb.line(0).contains("plain"));
+}
+
+/// 8. All three v0.19.0 APIs together in one tree:
+///    - outer `provide` of a config struct
+///    - inner `use_state_named` (incremented this frame)
+///    - `with_if` driven by a value pulled from the provided context
+#[test]
+fn combined_v0_19_apis() {
+    struct Cfg {
+        emphasize: bool,
+    }
+
+    let mut tb = TestBackend::new(40, 6);
+    tb.render(|ui| {
+        ui.provide(Cfg { emphasize: true }, |ui| {
+            let counter = ui.use_state_named::<i32>("combined_counter");
+            *counter.get_mut(ui) += 1;
+            let n = *counter.get(ui);
+            let emphasize = ui.use_context::<Cfg>().emphasize;
+            ui.text(format!("n={n}")).with_if(emphasize, |t| {
+                t.bold();
+            });
+        });
+    });
+    assert!(tb.line(0).contains("n=1"));
+}
+
+/// 9. `with_if` on a `ContainerBuilder` (the bordered container variant
+///    documented in the spec). The builder is consumed by value, so the
+///    closure receives `&mut Self` and any chained mutator (like
+///    `.title()`-equivalent state) only runs when the predicate is true.
+#[test]
+fn with_if_on_container_builder_runs_only_when_true() {
+    use slt::Border;
+
+    let mut tb = TestBackend::new(40, 6);
+    tb.render(|ui| {
+        // `with_if` must compose cleanly inside a bordered container's
+        // by-value builder chain. We assert by content: the body is
+        // always rendered regardless of the predicate path.
+        let _ = ui
+            .bordered(Border::Single)
+            .with_if(true, |c| {
+                // No-op modifier closure: just verifies the API shape.
+                // ContainerBuilder modifiers are by-value — return `c` unchanged.
+                c
+            })
+            .col(|ui| {
+                ui.text("body");
+            });
+    });
+    assert!(tb.to_string_trimmed().contains("body"));
+}
+
+/// 10. Provided values survive across nested `with_if` chains — context
+///     lookup still resolves inside conditionally-applied modifier
+///     blocks.
+#[test]
+fn provide_visible_inside_with_if_chain() {
+    struct Marker(&'static str);
+
+    let mut tb = TestBackend::new(40, 6);
+    tb.render(|ui| {
+        ui.provide(Marker("OK"), |ui| {
+            // Mid-chain context read: bind out before the conditional
+            // closure to avoid overlapping borrows of `ui`.
+            let label = ui.use_context::<Marker>().0;
+            ui.text(label).with_if(true, |t| {
+                t.bold();
+            });
+        });
+    });
+    assert!(tb.line(0).contains("OK"));
+}

--- a/tests/with_if.rs
+++ b/tests/with_if.rs
@@ -1,0 +1,218 @@
+//! Tests for `.with_if(cond, f)` and `.with(f)` on text style chains and
+//! `ContainerBuilder`. These conditional/grouping helpers should be free of
+//! side effects when the condition is false and equivalent to inline calls
+//! when the condition is true.
+
+use slt::{Border, Color, Modifiers, TestBackend};
+
+/// Read the style of the first non-empty cell on row `y`.
+fn first_styled_cell(tb: &TestBackend, y: u32) -> slt::Style {
+    let buf = tb.buffer();
+    for x in 0..tb.width() {
+        let cell = buf.get(x, y);
+        if cell.symbol.as_str() != " " && !cell.symbol.is_empty() {
+            return cell.style;
+        }
+    }
+    panic!("no non-empty cell on row {y}");
+}
+
+// ── text helpers ────────────────────────────────────────────────────────
+
+#[test]
+fn with_if_true_applies_modifier() {
+    let mut tb = TestBackend::new(20, 3);
+    tb.render(|ui| {
+        ui.text("hello").with_if(true, |t| {
+            t.bold();
+        });
+    });
+    let style = first_styled_cell(&tb, 0);
+    assert!(
+        style.modifiers.contains(Modifiers::BOLD),
+        "expected BOLD modifier when cond=true, got {:?}",
+        style.modifiers
+    );
+}
+
+#[test]
+fn with_if_false_skips() {
+    let mut tb_skip = TestBackend::new(20, 3);
+    tb_skip.render(|ui| {
+        ui.text("hello").with_if(false, |t| {
+            t.bold();
+        });
+    });
+    let skipped = first_styled_cell(&tb_skip, 0);
+    assert!(
+        !skipped.modifiers.contains(Modifiers::BOLD),
+        "expected BOLD to NOT be set when cond=false, got {:?}",
+        skipped.modifiers
+    );
+
+    // Equivalence: skipping with_if(false, ...) should match the no-op chain.
+    let mut tb_plain = TestBackend::new(20, 3);
+    tb_plain.render(|ui| {
+        ui.text("hello");
+    });
+    let plain = first_styled_cell(&tb_plain, 0);
+    assert_eq!(
+        skipped.modifiers, plain.modifiers,
+        "with_if(false) should leave modifiers identical to no-op text"
+    );
+    assert_eq!(
+        skipped.fg, plain.fg,
+        "with_if(false) should leave fg identical to no-op text"
+    );
+}
+
+#[test]
+fn with_always_applies() {
+    let mut tb = TestBackend::new(20, 3);
+    tb.render(|ui| {
+        ui.text("hello").with(|t| {
+            t.fg(Color::Red);
+        });
+    });
+    let style = first_styled_cell(&tb, 0);
+    assert_eq!(
+        style.fg,
+        Some(Color::Red),
+        "expected Red fg, got {:?}",
+        style.fg
+    );
+}
+
+#[test]
+fn with_if_chain_independently_applies_each_branch() {
+    // Three independent conditions: only the true ones should apply.
+    // True/False/True → expect BOLD set, ITALIC unset, fg = Cyan.
+    let mut tb = TestBackend::new(20, 3);
+    tb.render(|ui| {
+        ui.text("chain")
+            .with_if(true, |t| {
+                t.bold();
+            })
+            .with_if(false, |t| {
+                t.italic();
+            })
+            .with_if(true, |t| {
+                t.fg(Color::Cyan);
+            });
+    });
+    let style = first_styled_cell(&tb, 0);
+    assert!(
+        style.modifiers.contains(Modifiers::BOLD),
+        "branch 1 (true) should have set BOLD, modifiers={:?}",
+        style.modifiers
+    );
+    assert!(
+        !style.modifiers.contains(Modifiers::ITALIC),
+        "branch 2 (false) should NOT have set ITALIC, modifiers={:?}",
+        style.modifiers
+    );
+    assert_eq!(
+        style.fg,
+        Some(Color::Cyan),
+        "branch 3 (true) should have set Cyan fg, got {:?}",
+        style.fg
+    );
+}
+
+// ── ContainerBuilder helpers ────────────────────────────────────────────
+
+#[test]
+fn container_with_if_true_applies_modifier() {
+    // When cond=true, container should have a Single-line border drawn around it.
+    let mut tb = TestBackend::new(20, 5);
+    tb.render(|ui| {
+        let _ = ui
+            .container()
+            .w(10)
+            .h(3)
+            .with_if(true, |c| c.border(Border::Single))
+            .col(|ui| {
+                ui.text("X");
+            });
+    });
+    // Border::Single uses '┌' at the top-left corner.
+    let line0 = tb.line(0);
+    assert!(
+        line0.contains('┌'),
+        "expected top-left border corner '┌' on line 0, got {line0:?}"
+    );
+}
+
+#[test]
+fn container_with_if_false_skips() {
+    // When cond=false, no border should be drawn.
+    let mut tb = TestBackend::new(20, 5);
+    tb.render(|ui| {
+        let _ = ui
+            .container()
+            .w(10)
+            .h(3)
+            .with_if(false, |c| c.border(Border::Single))
+            .col(|ui| {
+                ui.text("X");
+            });
+    });
+    let line0 = tb.line(0);
+    assert!(
+        !line0.contains('┌'),
+        "expected NO border corner '┌' when cond=false, got {line0:?}"
+    );
+}
+
+#[test]
+fn container_with_always_applies() {
+    // .with always runs — verify a title appears in the top border.
+    let mut tb = TestBackend::new(20, 5);
+    tb.render(|ui| {
+        let _ = ui
+            .container()
+            .w(12)
+            .h(3)
+            .border(Border::Single)
+            .with(|c| c.title("Hi"))
+            .col(|ui| {
+                ui.text("X");
+            });
+    });
+    tb.assert_contains("Hi");
+}
+
+#[test]
+fn container_with_if_chain_independently_applies_each_branch() {
+    // Three independent conditions on the container builder.
+    // True/False/True → border drawn (true), title "SKIP" never set (false),
+    // title "OK" set (true).
+    let mut tb = TestBackend::new(30, 5);
+    tb.render(|ui| {
+        let _ = ui
+            .container()
+            .w(20)
+            .h(3)
+            .with_if(true, |c| c.border(Border::Single))
+            .with_if(false, |c| c.title("SKIP"))
+            .with_if(true, |c| c.title("OK"))
+            .col(|ui| {
+                ui.text("X");
+            });
+    });
+
+    let line0 = tb.line(0);
+    assert!(
+        line0.contains('┌'),
+        "branch 1 (true) should draw border corner '┌', got {line0:?}"
+    );
+    tb.assert_contains("OK");
+    // SKIP must not appear anywhere.
+    for y in 0..tb.height() {
+        let l = tb.line(y);
+        assert!(
+            !l.contains("SKIP"),
+            "branch 2 (false) should not have set title 'SKIP', found on line {y}: {l:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

**Minor release** adding three public APIs for React-like component ergonomics. Additive; no breaking changes.

- **`ui.provide` / `ui.use_context::<T>()` / `try_use_context`** — scoped context injection; kills prop-drilling of theme/toast/tick across render helpers
- **`ui.use_state_named(id)` / `use_state_named_with`** — component-local state keyed by `&'static str`; safe inside conditional rendering
- **`.with_if(cond, modifier)` / `.with`** — fluent conditional styling on text and `ContainerBuilder`

Docs: new `## Components` section in `docs/PATTERNS.md` with patterns + comparison table + anti-patterns. `examples/demo_website.rs` refactored as a reference showcase of the new APIs.

## Issues closed

Closes #66 (provide / use_context), #68 (.with_if), #71 (use_state_named), #72 (PATTERNS components), #75 (demo_website refactor)

## Tests

- 32 new tests: `tests/context_provider.rs` (8), `tests/use_state_named.rs` (6), `tests/with_if.rs` (8), `tests/v0_19_api_integration.rs` (10 end-to-end)
- Core gate: fmt / check / clippy / test / examples — all green
- Extended gate: typos / no-default / wasm / cargo-hack (26 combos) / audit / deny — all green
- Semver check: additive only — no API break

## API preview

```rust
struct AppState { theme: Theme, tick: u64 }

slt::run(|ui| {
    ui.provide(AppState { theme: Theme::Dark, tick: 0 }, |ui| {
        render_home(ui);  // no more &Theme, no more tick param
    });
});

fn render_home(ui: &mut Context) {
    let app = ui.use_context::<AppState>();
    let expanded = ui.use_state_named::<bool>("home.expanded");
    ui.text("Status")
        .with_if(*expanded.get(ui), |t| { t.bold().fg(Color::Cyan); });
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)