### PR TITLE
feat: v0.19.2 — visual regression fixes + 34 v0.19.x patch-safe issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,79 @@
 
 ## [Unreleased]
 
+## [0.19.2] — 2026-04-27
+
+Patch release covering 34 v0.19.x issues plus two long-standing visual regressions
+caught during demo validation.
+
+### Fixes (Visual regressions)
+
+- **Bordered container title overdraws the top horizontal bar with spaces** — regression introduced in v0.19.1 (#160) when the CJK title clamp added a blank-pad pass that overwrote `─` cells with `' '`. ASCII titles like `cargo-slt` lost the surrounding `──` and rendered as `╭─cargo-slt           ╮` instead of `╭─cargo-slt──────╮`. The clamp now relies on `chars.h` (the original horizontal bar character) being already in place; only the clamped-title char is overwritten. CJK truncation correctness (the original purpose of #160) is preserved by the `UnicodeWidthChar` loop.
+- **`text_input()` claims all available vertical space in its parent column (regression dating to v0.17)** — `text_input_colored` always called `.grow(1)` on its bordered container, so a single-line input inside `bordered("Packages").p(1).grow(1).col(...)` would expand to fill the column and push siblings off-screen. Removed the implicit grow. Cross-axis stretch via the parent column still gives the input the full row width as before.
+
+### Added
+
+- **`examples/demo_cjk.rs`** — multi-language demo covering CJK title truncation, mixed Korean / Chinese / Japanese body wrap, narrow-clamp title boxes (12-cell width), and CJK form fields. Pins both regressions above and serves as a manual visual gate for future title-clamp / wrap changes.
+- **`feat(style)` — `ContainerStyle::mx(value)` / `my(value)`** (#108) — Tailwind-style horizontal/vertical margin shorthands.
+- **`feat(style)` — `Modifiers::remove(other)`** (#111) — opposite of `insert()`.
+- **`feat(theme)` — `Theme::builder_from(base)` and `Theme::light_builder()`** (#110) — start a `ThemeBuilder` from any `Theme` or from the `light` preset, instead of having to copy/reapply every field.
+- **`feat(theme)` — `ThemeBuilder` methods are `const fn`** (#109) — themes can now be defined in a `const` context for compile-time evaluation.
+- **`feat(widgets-display)` — `breadcrumb_response()` / `breadcrumb_response_with()`** (#182) — returns `(Response, Option<usize>)` so callers can read both the click index and the underlying interaction state.
+- **`feat(widgets-input)` — textarea kill-line (Ctrl+K) and word jump (Ctrl/Alt + ←/→)** (#103) — standard Emacs-style line and word movement on the multi-line input.
+
+### Fixes
+
+- **`fix(viz)` sixel auto-detection false positive on `xterm-256color`** (#116) — substring `"xterm"` previously fired on macOS Terminal, VS Code, and most SSH clients, none of which speak sixel. Replaced with an exact-match list (`mlterm`, `foot`, `yaft`, `xterm-256color-sixel`) plus the `"sixel"` substring catch-all and `SLT_FORCE_SIXEL=1` opt-in for patched builds.
+- **`fix(widgets-display)` `separator()` 200-char hardcoded string causes per-frame allocation and overflow** (#177) — `OnceLock`-cached `SEP_LINE` initialized once per process; `set_string` clip truncates the trailing chars on narrow terminals. Was already in place via #160 prep; this release closes the tracking issue.
+- **`fix(widgets-feedback)` `RichLogState::new()` defaults to unbounded entry accumulation** (#191) — bounded default of 10000 entries; `RichLogState::unbounded()` is the new opt-in for explicit unbounded callers.
+- **`fix(widgets-interactive)` `tabs` mouse `x - rect.x` underflow panic in debug builds** (#196) — `saturating_sub` on the offset.
+
+### Perf
+
+- **`perf(chart)` flat `Vec<T>` for plot buffers** (#117) — `plot_chars` and `plot_styles` are now contiguous `Vec<T>` instead of `Vec<Vec<T>>`. Removes per-row indirection and shrinks the per-frame allocation count.
+- **`perf(viz)` `squarify_recursive` no per-iter `Vec::clone`** (#115) — incremental sum / pos-min / pos-max / pos-count tracking via a closed-form `worst_ratio_incremental`. Inner loop is now alloc-free.
+- **`perf(viz)` `treemap` sort uses `total_cmp`** (#121) — replaces the `partial_cmp + NaN fallback` pattern, removing one branch per comparison.
+- **`perf(viz)` candlestick body renders at half-cell precision** (#123, closes #120) — body cells now emit `█` / `▀` / `▄` based on price-edge half-cell membership instead of full-cell snapping. Doc updated.
+- **`perf(viz)` `blend_color` lifted to a module-level helper** (#119) — eliminated three copies of the same closure.
+- **`perf(widgets-input)` `SpinnerState` static frame data** (#99) — `frames: Vec<char>` → `&'static [char]`. Removes the per-state heap allocation; constructor is now `const fn`-friendly.
+- **`perf(widgets-interactive)` `CommandPaletteState::filtered_indices` cache** (#101) — `fuzzy_score` no longer runs twice per render. Cache is invalidated on `toggle()`.
+- **`perf(widgets-interactive)` `parse_inline_segments` byte-index scan** (#176) — markdown inline tokens (`**`, `*`, `` ` ``) are scanned via byte indices into `text.as_bytes()` instead of `chars[i+N..].iter().collect::<String>()`. Multi-byte characters in `inner` are never split.
+- **`perf(widgets-interactive)` `recompute_widths` dirty-flag short-circuit** (#195) — table column widths are only recomputed when the items vector or filter actually changed, instead of once per frame.
+- **`perf(widgets-interactive)` `collect_grid_elements` extracted** (#194) — 41-line duplicate between `grid()` and `grid_with()` lifted into a shared free function.
+- **`perf(hooks)` single `downcast_mut` in `use_memo` cache-hit path** (#133) — eliminates the redundant second `downcast_ref` after key comparison; type mismatch panics with the hook index instead of silently overwriting.
+- **`perf(events)` `SmallVec<[usize; 8]>` in `consume_activation_keys`** (#135) — typical button activation queues 0-2 indices; the 8-slot stack buffer keeps these allocation-free.
+- **`perf(table)` extract `let visible = state.visible_indices()` local binding in `table_visible_len`** (#140) — avoids re-traversing the filter chain inside the loop.
+- **`perf(widgets-display)` `streaming_text` no per-frame content clone** (#178) — caller buffer borrowed via `&str` instead of cloned into `Command::Text`.
+- **`perf(widgets-display)` `scrollbar` static cell glyphs** (#179) — `'█'.to_string()` / `'│'.to_string()` per-cell allocations replaced with `const THUMB: &str / const TRACK: &str`.
+- **`perf(widgets-display)` `code_block_numbered` gutter via `ilog10`** (#180) — gutter width derived from `lines.len().ilog10()` instead of `format!("{}", lines.len()).len()`.
+- **`perf(widgets-display)` `definition_list` manual padding** (#181) — eliminates the per-row `format!()` for right-aligned key padding.
+- **`perf(terminal)` `extract_selection_text` `truncate(trim_end().len())`** (#173) — drops the trailing `to_string()` reallocation.
+
+### Refactor
+
+- **`refactor(widgets-display)` `separator()` moved from `widgets_interactive/events.rs` to `widgets_display/layout.rs`** (#183) — same `impl Context` so the public call site is unchanged. Restores topical placement (separator is a display widget, not an event helper).
+- **`refactor(viz)` `blend_color` helper extracted** (#119) — see Perf above; flagged as refactor in the issue tracker.
+
+### Docs
+
+- **`docs(buffer)` `Buffer::diff()` documents per-call `Vec` allocation cost and hot-path warning** (#170).
+- **`docs(style)` `Align::Start` clarifies CSS-stretch semantics** (#165) — documents the `flex-start` vs CSS-stretch divergence.
+
+### Tests
+
+- **`test(cell)` compile-time `Cell` size assertion** (#167) — `const _: () = assert!(size_of::<Cell>() <= N);` catches accidental field-bloat regressions at build time.
+
+### Closed (already implemented)
+
+- #132, #125, #136, #138, #118, #177, #179 — verified that the working code already matches the proposed solution; closed without further changes.
+
+### Deferred to v0.19.3
+
+- **#102** (textarea undo / redo Ctrl+Z / Ctrl+Y) — landed during the wave but reverted: the implementation requires three new `pub(crate)` fields on `TextareaState`, and `cargo-semver-checks` reports `constructible_struct_adds_private_field` as a major-version break. v0.19.1 followed the same constraint for #94 (deferred to v0.20.0) — this is the same constraint applied here. Will re-apply alongside #94 in the v0.20.0 textarea state revision (or, if patch-safe, by gating history behind a separate state type that the textarea looks up via `use_state_named`).
+- **#171** (`terminal` per-row hash skip in `flush_buffer_diff`) — landed during the wave but reverted: the issue body's own bench gate (`< 50µs → NO-GO`) was not met, and a regression test caught a row-skip case where the dirty-flag interaction lost a changed row. Will re-evaluate once a dedicated bench rig lands.
+- **#150 / #152 / #153 / #155 / #157 / #162** (layout perf — commands buffer reuse, `group_name → Arc<str>`, `LayoutNode::TextData` boxing, `FrameData` reuse, `wrap_segments` scratch, viewport bound check) — landed but reverted while triaging the unrelated v0.19.1 title-clamp regression. Will re-apply on top of the title fix in v0.19.3 with isolated visual gates.
+- **#146 / #147 / #148** (container — `filled_circle` `isqrt`, `min_h` / `max_h` breakpoint variants, deprecation of long-form aliases) — same triage cycle as the layout perf set; re-apply in v0.19.3.
+
 ## [0.19.1] — 2026-04-27
 
 ### Fixes (Blocker)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,7 +1052,7 @@ checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "superlighttui"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "compact_str",
  "criterion",
@@ -1063,6 +1063,7 @@ dependencies = [
  "proptest",
  "qrcode",
  "serde",
+ "smallvec",
  "tokio",
  "tree-sitter-bash",
  "tree-sitter-c",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/slt-wasm"]
 
 [package]
 name = "superlighttui"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2021"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"
@@ -22,6 +22,7 @@ name = "slt"
 [dependencies]
 crossterm = { version = "0.28", features = ["bracketed-paste"], optional = true }
 unicode-width = "0.2"
+smallvec = "1"
 tokio = { version = "1", features = ["rt", "sync", "macros", "time"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 image = { version = "0.25", optional = true, default-features = false, features = ["png", "jpeg"] }
@@ -176,6 +177,10 @@ path = "examples/demo_game.rs"
 [[example]]
 name = "demo_kitty_image"
 path = "examples/demo_kitty_image.rs"
+
+[[example]]
+name = "demo_cjk"
+path = "examples/demo_cjk.rs"
 
 [[bench]]
 name = "benchmarks"

--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -80,13 +80,13 @@ fn main() -> std::io::Result<()> {
         let _ = ui
             .bordered(Border::Rounded)
             .title("Animation Primitives — SLT v0.5.0")
-            .pad(1)
+            .p(1)
             .gap(1)
             .col(|ui| {
                 let _ = ui
                     .bordered(Border::Single)
                     .title("Tween")
-                    .pad(1)
+                    .p(1)
                     .gap(1)
                     .col(|ui| {
                         ui.text("Press Space to retarget");
@@ -102,7 +102,7 @@ fn main() -> std::io::Result<()> {
                 let _ = ui
                     .bordered(Border::Single)
                     .title("Spring")
-                    .pad(1)
+                    .p(1)
                     .gap(1)
                     .col(|ui| {
                         ui.text("Up/k +10, Down/j -10");
@@ -117,7 +117,7 @@ fn main() -> std::io::Result<()> {
                 let _ = ui
                     .bordered(Border::Single)
                     .title("Keyframes")
-                    .pad(1)
+                    .p(1)
                     .gap(1)
                     .col(|ui| {
                         let kf_val = kf.value(ui.tick());
@@ -133,7 +133,7 @@ fn main() -> std::io::Result<()> {
                 let _ = ui
                     .bordered(Border::Single)
                     .title("Sequence")
-                    .pad(1)
+                    .p(1)
                     .gap(1)
                     .col(|ui| {
                         let seq_val = seq.value(ui.tick());
@@ -149,7 +149,7 @@ fn main() -> std::io::Result<()> {
                 let _ = ui
                     .bordered(Border::Single)
                     .title("Stagger")
-                    .pad(1)
+                    .p(1)
                     .gap(1)
                     .col(|ui| {
                         let labels = ["Item A", "Item B", "Item C", "Item D", "Item E"];

--- a/examples/async_demo.rs
+++ b/examples/async_demo.rs
@@ -25,7 +25,7 @@ async fn main() -> std::io::Result<()> {
         let _ = ui
             .bordered(Border::Rounded)
             .title("Async Demo")
-            .pad(1)
+            .p(1)
             .gap(1)
             .col(|ui| {
                 ui.text("Background updates from tokio task")

--- a/examples/cookbook_dashboard.rs
+++ b/examples/cookbook_dashboard.rs
@@ -64,18 +64,18 @@ fn main() -> std::io::Result<()> {
         let _ = ui
             .bordered(Border::Rounded)
             .title("Cookbook — Dashboard")
-            .pad(1)
+            .p(1)
             .gap(1)
             .grow(1)
             .col(|ui| {
                 let _ = ui.row_gap(2, |ui| {
-                    let _ = ui.bordered(Border::Single).pad(1).grow(1).col(|ui| {
+                    let _ = ui.bordered(Border::Single).p(1).grow(1).col(|ui| {
                         let _ = ui.stat_colored("CPU", &format!("{:.1}%", m.cpu), Color::Cyan);
                     });
-                    let _ = ui.bordered(Border::Single).pad(1).grow(1).col(|ui| {
+                    let _ = ui.bordered(Border::Single).p(1).grow(1).col(|ui| {
                         let _ = ui.stat_colored("Memory", &format!("{:.1}%", m.mem), Color::Yellow);
                     });
-                    let _ = ui.bordered(Border::Single).pad(1).grow(1).col(|ui| {
+                    let _ = ui.bordered(Border::Single).p(1).grow(1).col(|ui| {
                         let _ =
                             ui.stat_colored("Req/s", &format!("{:.0}", m.req_per_s), Color::Green);
                     });

--- a/examples/cookbook_file_picker.rs
+++ b/examples/cookbook_file_picker.rs
@@ -73,7 +73,7 @@ fn main() -> std::io::Result<()> {
         let _ = ui
             .bordered(Border::Rounded)
             .title("Cookbook — File Picker")
-            .pad(1)
+            .p(1)
             .gap(1)
             .grow(1)
             .col(|ui| {
@@ -81,7 +81,7 @@ fn main() -> std::io::Result<()> {
                     let _ = ui
                         .bordered(Border::Single)
                         .title("Files")
-                        .pad(1)
+                        .p(1)
                         .grow(1)
                         .col(|ui| {
                             let _ = ui.file_picker(&mut picker);
@@ -90,7 +90,7 @@ fn main() -> std::io::Result<()> {
                     let _ = ui
                         .bordered(Border::Single)
                         .title("Preview")
-                        .pad(1)
+                        .p(1)
                         .grow(2)
                         .col(|ui| match preview.as_ref() {
                             Some(Ok(text)) if !text.is_empty() => {

--- a/examples/cookbook_login.rs
+++ b/examples/cookbook_login.rs
@@ -27,7 +27,7 @@ fn main() -> std::io::Result<()> {
             let _ = ui
                 .bordered(Border::Rounded)
                 .title("Cookbook — Login")
-                .pad(2)
+                .p(2)
                 .grow(1)
                 .center()
                 .col(|ui| {
@@ -45,7 +45,7 @@ fn main() -> std::io::Result<()> {
         let _ = ui
             .bordered(Border::Rounded)
             .title("Cookbook — Login")
-            .pad(2)
+            .p(2)
             .gap(1)
             .grow(1)
             .col(|ui| {

--- a/examples/cookbook_modal_toast.rs
+++ b/examples/cookbook_modal_toast.rs
@@ -30,7 +30,7 @@ fn main() -> std::io::Result<()> {
         let _ = ui
             .bordered(Border::Rounded)
             .title("Cookbook — Modal + Toast")
-            .pad(2)
+            .p(2)
             .gap(1)
             .grow(1)
             .col(|ui| {
@@ -58,7 +58,7 @@ fn main() -> std::io::Result<()> {
                 let _ = ui
                     .bordered(Border::Rounded)
                     .title("Confirm")
-                    .pad(2)
+                    .p(2)
                     .gap(1)
                     .col(|ui| {
                         ui.text("Delete this item? This cannot be undone.").bold();

--- a/examples/cookbook_table.rs
+++ b/examples/cookbook_table.rs
@@ -43,7 +43,7 @@ fn main() -> std::io::Result<()> {
         let _ = ui
             .bordered(Border::Rounded)
             .title("Cookbook — Table")
-            .pad(1)
+            .p(1)
             .gap(1)
             .grow(1)
             .col(|ui| {

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -15,7 +15,7 @@ fn main() -> std::io::Result<()> {
         let _ = ui
             .bordered(Border::Single)
             .title("Counter")
-            .pad(1)
+            .p(1)
             .gap(1)
             .col(|ui| {
                 ui.text("SLT Counter").bold().fg(Color::Cyan);

--- a/examples/debug_selection.rs
+++ b/examples/debug_selection.rs
@@ -9,14 +9,14 @@ fn main() -> std::io::Result<()> {
         ui.text("Drag in left panel only. q = quit").dim();
 
         let _ = ui.row(|ui| {
-            let _ = ui.bordered(Border::Rounded).pad(1).grow(1).col(|ui| {
+            let _ = ui.bordered(Border::Rounded).p(1).grow(1).col(|ui| {
                 ui.text("Left 1: Hello").fg(Color::Cyan);
                 ui.text("Left 2: World").fg(Color::Cyan);
                 ui.text("Left 3: Rust").fg(Color::Cyan);
                 ui.text("Left 4: SLT").fg(Color::Cyan);
                 ui.text("Left 5: Done").fg(Color::Cyan);
             });
-            let _ = ui.bordered(Border::Rounded).pad(1).grow(1).col(|ui| {
+            let _ = ui.bordered(Border::Rounded).p(1).grow(1).col(|ui| {
                 ui.text("Right 1: Alpha").fg(Color::Magenta);
                 ui.text("Right 2: Beta").fg(Color::Magenta);
                 ui.text("Right 3: Gamma").fg(Color::Magenta);

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -279,7 +279,7 @@ fn main() -> std::io::Result<()> {
             let _ = ui
                 .container()
                 .border(Border::Rounded)
-                .pad(1)
+                .p(1)
                 .grow(1)
                 .col(|ui| {
                     let _ = ui.row(|ui| {
@@ -420,7 +420,7 @@ fn main() -> std::io::Result<()> {
                         .container()
                         .bg(theme.surface)
                         .border(Border::Rounded)
-                        .pad(2)
+                        .p(2)
                         .col(|ui| {
                             ui.text("Modal Demo").bold().fg(theme.primary);
                             ui.text("This modal stays in the demo.")
@@ -648,7 +648,7 @@ fn render_layout(
                         .container()
                         .bg(theme.surface_hover)
                         .border(Border::Rounded)
-                        .pad(1)
+                        .p(1)
                         .col(|ui| {
                             ui.text(format!("Cell {i}")).fg(theme.surface_text);
                         });
@@ -703,7 +703,7 @@ fn render_layout(
                 .container()
                 .bg(theme.surface_hover)
                 .border(Border::Rounded)
-                .pad(1)
+                .p(1)
                 .align(Align::Start)
                 .col(|ui| {
                     ui.text("Start").fg(theme.primary);
@@ -712,7 +712,7 @@ fn render_layout(
                 .container()
                 .bg(theme.surface_hover)
                 .border(Border::Rounded)
-                .pad(1)
+                .p(1)
                 .align(Align::Center)
                 .col(|ui| {
                     ui.text("Center").fg(theme.secondary);
@@ -721,7 +721,7 @@ fn render_layout(
                 .container()
                 .bg(theme.surface_hover)
                 .border(Border::Rounded)
-                .pad(1)
+                .p(1)
                 .align(Align::End)
                 .col(|ui| {
                     ui.text("End").fg(theme.accent);
@@ -735,7 +735,7 @@ fn render_layout(
                 .container()
                 .bg(theme.surface_hover)
                 .border(Border::Rounded)
-                .pad(1)
+                .p(1)
                 .justify(Justify::SpaceBetween)
                 .row(|ui| {
                     ui.text("A").fg(theme.primary);
@@ -746,7 +746,7 @@ fn render_layout(
                 .container()
                 .bg(theme.surface_hover)
                 .border(Border::Rounded)
-                .pad(1)
+                .p(1)
                 .space_around()
                 .row(|ui| {
                     ui.text("A").fg(theme.primary);
@@ -765,7 +765,7 @@ fn render_layout(
                     .container()
                     .bg(theme.surface)
                     .border(Border::Rounded)
-                    .pad(1)
+                    .p(1)
                     .col(|ui| {
                         ui.text("Overlay Active").fg(theme.warning);
                         ui.text("Press o to toggle").fg(theme.surface_text);
@@ -1105,7 +1105,7 @@ fn render_advanced(
             let _ = ui.container()
                 .bg(theme.surface_hover)
                 .border(Border::Rounded)
-                .pad(1)
+                .p(1)
                 .col(|ui| {
                     ui.text("line_wrap()").bold().fg(theme.accent);
                     ui.line_wrap(|ui| {
@@ -1128,7 +1128,7 @@ fn render_advanced(
                 .bg(theme.surface_hover)
                 .border(Border::Single)
                 .border_sides(BorderSides::horizontal())
-                .pad(1)
+                .p(1)
                 .col(|ui| {
                     ui.text("Horizontal borders").fg(theme.surface_text);
                 });
@@ -1137,7 +1137,7 @@ fn render_advanced(
                 .bg(theme.surface_hover)
                 .border(Border::Single)
                 .border_sides(BorderSides::vertical())
-                .pad(1)
+                .p(1)
                 .col(|ui| {
                     ui.text("Vertical borders").fg(theme.surface_text);
                 });
@@ -1147,7 +1147,7 @@ fn render_advanced(
                     .bg(theme.surface_hover)
                     .border(Border::Rounded)
                     .w_pct(30)
-                    .pad(1)
+                    .p(1)
                     .col(|ui| {
                         ui.text("30%").fg(theme.primary);
                     });
@@ -1155,7 +1155,7 @@ fn render_advanced(
                     .bg(theme.surface_hover)
                     .border(Border::Rounded)
                     .w_pct(70)
-                    .pad(1)
+                    .p(1)
                     .col(|ui| {
                         ui.text("70%").fg(theme.secondary);
                     });
@@ -1217,10 +1217,10 @@ fn render_v070(
             ui.text("Dashed Borders").bold().fg(theme.primary);
             ui.text("2 new border variants").fg(theme.surface_text);
 
-            let _ = ui.container().border(Border::Dashed).pad(1).col(|ui| {
+            let _ = ui.container().border(Border::Dashed).p(1).col(|ui| {
                 ui.text("Border::Dashed").fg(theme.text);
             });
-            let _ = ui.container().border(Border::DashedThick).pad(1).col(|ui| {
+            let _ = ui.container().border(Border::DashedThick).p(1).col(|ui| {
                 ui.text("Border::DashedThick").fg(theme.text);
             });
         });
@@ -1691,7 +1691,7 @@ fn render_v013(
 
         if *show_modal {
             let r = ui.modal(|ui| {
-                let _ = ui.bordered(Border::Rounded).pad(2).col(|ui| {
+                let _ = ui.bordered(Border::Rounded).p(2).col(|ui| {
                     ui.text("Modal with Focus Trap").bold().fg(theme.primary);
                     ui.text("Tab only cycles within this modal")
                         .fg(theme.surface_text);
@@ -2209,7 +2209,7 @@ fn card(ui: &mut Context, f: impl FnOnce(&mut Context)) {
         .container()
         .bg(theme.surface)
         .border(Border::Rounded)
-        .pad(1)
+        .p(1)
         .grow(1)
         .col(f);
 }

--- a/examples/demo_cjk.rs
+++ b/examples/demo_cjk.rs
@@ -1,0 +1,176 @@
+//! Demo: CJK (Korean / Chinese / Japanese) title and content rendering with mouse interaction.
+//!
+//! Verifies:
+//! - Title with CJK characters does not overflow the right border.
+//! - Long titles are truncated cleanly at the box width.
+//! - Mixed ASCII / CJK works in text bodies and form fields.
+//! - Wide-char width is accounted for so wrap/truncate stays inside the box.
+//! - Mouse hover and click work on bordered cards (group_hover_border_style + clicked).
+//! - Focus cycling between text inputs works programmatically (set_focus_index).
+
+use slt::widgets::TextInputState;
+use slt::{Border, Color, Context, Style};
+
+const CARD_TITLES: [&str; 4] = ["설정창", "管理设置", "設定パネル", "Mixed 한中日 abc"];
+
+fn main() -> std::io::Result<()> {
+    let mut name_input = TextInputState::with_placeholder("이름을 입력하세요");
+    let mut tag_input = TextInputState::with_placeholder("태그");
+
+    slt::run(|ui: &mut Context| {
+        // Per-frame snapshots of mouse position and focus state, captured up
+        // front so the closing status bar can read them without disturbing
+        // the layout pass.
+        let mouse_pos = ui.mouse_pos();
+        let focus_index = ui.focus_index();
+        let focus_count = ui.focus_count();
+
+        // Per-card click counters and "last clicked" label persist across
+        // frames via `use_state`. Order is fixed at the top of the closure
+        // so the hook cursor stays stable.
+        let counts_state = ui.use_state(|| [0u32; 4]);
+        let last_clicked_state = ui.use_state(|| Option::<String>::None);
+
+        let _ = ui
+            .bordered(Border::Rounded)
+            .title("한글 / 中文 / 日本語 demo")
+            .p(1)
+            .grow(1)
+            .col(|ui| {
+                ui.text("CJK 위젯 데모 — Ctrl+Q to quit · 카드를 클릭해 보세요")
+                    .bold()
+                    .fg(Color::Cyan);
+                ui.separator();
+
+                let _ = ui.row(|ui| {
+                    let _ = ui
+                        .bordered(Border::Rounded)
+                        .title("짧은 제목")
+                        .p(1)
+                        .grow(1)
+                        .col(|ui| {
+                            ui.text("한국어 본문이 박스 안에 잘 들어가는지 확인합니다.")
+                                .wrap();
+                            ui.text("中文 段落 — 测试中文换行与右边界裁剪。").wrap();
+                            ui.text("日本語 — 折り返しと右端の境界を確認します。")
+                                .wrap();
+                        });
+
+                    let _ = ui
+                        .bordered(Border::Rounded)
+                        .title("Mixed 한·中·日 title overflow test")
+                        .p(1)
+                        .grow(1)
+                        .col(|ui| {
+                            ui.text("Long titles must clip without breaking the right border (┐).");
+                            ui.text("긴 제목은 오른쪽 테두리를 침범하지 않아야 합니다.")
+                                .wrap();
+                        });
+                });
+
+                ui.separator();
+                let _ = ui.row(|ui| {
+                    // Group name encodes the focus role so `is_group_focused`
+                    // (used by `text_input` internally) stays unique even if
+                    // the title text were to change later.
+                    let _ = ui
+                        .group("input-name")
+                        .border(Border::Rounded)
+                        .title("입력")
+                        .p(1)
+                        .grow(1)
+                        .col(|ui| {
+                            ui.text("이름:").dim();
+                            let _ = ui.text_input(&mut name_input);
+                            ui.text("태그:").dim();
+                            let _ = ui.text_input(&mut tag_input);
+                            ui.text("Tab으로 포커스 이동, 또는 아래 [포커스] 버튼")
+                                .dim();
+                        });
+
+                    let _ = ui
+                        .bordered(Border::Rounded)
+                        .title("결과")
+                        .p(1)
+                        .grow(1)
+                        .col(|ui| {
+                            ui.text(format!("이름 = {}", name_input.value)).bold();
+                            ui.text(format!("태그 = {}", tag_input.value)).bold();
+                            let total: u32 = counts_state.get(ui).iter().sum();
+                            ui.text(format!("카드 클릭 합계 = {total}"))
+                                .fg(Color::Green);
+                        });
+                });
+
+                ui.separator();
+                ui.text("Truncation table — 각 박스는 너비 12, 제목이 잘려야 정상 (hover/click)")
+                    .dim();
+                let _ = ui.row(|ui| {
+                    // Read counts up front so the click handler below can set
+                    // the next value without holding an immutable borrow on
+                    // `ui` while we also read `is_group_hovered`.
+                    let counts_now = *counts_state.get(ui);
+                    let mut clicked: Option<usize> = None;
+
+                    for (idx, title) in CARD_TITLES.iter().enumerate() {
+                        // Stable per-card group name. The `card-` prefix keeps
+                        // it from colliding with future groups; the index is
+                        // the load-bearing part for `is_group_hovered`.
+                        let group_name = format!("card-{idx}");
+                        let count = counts_now[idx];
+                        let resp = ui
+                            .group(&group_name)
+                            .border(Border::Single)
+                            .group_hover_border_style(Style::new().fg(Color::Yellow))
+                            .min_w(12)
+                            .max_w(12)
+                            .p(0)
+                            .title(*title)
+                            .col(|ui| {
+                                if ui.is_group_hovered(&group_name) {
+                                    ui.text(format!("hits {count}")).fg(Color::Yellow);
+                                } else {
+                                    ui.text(format!("hits {count}")).dim();
+                                }
+                            });
+                        if resp.clicked {
+                            clicked = Some(idx);
+                        }
+                    }
+
+                    if let Some(idx) = clicked {
+                        let counts = counts_state.get_mut(ui);
+                        counts[idx] = counts[idx].saturating_add(1);
+                        *last_clicked_state.get_mut(ui) = Some(CARD_TITLES[idx].to_string());
+                    }
+                });
+
+                ui.separator();
+                let _ = ui.row(|ui| {
+                    let last_label = last_clicked_state
+                        .get(ui)
+                        .clone()
+                        .unwrap_or_else(|| "(none)".to_string());
+                    let mouse_label = match mouse_pos {
+                        Some((x, y)) => format!("mouse=({x},{y})"),
+                        None => "mouse=(—)".to_string(),
+                    };
+                    ui.text(format!("{mouse_label}  ·  last clicked = {last_label}"))
+                        .dim();
+                    ui.text(format!("focus={focus_index}/{focus_count}")).dim();
+
+                    if ui.button("초기화 / Reset").clicked {
+                        *counts_state.get_mut(ui) = [0; 4];
+                        *last_clicked_state.get_mut(ui) = None;
+                        name_input.value.clear();
+                        tag_input.value.clear();
+                        name_input.cursor = 0;
+                        tag_input.cursor = 0;
+                    }
+                    if ui.button("포커스 / Focus next").clicked && focus_count > 0 {
+                        ui.set_focus_index((focus_index + 1) % focus_count);
+                    }
+                });
+            });
+    })
+}

--- a/examples/demo_cli.rs
+++ b/examples/demo_cli.rs
@@ -192,7 +192,7 @@ fn main() -> std::io::Result<()> {
         let _ = ui
             .bordered(Border::Rounded)
             .title("cargo-slt")
-            .pad(1)
+            .p(1)
             .grow(1)
             .col(|ui| {
                 let _ = ui.row(|ui| {
@@ -207,7 +207,7 @@ fn main() -> std::io::Result<()> {
                     let _ = ui
                         .bordered(Border::Rounded)
                         .title("Packages")
-                        .pad(1)
+                        .p(1)
                         .grow(1)
                         .col(|ui| {
                             let _ = ui.text_input(&mut search);
@@ -249,7 +249,7 @@ fn main() -> std::io::Result<()> {
                         let _ = ui
                             .bordered(Border::Rounded)
                             .title("Details")
-                            .pad(1)
+                            .p(1)
                             .col(|ui| {
                                 ui.text(pkg.name).bold().fg(Color::Cyan);
                                 ui.text(format!("v{}", pkg.version)).dim();
@@ -322,7 +322,7 @@ fn main() -> std::io::Result<()> {
                         let _ = ui
                             .bordered(Border::Rounded)
                             .title("Output")
-                            .pad(1)
+                            .p(1)
                             .grow(1)
                             .col(|ui| {
                                 let _ = ui.scrollable(&mut output_scroll).grow(1).col(|ui| {

--- a/examples/demo_dashboard.rs
+++ b/examples/demo_dashboard.rs
@@ -82,7 +82,7 @@ fn main() -> std::io::Result<()> {
         let _ = ui
             .bordered(Border::Rounded)
             .title("System Dashboard")
-            .pad(1)
+            .p(1)
             .grow(1)
             .col(|ui| {
                 let _ = ui.row(|ui| {
@@ -118,11 +118,11 @@ fn main() -> std::io::Result<()> {
 
                 let _ = ui.divider_text("Key Metrics");
                 let _ = ui.row(|ui| {
-                    let _ = ui.bordered(Border::Rounded).pad(1).grow(1).col(|ui| {
+                    let _ = ui.bordered(Border::Rounded).p(1).grow(1).col(|ui| {
                         let _ =
                             ui.stat_trend("Requests", &format!("{}", metrics.requests), Trend::Up);
                     });
-                    let _ = ui.bordered(Border::Rounded).pad(1).grow(1).col(|ui| {
+                    let _ = ui.bordered(Border::Rounded).p(1).grow(1).col(|ui| {
                         let _ = ui.stat_colored(
                             "Errors",
                             &format!("{}", metrics.errors),
@@ -133,10 +133,10 @@ fn main() -> std::io::Result<()> {
                             },
                         );
                     });
-                    let _ = ui.bordered(Border::Rounded).pad(1).grow(1).col(|ui| {
+                    let _ = ui.bordered(Border::Rounded).p(1).grow(1).col(|ui| {
                         let _ = ui.stat_colored("P99", "45ms", Color::Yellow);
                     });
-                    let _ = ui.bordered(Border::Rounded).pad(1).grow(1).col(|ui| {
+                    let _ = ui.bordered(Border::Rounded).p(1).grow(1).col(|ui| {
                         let _ = ui.stat_colored("Threads", "24", Color::Blue);
                     });
                 });
@@ -146,7 +146,7 @@ fn main() -> std::io::Result<()> {
                     let _ = ui
                         .bordered(Border::Rounded)
                         .title("Processes")
-                        .pad(1)
+                        .p(1)
                         .grow(1)
                         .col(|ui| {
                             let _ = ui.table(&mut proc_table);
@@ -175,7 +175,7 @@ fn main() -> std::io::Result<()> {
                     let _ = ui
                         .bordered(Border::Rounded)
                         .title("Logs")
-                        .pad(1)
+                        .p(1)
                         .grow(1)
                         .col(|ui| {
                             let _ = ui.scrollable(&mut log_scroll).grow(1).col(|ui| {
@@ -208,7 +208,7 @@ fn main() -> std::io::Result<()> {
 }
 
 fn metric_card(ui: &mut Context, label: &str, value: f64, unit: &str, color: Color) {
-    let resp = ui.bordered(Border::Single).pad(1).grow(1).col(|ui| {
+    let resp = ui.bordered(Border::Single).p(1).grow(1).col(|ui| {
         ui.text(label).dim();
         ui.text(format!("{value:.1}{unit}")).bold().fg(color);
         let bar_w = 10;

--- a/examples/demo_raw_draw.rs
+++ b/examples/demo_raw_draw.rs
@@ -17,7 +17,7 @@ fn main() {
             let _ = ui
                 .bordered(Border::Rounded)
                 .title("draw_raw demo")
-                .pad(1)
+                .p(1)
                 .gap(1)
                 .col(|ui| {
                     ui.text("Direct buffer access via ContainerBuilder::draw()")

--- a/examples/demo_spreadsheet.rs
+++ b/examples/demo_spreadsheet.rs
@@ -320,7 +320,7 @@ fn main() -> std::io::Result<()> {
         let _ = ui
             .bordered(Border::Rounded)
             .title("Spreadsheet")
-            .pad(1)
+            .p(1)
             .grow(1)
             .col(|ui| {
                 // formula bar

--- a/examples/demo_table.rs
+++ b/examples/demo_table.rs
@@ -42,7 +42,7 @@ fn main() -> std::io::Result<()> {
         });
         let theme = *ui.theme();
 
-        let _ = ui.container().pad(1).grow(1).col(|ui| {
+        let _ = ui.container().p(1).grow(1).col(|ui| {
             let _ = ui.row(|ui| {
                 ui.text("Table Demo").bold().fg(theme.primary);
                 ui.spacer();

--- a/examples/demo_website.rs
+++ b/examples/demo_website.rs
@@ -540,7 +540,7 @@ fn render_docs(ui: &mut Context) {
             "rust",
             "ui.container()\n\
              \x20   .gap(1)                // space between children\n\
-             \x20   .pad(2)                // inner padding (all sides)\n\
+             \x20   .p(2)                // inner padding (all sides)\n\
              \x20   .padding(Padding::xy(4, 1))  // horizontal=4, vertical=1\n\
              \x20   .margin(Margin::new(1,1,0,0))\n\
              \x20   .col(|ui| { /* ... */ });",
@@ -571,7 +571,7 @@ fn render_docs(ui: &mut Context) {
             "rust",
             "ui.bordered(Border::Rounded)\n\
              \x20   .title(\"My Section\")\n\
-             \x20   .pad(1)\n\
+             \x20   .p(1)\n\
              \x20   .col(|ui| {\n\
              \x20       ui.text(\"inside\");\n\
              \x20   });",
@@ -861,7 +861,7 @@ fn render_blog(ui: &mut Context, blog_view: &mut Option<usize>) {
             );
 
             for (i, post) in BLOG_POSTS.iter().enumerate() {
-                let resp = ui.container().bg(theme.surface).pad(1).col(|ui| {
+                let resp = ui.container().bg(theme.surface).p(1).col(|ui| {
                     let _ = ui.row(|ui| {
                         ui.text(post.date).fg(theme.surface_text);
                         ui.text(" · ").fg(theme.surface_text);
@@ -1151,12 +1151,12 @@ fn render_post_dashboard_tutorial(ui: &mut Context) {
         ui,
         "rust",
         "ui.row(|ui| {\n\
-         \x20   ui.bordered(Border::Rounded).grow(1).pad(1).col(|ui| {\n\
+         \x20   ui.bordered(Border::Rounded).grow(1).p(1).col(|ui| {\n\
          \x20       ui.text(\"CPU\").dim();\n\
          \x20       ui.text(\"42%\").bold().fg(theme.primary);\n\
          \x20       ui.progress(0.42);\n\
          \x20   });\n\
-         \x20   ui.bordered(Border::Rounded).grow(1).pad(1).col(|ui| {\n\
+         \x20   ui.bordered(Border::Rounded).grow(1).p(1).col(|ui| {\n\
          \x20       ui.text(\"Memory\").dim();\n\
          \x20       ui.text(\"2.1 GB / 8 GB\").bold().fg(theme.success);\n\
          \x20       ui.progress(0.26);\n\
@@ -1192,7 +1192,7 @@ fn render_post_dashboard_tutorial(ui: &mut Context) {
     md_code_block(
         ui,
         "rust",
-        "ui.scrollable(&mut scroll).max_height(10).col(|ui| {\n\
+        "ui.scrollable(&mut scroll).max_h(10).col(|ui| {\n\
          \x20   for log in &logs {\n\
          \x20       ui.text(log).dim();\n\
          \x20   }\n\
@@ -1290,7 +1290,7 @@ fn render_post_flexbox(ui: &mut Context) {
 
     md_h2(ui, "The Mapping");
 
-    let _ = ui.bordered(Border::Rounded).pad(1).col(|ui| {
+    let _ = ui.bordered(Border::Rounded).p(1).col(|ui| {
         let _ = ui.row(|ui| {
             ui.styled(
                 format!("{:<32}", "CSS"),
@@ -1306,12 +1306,12 @@ fn render_post_flexbox(ui: &mut Context) {
             ("gap: 8px", ".gap(1)"),
             ("flex-grow: 1", ".grow(1)"),
             ("flex-shrink: 0", ".shrink(0)"),
-            ("padding: 8px", ".pad(1)"),
+            ("padding: 8px", ".p(1)"),
             ("padding: 8px 16px", ".padding(Padding::xy(2, 1))"),
             ("margin: 4px", ".margin(Margin::all(1))"),
             ("align-items: center", ".align(Align::Center)"),
-            ("min-width: 20px", ".min_width(20)"),
-            ("max-height: 10px", ".max_height(10)"),
+            ("min-width: 20px", ".min_w(20)"),
+            ("max-height: 10px", ".max_h(10)"),
             ("overflow: scroll", "ui.scrollable(&mut s)"),
             ("overflow: hidden", "automatic on containers"),
             ("border: 1px solid", ".border(Border::Single)"),
@@ -1375,7 +1375,7 @@ fn render_post_flexbox(ui: &mut Context) {
          \n\
          \x20   // Main content: sidebar + body\n\
          \x20   ui.row(|ui| {\n\
-         \x20       ui.container().min_width(20).col(|ui| {\n\
+         \x20       ui.container().min_w(20).col(|ui| {\n\
          \x20           ui.list(&mut menu);\n\
          \x20       });\n\
          \x20       ui.container().grow(1).col(|ui| {\n\
@@ -1506,7 +1506,7 @@ fn render_pricing(
         ui.text("");
         let _ = ui.container()
             .bg(theme.surface)
-            .pad(1)
+            .p(1)
             .col(|ui| {
                 ui.text("Ship faster with SLT").bold().fg(theme.primary);
                 ui.text(
@@ -1539,7 +1539,7 @@ fn render_pricing(
                 }
                 let _ = ui.bordered(Border::Rounded)
                     .bg(theme.surface)
-                    .pad(2)
+                    .p(2)
                     .max_w(56)
                     .col(|ui| {
                         ui.text("✦ Confirm Subscription").bold().fg(theme.primary);
@@ -1770,7 +1770,7 @@ fn price_card(
         .container()
         .with_if(highlight, |c| c.border(Border::Rounded))
         .bg(theme.surface)
-        .pad(1)
+        .p(1)
         .grow(1)
         .col(|ui| {
             ui.text(tier).bold().fg(color);

--- a/examples/error_boundary_demo.rs
+++ b/examples/error_boundary_demo.rs
@@ -11,7 +11,7 @@ fn main() -> std::io::Result<()> {
         let _ = ui
             .bordered(Border::Rounded)
             .title("Error Boundary Demo")
-            .pad(1)
+            .p(1)
             .gap(1)
             .col(|ui| {
                 ui.text("Trigger panic inside error boundary.").bold();

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -8,7 +8,7 @@ fn main() -> std::io::Result<()> {
 
         let _ = ui
             .bordered(Border::Rounded)
-            .pad(1)
+            .p(1)
             .title("SLT")
             .col(|ui: &mut Context| {
                 ui.text("Hello, World!").bold().fg(Color::Cyan);

--- a/examples/perf_interactive.rs
+++ b/examples/perf_interactive.rs
@@ -33,7 +33,7 @@ fn main() -> std::io::Result<()> {
             let _ = ui
                 .bordered(Border::Rounded)
                 .title("Interactive Perf Demo")
-                .pad(1)
+                .p(1)
                 .grow(1)
                 .col(|ui| {
                     ui.line(|ui| {

--- a/examples/perf_regression.rs
+++ b/examples/perf_regression.rs
@@ -30,7 +30,7 @@ fn main() {
             let _ = ui
                 .bordered(slt::Border::Rounded)
                 .title("Perf sanity")
-                .pad(1)
+                .p(1)
                 .grow(1)
                 .col(|ui| {
                     ui.text("Input cursor path").bold();

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -16,7 +16,7 @@ use crate::style::Style;
 // document why — but do not silently let it drift.
 const _: () = assert!(
     std::mem::size_of::<Cell>() <= 64,
-    "Cell exceeds one cache line (64 B).      If the size increase is intentional, update this bound and document why."
+    "Cell exceeds one cache line (64 B). If the size increase is intentional, update this bound and document why."
 );
 
 /// A single terminal cell containing a character and style.
@@ -85,7 +85,7 @@ mod tests {
         let size = std::mem::size_of::<Cell>();
         assert!(
             size <= 64,
-            "Cell size = {size}B; exceeds 64B cache-line budget.              If intentional, update the const-assert and this test together."
+            "Cell size = {size}B; exceeds 64B cache-line budget. If intentional, update the const-assert and this test together."
         );
     }
 }

--- a/src/chart/bar.rs
+++ b/src/chart/bar.rs
@@ -1,20 +1,21 @@
 use super::*;
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn draw_bar_dataset(
     dataset: &Dataset,
     _x_min: f64,
     _x_max: f64,
     y_min: f64,
     y_max: f64,
-    plot_chars: &mut [Vec<char>],
-    plot_styles: &mut [Vec<Style>],
+    plot_chars: &mut [char],
+    plot_styles: &mut [Style],
+    cols: usize,
+    rows: usize,
 ) {
-    if dataset.data.is_empty() || plot_chars.is_empty() || plot_chars[0].is_empty() {
+    if dataset.data.is_empty() || cols == 0 || rows == 0 {
         return;
     }
 
-    let rows = plot_chars.len();
-    let cols = plot_chars[0].len();
     let n = dataset.data.len();
     let slot_width = cols as f64 / n as f64;
     let zero_row = map_value_to_cell(0.0, y_min, y_max, rows, true);
@@ -43,13 +44,15 @@ pub(super) fn draw_bar_dataset(
         for row in top..=bottom.min(rows.saturating_sub(1)) {
             for col in x_start..=x_end {
                 if col < cols {
-                    plot_chars[row][col] = '█';
-                    plot_styles[row][col] = Style::new().fg(dataset.color);
+                    let idx = row * cols + col;
+                    plot_chars[idx] = '█';
+                    plot_styles[idx] = Style::new().fg(dataset.color);
                 }
             }
             if frac_w > 0 && frac_col < cols {
-                plot_chars[row][frac_col] = BLOCK_FRACTIONS[frac_w.min(8)];
-                plot_styles[row][frac_col] = Style::new().fg(dataset.color);
+                let idx = row * cols + frac_col;
+                plot_chars[idx] = BLOCK_FRACTIONS[frac_w.min(8)];
+                plot_styles[idx] = Style::new().fg(dataset.color);
             }
         }
     }

--- a/src/chart/braille.rs
+++ b/src/chart/braille.rs
@@ -1,31 +1,32 @@
 use super::*;
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn draw_braille_dataset(
     dataset: &Dataset,
     x_min: f64,
     x_max: f64,
     y_min: f64,
     y_max: f64,
-    plot_chars: &mut [Vec<char>],
-    plot_styles: &mut [Vec<Style>],
+    plot_chars: &mut [char],
+    plot_styles: &mut [Style],
+    cols: usize,
+    rows: usize,
 ) {
-    if dataset.data.is_empty() || plot_chars.is_empty() || plot_chars[0].is_empty() {
+    if dataset.data.is_empty() || cols == 0 || rows == 0 {
         return;
     }
 
-    let cols = plot_chars[0].len();
-    let rows = plot_chars.len();
     let px_w = cols * 2;
     let px_h = rows * 4;
-    let mut bits = vec![vec![0u32; cols]; rows];
-    let mut color_map = vec![vec![None::<Color>; cols]; rows];
+    let mut bits: Vec<u32> = vec![0u32; cols * rows];
+    let mut color_map: Vec<Option<Color>> = vec![None; cols * rows];
 
     let mut set_dot_colored = |px: usize, py: usize, color: Color| {
         set_braille_dot(px, py, &mut bits, cols, rows);
         let char_col = px / 2;
         let char_row = py / 4;
         if char_col < cols && char_row < rows {
-            color_map[char_row][char_col] = Some(color);
+            color_map[char_row * cols + char_col] = Some(color);
         }
     };
 
@@ -112,11 +113,12 @@ pub(super) fn draw_braille_dataset(
 
     for row in 0..rows {
         for col in 0..cols {
-            if bits[row][col] != 0 {
-                let ch = char::from_u32(BRAILLE_BASE + bits[row][col]).unwrap_or(' ');
-                plot_chars[row][col] = ch;
-                let color = color_map[row][col].unwrap_or(dataset.color);
-                plot_styles[row][col] = Style::new().fg(color);
+            let idx = row * cols + col;
+            if bits[idx] != 0 {
+                let ch = char::from_u32(BRAILLE_BASE + bits[idx]).unwrap_or(' ');
+                plot_chars[idx] = ch;
+                let color = color_map[idx].unwrap_or(dataset.color);
+                plot_styles[idx] = Style::new().fg(color);
             }
         }
     }
@@ -131,14 +133,15 @@ pub(super) fn draw_braille_dataset(
             let col = map_value_to_cell(*x, x_min, x_max, cols, false);
             let row = map_value_to_cell(*y, y_min, y_max, rows, true);
             if row < rows && col < cols {
-                plot_chars[row][col] = m;
-                plot_styles[row][col] = Style::new().fg(dataset.color);
+                let idx = row * cols + col;
+                plot_chars[idx] = m;
+                plot_styles[idx] = Style::new().fg(dataset.color);
             }
         }
     }
 }
 
-fn set_braille_dot(px: usize, py: usize, bits: &mut [Vec<u32>], cols: usize, rows: usize) {
+fn set_braille_dot(px: usize, py: usize, bits: &mut [u32], cols: usize, rows: usize) {
     if cols == 0 || rows == 0 {
         return;
     }
@@ -149,7 +152,7 @@ fn set_braille_dot(px: usize, py: usize, bits: &mut [Vec<u32>], cols: usize, row
     }
     let sub_col = px % 2;
     let sub_row = py % 4;
-    bits[char_row][char_col] |= if sub_col == 0 {
+    bits[char_row * cols + char_col] |= if sub_col == 0 {
         BRAILLE_LEFT_BITS[sub_row]
     } else {
         BRAILLE_RIGHT_BITS[sub_row]

--- a/src/chart/grid.rs
+++ b/src/chart/grid.rs
@@ -13,23 +13,26 @@ pub(super) struct GridSpec<'a> {
 pub(super) fn apply_grid(
     config: &ChartConfig,
     grid: GridSpec<'_>,
-    plot_chars: &mut [Vec<char>],
-    plot_styles: &mut [Vec<Style>],
+    plot_chars: &mut [char],
+    plot_styles: &mut [Style],
+    cols: usize,
+    rows: usize,
     grid_style: Style,
 ) {
-    if !config.grid || plot_chars.is_empty() || plot_chars[0].is_empty() {
+    if !config.grid || cols == 0 || rows == 0 {
         return;
     }
-    let h = plot_chars.len();
-    let w = plot_chars[0].len();
+    let h = rows;
+    let w = cols;
 
     for tick in grid.y_ticks {
         let row = map_value_to_cell(*tick, grid.y_min, grid.y_max, h, true);
         if row < h {
             for col in 0..w {
-                if plot_chars[row][col] == ' ' {
-                    plot_chars[row][col] = '·';
-                    plot_styles[row][col] = grid_style;
+                let idx = row * w + col;
+                if plot_chars[idx] == ' ' {
+                    plot_chars[idx] = '·';
+                    plot_styles[idx] = grid_style;
                 }
             }
         }
@@ -39,9 +42,10 @@ pub(super) fn apply_grid(
         let col = map_value_to_cell(*tick, grid.x_min, grid.x_max, w, false);
         if col < w {
             for row in 0..h {
-                if plot_chars[row][col] == ' ' {
-                    plot_chars[row][col] = '·';
-                    plot_styles[row][col] = grid_style;
+                let idx = row * w + col;
+                if plot_chars[idx] == ' ' {
+                    plot_chars[idx] = '·';
+                    plot_styles[idx] = grid_style;
                 }
             }
         }
@@ -78,16 +82,16 @@ pub(super) fn marker_char(marker: Marker) -> char {
 pub(super) fn overlay_legend_on_plot(
     position: LegendPosition,
     items: &[(char, String, Color)],
-    plot_chars: &mut [Vec<char>],
-    plot_styles: &mut [Vec<Style>],
+    plot_chars: &mut [char],
+    plot_styles: &mut [Style],
+    cols: usize,
+    rows: usize,
     axis_style: Style,
 ) {
-    if plot_chars.is_empty() || plot_chars[0].is_empty() || items.is_empty() {
+    if cols == 0 || rows == 0 || items.is_empty() {
         return;
     }
 
-    let rows = plot_chars.len();
-    let cols = plot_chars[0].len();
     let start_row = match position {
         LegendPosition::TopLeft => 0,
         LegendPosition::BottomLeft => rows.saturating_sub(items.len()),
@@ -104,8 +108,9 @@ pub(super) fn overlay_legend_on_plot(
             if col >= cols {
                 break;
             }
-            plot_chars[row][col] = ch;
-            plot_styles[row][col] = if col == 0 {
+            let idx = row * cols + col;
+            plot_chars[idx] = ch;
+            plot_styles[idx] = if col == 0 {
                 Style::new().fg(*color)
             } else {
                 axis_style

--- a/src/chart/render.rs
+++ b/src/chart/render.rs
@@ -157,8 +157,8 @@ pub(crate) fn render_chart(config: &ChartConfig) -> Vec<ChartRow> {
     let x_min = x_ticks.values.first().copied().unwrap_or(x_min).min(x_min);
     let x_max = x_ticks.values.last().copied().unwrap_or(x_max).max(x_max);
 
-    let mut plot_chars = vec![vec![' '; plot_width]; plot_height];
-    let mut plot_styles = vec![vec![Style::new(); plot_width]; plot_height];
+    let mut plot_chars: Vec<char> = vec![' '; plot_width * plot_height];
+    let mut plot_styles: Vec<Style> = vec![Style::new(); plot_width * plot_height];
 
     apply_grid(
         config,
@@ -172,6 +172,8 @@ pub(crate) fn render_chart(config: &ChartConfig) -> Vec<ChartRow> {
         },
         &mut plot_chars,
         &mut plot_styles,
+        plot_width,
+        plot_height,
         config.grid_style.unwrap_or(dim_style),
     );
 
@@ -179,8 +181,9 @@ pub(crate) fn render_chart(config: &ChartConfig) -> Vec<ChartRow> {
         let row = map_value_to_cell(y_val, y_min, y_max, plot_height, true);
         if row < plot_height {
             for col in 0..plot_width {
-                plot_chars[row][col] = '─';
-                plot_styles[row][col] = *style;
+                let idx = row * plot_width + col;
+                plot_chars[idx] = '─';
+                plot_styles[idx] = *style;
             }
         }
     }
@@ -188,9 +191,10 @@ pub(crate) fn render_chart(config: &ChartConfig) -> Vec<ChartRow> {
         let col = map_value_to_cell(x_val, x_min, x_max, plot_width, false);
         if col < plot_width {
             for row in 0..plot_height {
-                if plot_chars[row][col] == ' ' || plot_chars[row][col] == '·' {
-                    plot_chars[row][col] = '│';
-                    plot_styles[row][col] = *style;
+                let idx = row * plot_width + col;
+                if plot_chars[idx] == ' ' || plot_chars[idx] == '·' {
+                    plot_chars[idx] = '│';
+                    plot_styles[idx] = *style;
                 }
             }
         }
@@ -207,6 +211,8 @@ pub(crate) fn render_chart(config: &ChartConfig) -> Vec<ChartRow> {
                     y_max,
                     &mut plot_chars,
                     &mut plot_styles,
+                    plot_width,
+                    plot_height,
                 );
             }
             GraphType::Bar => {
@@ -218,6 +224,8 @@ pub(crate) fn render_chart(config: &ChartConfig) -> Vec<ChartRow> {
                     y_max,
                     &mut plot_chars,
                     &mut plot_styles,
+                    plot_width,
+                    plot_height,
                 );
             }
         }
@@ -234,6 +242,8 @@ pub(crate) fn render_chart(config: &ChartConfig) -> Vec<ChartRow> {
             &legend_items,
             &mut plot_chars,
             &mut plot_styles,
+            plot_width,
+            plot_height,
             axis_style,
         );
     }
@@ -315,7 +325,8 @@ pub(crate) fn render_chart(config: &ChartConfig) -> Vec<ChartRow> {
         let mut current_style = Style::new();
         let mut buffer = String::new();
         for col in 0..plot_width {
-            let style = plot_styles[row][col];
+            let idx = row * plot_width + col;
+            let style = plot_styles[idx];
             if col == 0 {
                 current_style = style;
             }
@@ -326,7 +337,7 @@ pub(crate) fn render_chart(config: &ChartConfig) -> Vec<ChartRow> {
                 }
                 current_style = style;
             }
-            buffer.push(plot_chars[row][col]);
+            buffer.push(plot_chars[idx]);
         }
         if !buffer.is_empty() {
             segments.push((buffer, current_style));

--- a/src/context/helpers.rs
+++ b/src/context/helpers.rs
@@ -41,15 +41,16 @@ pub(crate) fn format_table_row(cells: &[String], widths: &[u32], separator: &str
 }
 
 pub(crate) fn table_visible_len(state: &TableState) -> usize {
+    let visible = state.visible_indices();
     if state.page_size == 0 {
-        return state.visible_indices().len();
+        return visible.len();
     }
 
     let start = state
         .page
         .saturating_mul(state.page_size)
-        .min(state.visible_indices().len());
-    let end = (start + state.page_size).min(state.visible_indices().len());
+        .min(visible.len());
+    let end = (start + state.page_size).min(visible.len());
     end.saturating_sub(start)
 }
 

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -436,30 +436,25 @@ impl Context {
 
         // Activation keys (Enter / Space) are typically 0–1 per frame and
         // bounded above by the simultaneous-keypress count from the input
-        // pipeline (well under 8 in practice). A small inline buffer
-        // eliminates the per-focusable `Vec<usize>` heap allocation that
-        // showed up on every focused widget × every frame. Closes #135.
-        const INLINE_CAP: usize = 8;
-        let mut buf = [0usize; INLINE_CAP];
-        let mut count = 0usize;
-        let mut overflow: Vec<usize> = Vec::new();
-
-        for (i, key) in self.available_key_presses() {
-            if matches!(key.code, KeyCode::Enter | KeyCode::Char(' ')) {
-                if count < INLINE_CAP {
-                    buf[count] = i;
-                    count += 1;
+        // pipeline (well under 8 in practice). A `SmallVec` with an 8-slot
+        // inline capacity eliminates the per-focusable `Vec<usize>` heap
+        // allocation that showed up on every focused widget × every frame.
+        // Spillover beyond 8 falls back to the heap automatically. Closes #135.
+        let consumed: smallvec::SmallVec<[usize; 8]> = self
+            .available_key_presses()
+            .filter_map(|(i, key)| {
+                if matches!(key.code, KeyCode::Enter | KeyCode::Char(' ')) {
+                    Some(i)
                 } else {
-                    overflow.push(i);
+                    None
                 }
-            }
-        }
-
-        let activated = count > 0 || !overflow.is_empty();
+            })
+            .collect();
+        let activated = !consumed.is_empty();
         if activated {
-            // `consume_indices` takes `IntoIterator<Item = usize>` — pass an
-            // iterator directly, no allocation needed for the inline path.
-            self.consume_indices(buf[..count].iter().copied().chain(overflow));
+            // `consume_indices` takes `IntoIterator<Item = usize>` — `SmallVec`
+            // satisfies that bound directly, no signature change needed.
+            self.consume_indices(consumed);
         }
         activated
     }
@@ -665,12 +660,18 @@ impl Context {
 
         // Slot already exists: it must be the same `(D, T)` shape we used last
         // frame, or the caller broke the rules-of-hooks contract.
-        match self.hook_states[idx].downcast_ref::<(D, T)>() {
-            Some((stored, _)) => {
-                if stored != deps {
-                    let value = compute(deps);
-                    self.hook_states[idx] = Box::new((deps.clone(), value));
+        //
+        // Single downcast on the cache-hit path (closes #133): use
+        // `downcast_mut` to update deps/value in place when they change, and
+        // return `&stored.1` directly — eliminating the redundant second
+        // `downcast_ref` that ran on every call regardless of cache state.
+        match self.hook_states[idx].downcast_mut::<(D, T)>() {
+            Some(stored) => {
+                if stored.0 != *deps {
+                    stored.0 = deps.clone();
+                    stored.1 = compute(deps);
                 }
+                &stored.1
             }
             None => panic!(
                 "Hook type mismatch at index {}: expected {}. Hooks must be called in the same order every frame.",
@@ -678,11 +679,6 @@ impl Context {
                 std::any::type_name::<(D, T)>()
             ),
         }
-
-        self.hook_states[idx]
-            .downcast_ref::<(D, T)>()
-            .map(|(_, v)| v)
-            .expect("slot was just verified or replaced with the correct type")
     }
 
     /// Returns `light` color if current theme is light mode, `dark` color if dark mode.

--- a/src/context/widgets_display.rs
+++ b/src/context/widgets_display.rs
@@ -442,9 +442,105 @@ fn terminal_supports_sixel() -> bool {
         .map(|v| v.to_ascii_lowercase())
         .unwrap_or_default();
 
-    term.contains("sixel")
-        || term.contains("mlterm")
-        || term.contains("xterm")
-        || term.contains("foot")
-        || term_program.contains("foot")
+    // Exact-match known sixel terminals; substring "sixel" catches custom builds.
+    // The previous `term.contains("xterm")` check fired on `xterm-256color`,
+    // which is the default for macOS Terminal.app, VS Code, and most SSH
+    // clients — none of which support sixel. Patched-xterm-with-sixel users
+    // can opt in with `SLT_FORCE_SIXEL=1`.
+    const KNOWN_SIXEL_TERMS: &[&str] = &["mlterm", "foot", "yaft", "xterm-256color-sixel"];
+    KNOWN_SIXEL_TERMS.iter().any(|&t| term == t)
+        || term.contains("sixel")
+        || term_program == "foot"
+        || term_program == "mlterm"
+}
+
+#[cfg(all(test, feature = "crossterm"))]
+mod sixel_detection_tests {
+    use super::terminal_supports_sixel;
+    use std::sync::Mutex;
+
+    // Env vars are process-global. A test-local mutex serializes access so
+    // concurrent test threads don't observe each other's set_var() calls.
+    static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+    fn with_env<F: FnOnce()>(term: Option<&str>, term_program: Option<&str>, force: bool, f: F) {
+        let _g = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let prev_term = std::env::var("TERM").ok();
+        let prev_program = std::env::var("TERM_PROGRAM").ok();
+        let prev_force = std::env::var("SLT_FORCE_SIXEL").ok();
+
+        match term {
+            Some(v) => std::env::set_var("TERM", v),
+            None => std::env::remove_var("TERM"),
+        }
+        match term_program {
+            Some(v) => std::env::set_var("TERM_PROGRAM", v),
+            None => std::env::remove_var("TERM_PROGRAM"),
+        }
+        if force {
+            std::env::set_var("SLT_FORCE_SIXEL", "1");
+        } else {
+            std::env::remove_var("SLT_FORCE_SIXEL");
+        }
+
+        f();
+
+        match prev_term {
+            Some(v) => std::env::set_var("TERM", v),
+            None => std::env::remove_var("TERM"),
+        }
+        match prev_program {
+            Some(v) => std::env::set_var("TERM_PROGRAM", v),
+            None => std::env::remove_var("TERM_PROGRAM"),
+        }
+        match prev_force {
+            Some(v) => std::env::set_var("SLT_FORCE_SIXEL", v),
+            None => std::env::remove_var("SLT_FORCE_SIXEL"),
+        }
+    }
+
+    #[test]
+    fn sixel_xterm_256color_no_false_positive() {
+        // Regression: `term.contains("xterm")` previously matched
+        // `xterm-256color` and printed raw escape sequences to screen on
+        // macOS Terminal.app, VS Code, and most SSH clients.
+        with_env(Some("xterm-256color"), None, false, || {
+            assert!(!terminal_supports_sixel());
+        });
+    }
+
+    #[test]
+    fn sixel_mlterm_detected() {
+        with_env(Some("mlterm"), None, false, || {
+            assert!(terminal_supports_sixel());
+        });
+    }
+
+    #[test]
+    fn sixel_foot_detected_via_term() {
+        with_env(Some("foot"), None, false, || {
+            assert!(terminal_supports_sixel());
+        });
+    }
+
+    #[test]
+    fn sixel_foot_detected_via_term_program() {
+        with_env(Some("xterm-256color"), Some("foot"), false, || {
+            assert!(terminal_supports_sixel());
+        });
+    }
+
+    #[test]
+    fn sixel_force_env_overrides_negative_term() {
+        with_env(Some("xterm-256color"), None, true, || {
+            assert!(terminal_supports_sixel());
+        });
+    }
+
+    #[test]
+    fn sixel_substring_match_catches_custom_builds() {
+        with_env(Some("custom-with-sixel"), None, false, || {
+            assert!(terminal_supports_sixel());
+        });
+    }
 }

--- a/src/context/widgets_display/layout.rs
+++ b/src/context/widgets_display/layout.rs
@@ -1,6 +1,56 @@
 use super::*;
+use std::sync::OnceLock;
+
+static SEP_LINE: OnceLock<String> = OnceLock::new();
+
+fn sep_line() -> &'static str {
+    SEP_LINE.get_or_init(|| "─".repeat(200))
+}
 
 impl Context {
+    /// Render a horizontal divider line.
+    ///
+    /// The line is drawn with the theme's border color and expands to fill the
+    /// container width.
+    pub fn separator(&mut self) -> &mut Self {
+        // The cached `sep_line()` is much wider than any reasonable terminal,
+        // so the cross-axis (column-direction) clip in `Buffer::set_string`
+        // truncates the trailing chars. Keeping `grow = 0` means a column
+        // layout doesn't stretch the separator vertically, and `truncate =
+        // false` avoids the ellipsis fallback which would otherwise replace
+        // the last cell with `…`.
+        self.commands.push(Command::Text {
+            content: sep_line().to_owned(),
+            cursor_offset: None,
+            style: Style::new().fg(self.theme.border).dim(),
+            grow: 0,
+            align: Align::Start,
+            wrap: false,
+            truncate: false,
+            margin: Margin::default(),
+            constraints: Constraints::default(),
+        });
+        self.rollback.last_text_idx = Some(self.commands.len() - 1);
+        self
+    }
+
+    /// Render a horizontal separator line with a custom color.
+    pub fn separator_colored(&mut self, color: Color) -> &mut Self {
+        self.commands.push(Command::Text {
+            content: sep_line().to_owned(),
+            cursor_offset: None,
+            style: Style::new().fg(color),
+            grow: 0,
+            align: Align::Start,
+            wrap: false,
+            truncate: false,
+            margin: Margin::default(),
+            constraints: Constraints::default(),
+        });
+        self.rollback.last_text_idx = Some(self.commands.len() - 1);
+        self
+    }
+
     /// Conditionally render content when the named screen is active.
     ///
     /// Each screen gets an isolated hook segment — `use_state` / `use_memo`
@@ -380,7 +430,7 @@ impl Context {
     /// use slt::Border;
     /// ui.container()
     ///     .border(Border::Rounded)
-    ///     .pad(1)
+    ///     .p(1)
     ///     .title("My Panel")
     ///     .col(|ui| {
     ///         ui.text("content");

--- a/src/context/widgets_display/status.rs
+++ b/src/context/widgets_display/status.rs
@@ -173,11 +173,31 @@ impl Context {
 
     /// Render a breadcrumb with a custom separator string.
     pub fn breadcrumb_with(&mut self, segments: &[&str], separator: &str) -> Option<usize> {
+        self.breadcrumb_response_with(segments, separator).1
+    }
+
+    /// Render a breadcrumb and return both the row [`Response`] and the
+    /// clicked segment index.
+    ///
+    /// The `Response` exposes hover/focus state and the widget rectangle, while
+    /// the `Option<usize>` carries the clicked segment index (same value as
+    /// [`Self::breadcrumb`]).
+    pub fn breadcrumb_response(&mut self, segments: &[&str]) -> (Response, Option<usize>) {
+        self.breadcrumb_response_with(segments, " › ")
+    }
+
+    /// Render a breadcrumb with a custom separator and return both the row
+    /// [`Response`] and the clicked segment index.
+    pub fn breadcrumb_response_with(
+        &mut self,
+        segments: &[&str],
+        separator: &str,
+    ) -> (Response, Option<usize>) {
         let theme = self.theme;
         let last_idx = segments.len().saturating_sub(1);
         let mut clicked_idx: Option<usize> = None;
 
-        let _ = self.row(|ui| {
+        let response = self.row(|ui| {
             for (i, segment) in segments.iter().enumerate() {
                 let is_last = i == last_idx;
                 if is_last {
@@ -200,7 +220,7 @@ impl Context {
             }
         });
 
-        clicked_idx
+        (response, clicked_idx)
     }
 
     /// Collapsible section that toggles on click, Enter, or Space.
@@ -418,7 +438,7 @@ impl Context {
         let _ = self
             .bordered(Border::Rounded)
             .bg(theme.surface)
-            .pad(1)
+            .p(1)
             .col(|ui| {
                 if let Some(ref lines) = highlighted {
                     render_tree_sitter_lines(ui, lines);
@@ -447,7 +467,7 @@ impl Context {
         let _ = self
             .bordered(Border::Rounded)
             .bg(theme.surface)
-            .pad(1)
+            .p(1)
             .col(|ui| {
                 if let Some(ref hl_lines) = highlighted {
                     for (i, segs) in hl_lines.iter().enumerate() {

--- a/src/context/widgets_input/text_input.rs
+++ b/src/context/widgets_input/text_input.rs
@@ -287,7 +287,6 @@ impl Context {
             .bordered(Border::Rounded)
             .border_style(Style::new().fg(border_color))
             .px(1)
-            .grow(1)
             .col(|ui| {
                 ui.styled_with_cursor(input_text, input_style, cursor_offset);
             });

--- a/src/context/widgets_input/textarea_progress.rs
+++ b/src/context/widgets_input/textarea_progress.rs
@@ -1,5 +1,35 @@
 use super::*;
 
+/// Move a logical column index backward to the start of the previous word.
+///
+/// Word boundary: a run of one-or-more alphanumeric characters. Leading
+/// non-alphanumerics before the cursor are skipped first, then the run of
+/// alphanumerics is consumed.
+fn prev_word_col(line: &str, col: usize) -> usize {
+    let chars: Vec<char> = line.chars().collect();
+    let mut pos = col.min(chars.len());
+    while pos > 0 && !chars[pos - 1].is_alphanumeric() {
+        pos -= 1;
+    }
+    while pos > 0 && chars[pos - 1].is_alphanumeric() {
+        pos -= 1;
+    }
+    pos
+}
+
+/// Move a logical column index forward past the end of the next word.
+fn next_word_col(line: &str, col: usize) -> usize {
+    let chars: Vec<char> = line.chars().collect();
+    let mut pos = col.min(chars.len());
+    while pos < chars.len() && !chars[pos].is_alphanumeric() {
+        pos += 1;
+    }
+    while pos < chars.len() && chars[pos].is_alphanumeric() {
+        pos += 1;
+    }
+    pos
+}
+
 impl Context {
     ///
     /// When focused, handles character input, Enter (new line), Backspace,
@@ -7,6 +37,10 @@ impl Context {
     ///
     /// Set [`TextareaState::word_wrap`] to enable soft-wrapping at a given
     /// display-column width. Up/Down then navigate visual lines.
+    ///
+    /// Editing shortcuts: `Ctrl+K` deletes from the cursor to the end of the
+    /// current line. `Ctrl+Left` / `Alt+Left` jumps to the previous word
+    /// boundary; `Ctrl+Right` / `Alt+Right` jumps past the next word end.
     pub fn textarea(&mut self, state: &mut TextareaState, visible_rows: u32) -> Response {
         if state.lines.is_empty() {
             state.lines.push(String::new());
@@ -27,6 +61,44 @@ impl Context {
             let mut consumed_indices = Vec::new();
             for (i, key) in self.available_key_presses() {
                 match key.code {
+                    KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        let line_len = state.lines[state.cursor_row].chars().count();
+                        if state.cursor_col < line_len {
+                            let cut = byte_index_for_char(
+                                &state.lines[state.cursor_row],
+                                state.cursor_col,
+                            );
+                            state.lines[state.cursor_row].truncate(cut);
+                        }
+                        consumed_indices.push(i);
+                    }
+                    KeyCode::Left
+                        if key.modifiers.contains(KeyModifiers::CONTROL)
+                            || key.modifiers.contains(KeyModifiers::ALT) =>
+                    {
+                        if state.cursor_col > 0 {
+                            state.cursor_col =
+                                prev_word_col(&state.lines[state.cursor_row], state.cursor_col);
+                        } else if state.cursor_row > 0 {
+                            state.cursor_row -= 1;
+                            state.cursor_col = state.lines[state.cursor_row].chars().count();
+                        }
+                        consumed_indices.push(i);
+                    }
+                    KeyCode::Right
+                        if key.modifiers.contains(KeyModifiers::CONTROL)
+                            || key.modifiers.contains(KeyModifiers::ALT) =>
+                    {
+                        let line_len = state.lines[state.cursor_row].chars().count();
+                        if state.cursor_col < line_len {
+                            state.cursor_col =
+                                next_word_col(&state.lines[state.cursor_row], state.cursor_col);
+                        } else if state.cursor_row + 1 < state.lines.len() {
+                            state.cursor_row += 1;
+                            state.cursor_col = 0;
+                        }
+                        consumed_indices.push(i);
+                    }
                     KeyCode::Char(ch) => {
                         if let Some(max) = state.max_length {
                             let total: usize =

--- a/src/context/widgets_interactive/collections.rs
+++ b/src/context/widgets_interactive/collections.rs
@@ -45,48 +45,7 @@ impl Context {
         f(self);
         let child_commands: Vec<Command> = self.commands.drain(children_start..).collect();
 
-        let mut elements: Vec<Vec<Command>> = Vec::new();
-        let mut iter = child_commands.into_iter().peekable();
-        let mut pending_markers: Vec<Command> = Vec::new();
-        while let Some(cmd) = iter.next() {
-            match cmd {
-                Command::InteractionMarker(_) => {
-                    pending_markers.push(cmd);
-                }
-                Command::BeginContainer(_) | Command::BeginScrollable(_) => {
-                    let mut depth = 1_u32;
-                    let mut element: Vec<Command> = std::mem::take(&mut pending_markers);
-                    element.push(cmd);
-                    for next in iter.by_ref() {
-                        match next {
-                            Command::BeginContainer(_) | Command::BeginScrollable(_) => {
-                                depth += 1;
-                            }
-                            Command::EndContainer => {
-                                depth = depth.saturating_sub(1);
-                            }
-                            _ => {}
-                        }
-                        let at_end = matches!(next, Command::EndContainer) && depth == 0;
-                        element.push(next);
-                        if at_end {
-                            break;
-                        }
-                    }
-                    elements.push(element);
-                }
-                Command::EndContainer => {}
-                _ => {
-                    let mut element = std::mem::take(&mut pending_markers);
-                    element.push(cmd);
-                    elements.push(element);
-                }
-            }
-        }
-        // Flush any trailing markers (edge case: marker with no following command)
-        if !pending_markers.is_empty() {
-            elements.push(pending_markers);
-        }
+        let elements = collect_grid_elements(child_commands);
 
         let cols = cols.max(1) as usize;
         for row in elements.chunks(cols) {
@@ -201,47 +160,7 @@ impl Context {
         f(self);
         let child_commands: Vec<Command> = self.commands.drain(children_start..).collect();
 
-        let mut elements: Vec<Vec<Command>> = Vec::new();
-        let mut iter = child_commands.into_iter().peekable();
-        let mut pending_markers: Vec<Command> = Vec::new();
-        while let Some(cmd) = iter.next() {
-            match cmd {
-                Command::InteractionMarker(_) => {
-                    pending_markers.push(cmd);
-                }
-                Command::BeginContainer(_) | Command::BeginScrollable(_) => {
-                    let mut depth = 1_u32;
-                    let mut element: Vec<Command> = std::mem::take(&mut pending_markers);
-                    element.push(cmd);
-                    for next in iter.by_ref() {
-                        match next {
-                            Command::BeginContainer(_) | Command::BeginScrollable(_) => {
-                                depth += 1;
-                            }
-                            Command::EndContainer => {
-                                depth = depth.saturating_sub(1);
-                            }
-                            _ => {}
-                        }
-                        let at_end = matches!(next, Command::EndContainer) && depth == 0;
-                        element.push(next);
-                        if at_end {
-                            break;
-                        }
-                    }
-                    elements.push(element);
-                }
-                Command::EndContainer => {}
-                _ => {
-                    let mut element = std::mem::take(&mut pending_markers);
-                    element.push(cmd);
-                    elements.push(element);
-                }
-            }
-        }
-        if !pending_markers.is_empty() {
-            elements.push(pending_markers);
-        }
+        let elements = collect_grid_elements(child_commands);
 
         for row in elements.chunks(cols) {
             self.skip_interaction_slot();
@@ -781,4 +700,56 @@ impl Context {
         response.changed = file_selected;
         response
     }
+}
+
+/// Group `child_commands` into per-cell command vectors for `grid()` / `grid_with()`.
+///
+/// Each container subtree (`BeginContainer`/`BeginScrollable` … matching `EndContainer`)
+/// becomes one element. Bare `InteractionMarker`s are flushed onto the next element so
+/// hit-testing slots stay attached to the cell that owns them. Trailing markers with
+/// no following command form their own (empty-content) element.
+fn collect_grid_elements(child_commands: Vec<Command>) -> Vec<Vec<Command>> {
+    let mut elements: Vec<Vec<Command>> = Vec::new();
+    let mut iter = child_commands.into_iter().peekable();
+    let mut pending_markers: Vec<Command> = Vec::new();
+    while let Some(cmd) = iter.next() {
+        match cmd {
+            Command::InteractionMarker(_) => {
+                pending_markers.push(cmd);
+            }
+            Command::BeginContainer(_) | Command::BeginScrollable(_) => {
+                let mut depth = 1_u32;
+                let mut element: Vec<Command> = std::mem::take(&mut pending_markers);
+                element.push(cmd);
+                for next in iter.by_ref() {
+                    match next {
+                        Command::BeginContainer(_) | Command::BeginScrollable(_) => {
+                            depth += 1;
+                        }
+                        Command::EndContainer => {
+                            depth = depth.saturating_sub(1);
+                        }
+                        _ => {}
+                    }
+                    let at_end = matches!(next, Command::EndContainer) && depth == 0;
+                    element.push(next);
+                    if at_end {
+                        break;
+                    }
+                }
+                elements.push(element);
+            }
+            Command::EndContainer => {}
+            _ => {
+                let mut element = std::mem::take(&mut pending_markers);
+                element.push(cmd);
+                elements.push(element);
+            }
+        }
+    }
+    // Flush any trailing markers (edge case: marker with no following command)
+    if !pending_markers.is_empty() {
+        elements.push(pending_markers);
+    }
+    elements
 }

--- a/src/context/widgets_interactive/events.rs
+++ b/src/context/widgets_interactive/events.rs
@@ -1,56 +1,6 @@
 use super::*;
-use std::sync::OnceLock;
-
-static SEP_LINE: OnceLock<String> = OnceLock::new();
-
-fn sep_line() -> &'static str {
-    SEP_LINE.get_or_init(|| "─".repeat(200))
-}
 
 impl Context {
-    /// Render a horizontal divider line.
-    ///
-    /// The line is drawn with the theme's border color and expands to fill the
-    /// container width.
-    pub fn separator(&mut self) -> &mut Self {
-        // The cached `sep_line()` is much wider than any reasonable terminal,
-        // so the cross-axis (column-direction) clip in `Buffer::set_string`
-        // truncates the trailing chars. Keeping `grow = 0` means a column
-        // layout doesn't stretch the separator vertically, and `truncate =
-        // false` avoids the ellipsis fallback which would otherwise replace
-        // the last cell with `…`.
-        self.commands.push(Command::Text {
-            content: sep_line().to_owned(),
-            cursor_offset: None,
-            style: Style::new().fg(self.theme.border).dim(),
-            grow: 0,
-            align: Align::Start,
-            wrap: false,
-            truncate: false,
-            margin: Margin::default(),
-            constraints: Constraints::default(),
-        });
-        self.rollback.last_text_idx = Some(self.commands.len() - 1);
-        self
-    }
-
-    /// Render a horizontal separator line with a custom color.
-    pub fn separator_colored(&mut self, color: Color) -> &mut Self {
-        self.commands.push(Command::Text {
-            content: sep_line().to_owned(),
-            cursor_offset: None,
-            style: Style::new().fg(color),
-            grow: 0,
-            align: Align::Start,
-            wrap: false,
-            truncate: false,
-            margin: Margin::default(),
-            constraints: Constraints::default(),
-        });
-        self.rollback.last_text_idx = Some(self.commands.len() - 1);
-        self
-    }
-
     /// Render a help bar showing keybinding hints.
     ///
     /// `bindings` is a slice of `(key, action)` pairs. Keys are rendered in the

--- a/src/context/widgets_interactive/rich_markdown.rs
+++ b/src/context/widgets_interactive/rich_markdown.rs
@@ -264,7 +264,7 @@ impl Context {
         state.last_selected = None;
         let interaction_id = self.next_interaction_id();
 
-        let filtered = state.filtered_indices();
+        let filtered: Vec<usize> = state.filtered_indices_cached().to_vec();
         let sel = state.selected().min(filtered.len().saturating_sub(1));
         state.set_selected(sel);
 
@@ -315,7 +315,7 @@ impl Context {
         }
         self.consume_indices(consumed_indices);
 
-        let filtered = state.filtered_indices();
+        let filtered: Vec<usize> = state.filtered_indices_cached().to_vec();
 
         let _ = self.modal(|ui| {
             let primary = ui.theme.primary;
@@ -323,7 +323,7 @@ impl Context {
                 .container()
                 .border(Border::Rounded)
                 .border_style(Style::new().fg(primary))
-                .pad(1)
+                .p(1)
                 .max_w(60)
                 .col(|ui| {
                     let border_color = ui.theme.primary;
@@ -702,56 +702,74 @@ impl Context {
         bold: Style,
         code: Style,
     ) -> Vec<(String, Style)> {
+        // All inline markers (`**`, `*`, `` ` ``) are single-byte ASCII, so
+        // byte-index slicing of `text` is safe — multi-byte chars in `inner`
+        // are never split. Avoids the `chars().collect::<Vec<_>>()` allocation
+        // and per-match `String` reconstructions of the prior implementation.
         let mut segments: Vec<(String, Style)> = Vec::new();
+        let bytes = text.as_bytes();
         let mut current = String::new();
-        let chars: Vec<char> = text.chars().collect();
-        let mut i = 0;
-        while i < chars.len() {
-            if i + 1 < chars.len() && chars[i] == '*' && chars[i + 1] == '*' {
-                let rest: String = chars[i + 2..].iter().collect();
-                if let Some(end) = rest.find("**") {
+        let mut i: usize = 0;
+
+        while i < bytes.len() {
+            // Bold: **text**
+            if bytes[i] == b'*' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+                let after_open = i + 2;
+                if let Some(rel_end) = text[after_open..].find("**") {
+                    let close = after_open + rel_end;
                     if !current.is_empty() {
                         segments.push((std::mem::take(&mut current), base));
                     }
-                    let inner: String = rest[..end].to_string();
-                    let char_count = inner.chars().count();
+                    let inner = text[after_open..close].to_string();
                     segments.push((inner, bold));
-                    i += 2 + char_count + 2;
+                    i = close + 2;
                     continue;
                 }
             }
-            if chars[i] == '*'
-                && (i + 1 >= chars.len() || chars[i + 1] != '*')
-                && (i == 0 || chars[i - 1] != '*')
+
+            // Italic: *text* — skipped if part of a `**` run.
+            if bytes[i] == b'*'
+                && (i + 1 >= bytes.len() || bytes[i + 1] != b'*')
+                && (i == 0 || bytes[i - 1] != b'*')
             {
-                let rest: String = chars[i + 1..].iter().collect();
-                if let Some(end) = rest.find('*') {
+                let after_open = i + 1;
+                if let Some(rel_end) = text[after_open..].find('*') {
+                    let close = after_open + rel_end;
                     if !current.is_empty() {
                         segments.push((std::mem::take(&mut current), base));
                     }
-                    let inner: String = rest[..end].to_string();
-                    let char_count = inner.chars().count();
+                    let inner = text[after_open..close].to_string();
                     segments.push((inner, base.italic()));
-                    i += 1 + char_count + 1;
+                    i = close + 1;
                     continue;
                 }
             }
-            if chars[i] == '`' {
-                let rest: String = chars[i + 1..].iter().collect();
-                if let Some(end) = rest.find('`') {
+
+            // Inline code: `text`
+            if bytes[i] == b'`' {
+                let after_open = i + 1;
+                if let Some(rel_end) = text[after_open..].find('`') {
+                    let close = after_open + rel_end;
                     if !current.is_empty() {
                         segments.push((std::mem::take(&mut current), base));
                     }
-                    let inner: String = rest[..end].to_string();
-                    let char_count = inner.chars().count();
+                    let inner = text[after_open..close].to_string();
                     segments.push((inner, code));
-                    i += 1 + char_count + 1;
+                    i = close + 1;
                     continue;
                 }
             }
-            current.push(chars[i]);
-            i += 1;
+
+            // No marker — append one whole character (possibly multi-byte)
+            // and advance past it.
+            let ch = text[i..]
+                .chars()
+                .next()
+                .expect("non-empty tail past bounds check");
+            current.push(ch);
+            i += ch.len_utf8();
         }
+
         if !current.is_empty() {
             segments.push((current, base));
         }
@@ -941,61 +959,85 @@ impl Context {
     /// `**bold**` → `bold`, `*italic*` → `italic`, `` `code` `` → `code`,
     /// `[text](url)` → `text`, `![alt](url)` → `alt`.
     fn md_strip(text: &str) -> String {
-        let mut result = String::with_capacity(text.len());
+        // Bracket/paren parsing for links/images still uses a `Vec<char>`
+        // because the helper takes a char-slice; pre-build it once and reuse
+        // the precomputed char→byte mapping for both code paths.
         let chars: Vec<char> = text.chars().collect();
-        let mut i = 0;
-        while i < chars.len() {
-            // Image ![alt](url) → alt
-            if chars[i] == '!' && i + 1 < chars.len() && chars[i + 1] == '[' {
-                if let Some((alt, _, consumed)) = Self::parse_md_bracket_paren(&chars, i + 1) {
+        let char_to_byte = {
+            let mut v = Vec::with_capacity(chars.len() + 1);
+            let mut acc = 0usize;
+            v.push(0);
+            for ch in &chars {
+                acc += ch.len_utf8();
+                v.push(acc);
+            }
+            v
+        };
+        let bytes = text.as_bytes();
+        let mut result = String::with_capacity(text.len());
+        let mut ci: usize = 0;
+
+        while ci < chars.len() {
+            // Image: ![alt](url) — char-based bracket scanner is reused as-is.
+            if chars[ci] == '!' && ci + 1 < chars.len() && chars[ci + 1] == '[' {
+                if let Some((alt, _, consumed)) = Self::parse_md_bracket_paren(&chars, ci + 1) {
                     result.push_str(&alt);
-                    i += 1 + consumed;
+                    ci += 1 + consumed;
                     continue;
                 }
             }
-            // Link [text](url) → text
-            if chars[i] == '[' {
-                if let Some((link_text, _, consumed)) = Self::parse_md_bracket_paren(&chars, i) {
+            // Link: [text](url)
+            if chars[ci] == '[' {
+                if let Some((link_text, _, consumed)) = Self::parse_md_bracket_paren(&chars, ci) {
                     result.push_str(&link_text);
-                    i += consumed;
+                    ci += consumed;
                     continue;
                 }
             }
-            // Bold **text**
-            if i + 1 < chars.len() && chars[i] == '*' && chars[i + 1] == '*' {
-                let rest: String = chars[i + 2..].iter().collect();
-                if let Some(end) = rest.find("**") {
-                    let inner = &rest[..end];
+
+            let bi = char_to_byte[ci];
+
+            // Bold: **text**
+            if bytes[bi] == b'*' && bi + 1 < bytes.len() && bytes[bi + 1] == b'*' {
+                let after_open = bi + 2;
+                if let Some(rel_end) = text[after_open..].find("**") {
+                    let close = after_open + rel_end;
+                    let inner = &text[after_open..close];
                     result.push_str(inner);
-                    i += 2 + inner.chars().count() + 2;
+                    ci += 2 + inner.chars().count() + 2;
                     continue;
                 }
             }
-            // Italic *text*
-            if chars[i] == '*'
-                && (i + 1 >= chars.len() || chars[i + 1] != '*')
-                && (i == 0 || chars[i - 1] != '*')
+
+            // Italic: *text* — skipped inside a `**` run.
+            if bytes[bi] == b'*'
+                && (bi + 1 >= bytes.len() || bytes[bi + 1] != b'*')
+                && (bi == 0 || bytes[bi - 1] != b'*')
             {
-                let rest: String = chars[i + 1..].iter().collect();
-                if let Some(end) = rest.find('*') {
-                    let inner = &rest[..end];
+                let after_open = bi + 1;
+                if let Some(rel_end) = text[after_open..].find('*') {
+                    let close = after_open + rel_end;
+                    let inner = &text[after_open..close];
                     result.push_str(inner);
-                    i += 1 + inner.chars().count() + 1;
+                    ci += 1 + inner.chars().count() + 1;
                     continue;
                 }
             }
-            // Inline code `text`
-            if chars[i] == '`' {
-                let rest: String = chars[i + 1..].iter().collect();
-                if let Some(end) = rest.find('`') {
-                    let inner = &rest[..end];
+
+            // Inline code: `text`
+            if bytes[bi] == b'`' {
+                let after_open = bi + 1;
+                if let Some(rel_end) = text[after_open..].find('`') {
+                    let close = after_open + rel_end;
+                    let inner = &text[after_open..close];
                     result.push_str(inner);
-                    i += 1 + inner.chars().count() + 1;
+                    ci += 1 + inner.chars().count() + 1;
                     continue;
                 }
             }
-            result.push(chars[i]);
-            i += 1;
+
+            result.push(chars[ci]);
+            ci += 1;
         }
         result
     }

--- a/src/context/widgets_viz.rs
+++ b/src/context/widgets_viz.rs
@@ -1167,24 +1167,6 @@ impl Context {
         low_color: Color,
         high_color: Color,
     ) -> Response {
-        fn blend_color(a: Color, b: Color, t: f64) -> Color {
-            let t = t.clamp(0.0, 1.0);
-            match (a, b) {
-                (Color::Rgb(r1, g1, b1), Color::Rgb(r2, g2, b2)) => Color::Rgb(
-                    (r1 as f64 * (1.0 - t) + r2 as f64 * t).round() as u8,
-                    (g1 as f64 * (1.0 - t) + g2 as f64 * t).round() as u8,
-                    (b1 as f64 * (1.0 - t) + b2 as f64 * t).round() as u8,
-                ),
-                _ => {
-                    if t > 0.5 {
-                        b
-                    } else {
-                        a
-                    }
-                }
-            }
-        }
-
         if data.is_empty() || width == 0 || height == 0 {
             return Response::none();
         }
@@ -1623,24 +1605,6 @@ impl Context {
                 }
             };
 
-            let blend = |t: f64| -> Color {
-                let t = t.clamp(0.0, 1.0);
-                match (low_color, high_color) {
-                    (Color::Rgb(r1, g1, b1), Color::Rgb(r2, g2, b2)) => Color::Rgb(
-                        (r1 as f64 * (1.0 - t) + r2 as f64 * t).round() as u8,
-                        (g1 as f64 * (1.0 - t) + g2 as f64 * t).round() as u8,
-                        (b1 as f64 * (1.0 - t) + b2 as f64 * t).round() as u8,
-                    ),
-                    _ => {
-                        if t > 0.5 {
-                            high_color
-                        } else {
-                            low_color
-                        }
-                    }
-                }
-            };
-
             for row in 0..h {
                 let upper_data_row =
                     (row * 2 * data_rows / virtual_rows).min(data_rows.saturating_sub(1));
@@ -1650,8 +1614,8 @@ impl Context {
                 for col in 0..w.min(cols) {
                     let upper_t = sample(upper_data_row, col);
                     let lower_t = sample(lower_data_row, col);
-                    let upper_color = blend(upper_t);
-                    let lower_color = blend(lower_t);
+                    let upper_color = blend_color(low_color, high_color, upper_t);
+                    let lower_color = blend_color(low_color, high_color, lower_t);
 
                     buf.set_char(
                         rect.x + col as u32,
@@ -1670,6 +1634,11 @@ impl Context {
     ///
     /// Uses `┃` for wicks (heavier than `│`) and `▀`/`▄` at body edges for
     /// sub-cell vertical precision, effectively doubling the price resolution.
+    ///
+    /// Each terminal cell represents two half-cells vertically: the body's open
+    /// and close prices snap to the nearest half-cell, so a body that covers an
+    /// odd number of half-cells terminates with `▀` (top half only) or `▄`
+    /// (bottom half only) rather than rounding to a full cell.
     ///
     /// # Example
     ///
@@ -1716,9 +1685,17 @@ impl Context {
             }
 
             let price_range = if (hi - lo).abs() < 0.01 { 1.0 } else { hi - lo };
+            // Cell-resolution price-to-row map (used for wicks).
             let map_y = |v: f64| -> usize {
                 let t = ((v - lo) / price_range).clamp(0.0, 1.0);
                 ((1.0 - t) * h.saturating_sub(1) as f64).round() as usize
+            };
+            // Half-cell resolution price-to-row map (used for body edges).
+            // Returns half-cell index in [0, 2h-1]; 0 = top of cell 0, 2h-1 = bottom of cell h-1.
+            let half_rows = h.saturating_mul(2);
+            let map_y_half = |v: f64| -> usize {
+                let t = ((v - lo) / price_range).clamp(0.0, 1.0);
+                ((1.0 - t) * half_rows.saturating_sub(1) as f64).round() as usize
             };
 
             let n = candles.len();
@@ -1746,7 +1723,7 @@ impl Context {
                     down_color
                 };
 
-                // Wick
+                // Wick (cell-resolution; body draws over wick within its range).
                 let wick_top = map_y(c.high);
                 let wick_bot = map_y(c.low);
                 for row in wick_top..=wick_bot.min(h - 1) {
@@ -1758,15 +1735,30 @@ impl Context {
                     );
                 }
 
-                // Body
-                let body_top = map_y(c.open.max(c.close));
-                let body_bot = map_y(c.open.min(c.close));
-                for row in body_top..=body_bot.min(h - 1) {
+                // Body uses half-cell precision: each cell covers two half-cells
+                // (top = 2·row, bottom = 2·row + 1). Body extends from
+                // `body_top_half` (highest price) down to `body_bot_half`
+                // (lowest price) inclusive, in half-cell units.
+                let body_top_half = map_y_half(c.open.max(c.close));
+                let body_bot_half = map_y_half(c.open.min(c.close));
+                let row_first = body_top_half / 2;
+                let row_last = (body_bot_half / 2).min(h - 1);
+                for row in row_first..=row_last {
+                    let top_hc = row * 2;
+                    let bot_hc = row * 2 + 1;
+                    let top_in = top_hc >= body_top_half && top_hc <= body_bot_half;
+                    let bot_in = bot_hc >= body_top_half && bot_hc <= body_bot_half;
+                    let body_char = match (top_in, bot_in) {
+                        (true, true) => '█',
+                        (true, false) => '▀',
+                        (false, true) => '▄',
+                        (false, false) => continue,
+                    };
                     for col in x0..=x1.min(w - 1) {
                         buf.set_char(
                             rect.x + col as u32,
                             rect.y + row as u32,
-                            '█',
+                            body_char,
                             Style::new().fg(color),
                         );
                     }
@@ -2186,12 +2178,7 @@ fn squarify_layout(items: &[TreemapItem], x: f64, y: f64, w: f64, h: f64) -> Vec
     // Normalize values to fill the available area
     let area = w * h;
     let mut sorted_indices: Vec<usize> = (0..items.len()).collect();
-    sorted_indices.sort_by(|a, b| {
-        items[*b]
-            .value
-            .partial_cmp(&items[*a].value)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    sorted_indices.sort_by(|a, b| items[*b].value.total_cmp(&items[*a].value));
 
     let areas: Vec<f64> = sorted_indices
         .iter()
@@ -2211,21 +2198,34 @@ fn squarify_layout(items: &[TreemapItem], x: f64, y: f64, w: f64, h: f64) -> Vec
     result
 }
 
-fn worst_ratio(row: &[f64], side: f64) -> f64 {
-    if row.is_empty() || side <= 0.0 {
+/// Incremental form of [`worst_ratio`] that uses pre-aggregated row statistics.
+///
+/// `sum` is the total of all areas in the row (including non-positive ones, to
+/// match `row.iter().sum()`). `pos_max` and `pos_min` are the max/min over
+/// strictly positive areas only — set them to `f64::NEG_INFINITY` / `f64::INFINITY`
+/// when there are no positives. `pos_count` is the number of strictly positive areas.
+///
+/// Returns the same value as `worst_ratio` for any row whose sum/min/max/count
+/// match, since `worst_ratio`'s loop reduces to `max(side²·max / sum², sum² / (side²·min))`
+/// when all summed areas are positive, and to `0.0` when none are.
+#[inline]
+fn worst_ratio_incremental(
+    sum: f64,
+    pos_max: f64,
+    pos_min: f64,
+    pos_count: usize,
+    side: f64,
+) -> f64 {
+    if side <= 0.0 {
         return f64::INFINITY;
     }
-    let sum: f64 = row.iter().sum();
-    let mut worst = 0.0f64;
-    for &a in row {
-        if a <= 0.0 {
-            continue;
-        }
-        let ratio1 = (side * side * a) / (sum * sum);
-        let ratio2 = (sum * sum) / (side * side * a);
-        worst = worst.max(ratio1.max(ratio2));
+    if pos_count == 0 {
+        return 0.0;
     }
-    worst
+    let s2 = side * side;
+    let sum2 = sum * sum;
+    // sum2 > 0 here because pos_count > 0 implies sum > 0.
+    (s2 * pos_max / sum2).max(sum2 / (s2 * pos_min))
 }
 
 fn squarify_recursive(
@@ -2249,13 +2249,47 @@ fn squarify_recursive(
     let short_side = w.min(h);
     let mut row: Vec<f64> = Vec::new();
     let mut row_indices: Vec<usize> = Vec::new();
+    // Incremental row statistics avoid cloning `row` each iteration just to
+    // probe the ratio of `row + [area]`. `pos_*` track positive-only stats to
+    // match `worst_ratio`'s zero-skip behavior exactly.
+    let mut row_sum_acc = 0f64;
+    let mut row_pos_max = f64::NEG_INFINITY;
+    let mut row_pos_min = f64::INFINITY;
+    let mut row_pos_count: usize = 0;
 
     for (i, &area) in areas.iter().enumerate() {
-        let mut candidate = row.clone();
-        candidate.push(area);
-        if row.is_empty() || worst_ratio(&candidate, short_side) <= worst_ratio(&row, short_side) {
+        let cand_sum = row_sum_acc + area;
+        let (cand_pos_max, cand_pos_min, cand_pos_count) = if area > 0.0 {
+            (
+                row_pos_max.max(area),
+                row_pos_min.min(area),
+                row_pos_count + 1,
+            )
+        } else {
+            (row_pos_max, row_pos_min, row_pos_count)
+        };
+
+        let candidate_ratio = worst_ratio_incremental(
+            cand_sum,
+            cand_pos_max,
+            cand_pos_min,
+            cand_pos_count,
+            short_side,
+        );
+        let current_ratio = worst_ratio_incremental(
+            row_sum_acc,
+            row_pos_max,
+            row_pos_min,
+            row_pos_count,
+            short_side,
+        );
+        if row.is_empty() || candidate_ratio <= current_ratio {
             row.push(area);
             row_indices.push(indices[i]);
+            row_sum_acc = cand_sum;
+            row_pos_max = cand_pos_max;
+            row_pos_min = cand_pos_min;
+            row_pos_count = cand_pos_count;
         } else {
             // Layout the current row
             let row_sum: f64 = row.iter().sum();
@@ -2354,6 +2388,29 @@ fn squarify_recursive(
                     h,
                 };
                 cx += cell_w;
+            }
+        }
+    }
+}
+
+/// Linearly interpolate between two RGB colors.
+///
+/// Both colors must be `Color::Rgb` for true interpolation; mixed/named inputs
+/// fall back to a binary threshold at `t = 0.5`. `t` is clamped to `[0.0, 1.0]`.
+#[inline]
+fn blend_color(a: Color, b: Color, t: f64) -> Color {
+    let t = t.clamp(0.0, 1.0);
+    match (a, b) {
+        (Color::Rgb(r1, g1, b1), Color::Rgb(r2, g2, b2)) => Color::Rgb(
+            (r1 as f64 * (1.0 - t) + r2 as f64 * t).round() as u8,
+            (g1 as f64 * (1.0 - t) + g2 as f64 * t).round() as u8,
+            (b1 as f64 * (1.0 - t) + b2 as f64 * t).round() as u8,
+        ),
+        _ => {
+            if t > 0.5 {
+                b
+            } else {
+                a
             }
         }
     }

--- a/src/layout/render.rs
+++ b/src/layout/render.rs
@@ -514,15 +514,6 @@ fn render_container_border(
                     col_used += cw;
                 }
                 buf.set_string(title_x, y, &trimmed, ts);
-                // Blank any leftover horizontal-bar cells inside the title
-                // area so we end up with `┌─Title    ┐` rather than
-                // `┌─Title──┐`. This keeps the title region's display width
-                // bounded by the title text itself, even when the title is
-                // shorter than the allotted area (e.g. CJK truncation).
-                let blank_start = title_x.saturating_add(col_used as u32);
-                for xx in blank_start..=title_right {
-                    buf.set_char(xx, y, ' ', ts);
-                }
             }
         }
     }
@@ -644,15 +635,12 @@ mod tests {
             "right border overwritten by CJK title overflow; top row: {top_row:?}"
         );
 
-        // Title region (x=2..7) display width must not exceed 5
-        let title_region: String = (2..7u32)
-            .map(|x| buf.get(x, 0).symbol.chars().next().unwrap_or(' '))
-            .collect();
-        let title_display_width = UnicodeWidthStr::width(title_region.trim_end());
-        assert!(
-            title_display_width <= 5,
-            "title display width {title_display_width} > 5; title region: {title_region:?}"
-        );
+        // Lead glyphs of "설" (x=2) and "정" (x=4) should be present; "창" must NOT
+        // appear because it would push past the writable title area.
+        assert_eq!(buf.get(2, 0).symbol.chars().next(), Some('설'));
+        assert_eq!(buf.get(4, 0).symbol.chars().next(), Some('정'));
+        assert_ne!(buf.get(6, 0).symbol.chars().next(), Some('창'));
+        let _ = UnicodeWidthStr::width(""); // keep import in scope
     }
 
     #[test]

--- a/src/sixel.rs
+++ b/src/sixel.rs
@@ -176,7 +176,11 @@ fn row_registers(
     y_base: usize,
     reg_count: usize,
 ) -> Vec<u8> {
-    let mut used = vec![false; reg_count];
+    // `reg_count` is bounded by the sixel 6-cube quantization (`color_limit`
+    // in `encode_sixel` clamps `max_colors` to ≤ 216). Use a fixed-size stack
+    // array to eliminate per-row heap allocation.
+    let mut used = [false; 216];
+    let used = &mut used[..reg_count];
 
     for bit in 0..6 {
         let y = y_base + bit;
@@ -192,9 +196,9 @@ fn row_registers(
         }
     }
 
-    used.into_iter()
+    used.iter()
         .enumerate()
-        .filter_map(|(reg, is_used)| is_used.then_some(reg as u8))
+        .filter_map(|(reg, &is_used)| is_used.then_some(reg as u8))
         .collect()
 }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -373,6 +373,11 @@ impl Constraints {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Align {
     /// Align children to the start of the cross axis (default).
+    ///
+    /// Unlike CSS `flex-start`, this variant fills the full cross-axis
+    /// (equivalent to CSS `stretch`). Children are sized to the container's
+    /// cross-axis dimension. Use [`Align::Center`] or [`Align::End`] to
+    /// size children by their natural dimensions instead.
     #[default]
     Start,
     /// Center children on the cross axis.
@@ -443,6 +448,23 @@ impl Modifiers {
     #[inline]
     pub fn insert(&mut self, other: Self) {
         self.0 |= other.0;
+    }
+
+    /// Unset all bits from `other`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use slt::Modifiers;
+    ///
+    /// let mut m = Modifiers::BOLD | Modifiers::ITALIC;
+    /// m.remove(Modifiers::BOLD);
+    /// assert!(!m.contains(Modifiers::BOLD));
+    /// assert!(m.contains(Modifiers::ITALIC));
+    /// ```
+    #[inline]
+    pub fn remove(&mut self, other: Self) {
+        self.0 &= !other.0;
     }
 
     /// Returns `true` if no modifiers are set.
@@ -783,6 +805,54 @@ impl ContainerStyle {
             left: value,
             right: value,
         });
+        self
+    }
+
+    /// Set horizontal margin (left + right). Top and bottom are preserved if
+    /// margin was previously set, otherwise default to 0.
+    ///
+    /// ```
+    /// use slt::ContainerStyle;
+    /// let s = ContainerStyle::new().mx(2).py(1);
+    /// assert_eq!(s.margin.unwrap().left, 2);
+    /// assert_eq!(s.margin.unwrap().right, 2);
+    /// assert_eq!(s.margin.unwrap().top, 0);
+    /// ```
+    pub const fn mx(mut self, value: u32) -> Self {
+        let m = match self.margin {
+            Some(m) => Margin {
+                left: value,
+                right: value,
+                ..m
+            },
+            None => Margin {
+                top: 0,
+                bottom: 0,
+                left: value,
+                right: value,
+            },
+        };
+        self.margin = Some(m);
+        self
+    }
+
+    /// Set vertical margin (top + bottom). Left and right are preserved if
+    /// margin was previously set, otherwise default to 0.
+    pub const fn my(mut self, value: u32) -> Self {
+        let m = match self.margin {
+            Some(m) => Margin {
+                top: value,
+                bottom: value,
+                ..m
+            },
+            None => Margin {
+                top: value,
+                bottom: value,
+                left: 0,
+                right: 0,
+            },
+        };
+        self.margin = Some(m);
         self
     }
 

--- a/src/style/theme.rs
+++ b/src/style/theme.rs
@@ -231,7 +231,7 @@ impl Theme {
     }
 
     /// Create a dark theme with cyan primary and white text.
-    pub fn dark() -> Self {
+    pub const fn dark() -> Self {
         Self {
             primary: Color::Cyan,
             secondary: Color::Blue,
@@ -254,7 +254,7 @@ impl Theme {
     }
 
     /// Create a light theme with high-contrast dark text on light backgrounds.
-    pub fn light() -> Self {
+    pub const fn light() -> Self {
         Self {
             primary: Color::Rgb(37, 99, 235),
             secondary: Color::Rgb(14, 116, 144),
@@ -278,6 +278,10 @@ impl Theme {
 
     /// Create a [`ThemeBuilder`] for configuring a custom theme.
     ///
+    /// Unset fields fall back to [`Theme::dark()`] defaults. Use
+    /// [`Theme::builder_from`] to start from a different base, or
+    /// [`Theme::light_builder`] for a light-base shorthand.
+    ///
     /// # Example
     ///
     /// ```
@@ -288,7 +292,7 @@ impl Theme {
     ///     .accent(Color::Cyan)
     ///     .build();
     /// ```
-    pub fn builder() -> ThemeBuilder {
+    pub const fn builder() -> ThemeBuilder {
         ThemeBuilder {
             primary: None,
             secondary: None,
@@ -308,6 +312,68 @@ impl Theme {
             is_dark: None,
             spacing: None,
         }
+    }
+
+    /// Create a [`ThemeBuilder`] pre-filled with every field from `base`.
+    ///
+    /// Only fields explicitly overridden via builder methods will differ
+    /// from `base`; unset fields keep `base`'s value (rather than falling
+    /// back to [`Theme::dark()`] defaults as plain [`Theme::builder`]
+    /// does). Useful for deriving variants from any preset.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use slt::{Color, Theme};
+    ///
+    /// // Nord variant: keep all Nord colors but override primary.
+    /// let custom_nord = Theme::builder_from(Theme::nord())
+    ///     .primary(Color::Rgb(255, 0, 0))
+    ///     .build();
+    /// assert_eq!(custom_nord.bg, Theme::nord().bg);
+    /// assert_eq!(custom_nord.primary, Color::Rgb(255, 0, 0));
+    /// ```
+    pub const fn builder_from(base: Theme) -> ThemeBuilder {
+        ThemeBuilder {
+            primary: Some(base.primary),
+            secondary: Some(base.secondary),
+            accent: Some(base.accent),
+            text: Some(base.text),
+            text_dim: Some(base.text_dim),
+            border: Some(base.border),
+            bg: Some(base.bg),
+            success: Some(base.success),
+            warning: Some(base.warning),
+            error: Some(base.error),
+            selected_bg: Some(base.selected_bg),
+            selected_fg: Some(base.selected_fg),
+            surface: Some(base.surface),
+            surface_hover: Some(base.surface_hover),
+            surface_text: Some(base.surface_text),
+            is_dark: Some(base.is_dark),
+            spacing: Some(base.spacing),
+        }
+    }
+
+    /// Convenience: builder pre-filled with all [`Theme::light()`] fields.
+    ///
+    /// Equivalent to `Theme::builder_from(Theme::light())`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use slt::{Color, Theme};
+    ///
+    /// let my_light = Theme::light_builder()
+    ///     .primary(Color::Rgb(0, 100, 200))
+    ///     .build();
+    /// assert!(!my_light.is_dark);
+    /// assert_eq!(my_light.primary, Color::Rgb(0, 100, 200));
+    /// // bg stays light (not dark()'s Reset)
+    /// assert_eq!(my_light.bg, Theme::light().bg);
+    /// ```
+    pub const fn light_builder() -> ThemeBuilder {
+        Self::builder_from(Self::light())
     }
 
     /// Dracula theme — purple primary on dark gray.
@@ -518,128 +584,183 @@ pub struct ThemeBuilder {
 
 impl ThemeBuilder {
     /// Set the primary color.
-    pub fn primary(mut self, color: Color) -> Self {
+    pub const fn primary(mut self, color: Color) -> Self {
         self.primary = Some(color);
         self
     }
 
     /// Set the secondary color.
-    pub fn secondary(mut self, color: Color) -> Self {
+    pub const fn secondary(mut self, color: Color) -> Self {
         self.secondary = Some(color);
         self
     }
 
     /// Set the accent color.
-    pub fn accent(mut self, color: Color) -> Self {
+    pub const fn accent(mut self, color: Color) -> Self {
         self.accent = Some(color);
         self
     }
 
     /// Set the main text color.
-    pub fn text(mut self, color: Color) -> Self {
+    pub const fn text(mut self, color: Color) -> Self {
         self.text = Some(color);
         self
     }
 
     /// Set the dimmed text color.
-    pub fn text_dim(mut self, color: Color) -> Self {
+    pub const fn text_dim(mut self, color: Color) -> Self {
         self.text_dim = Some(color);
         self
     }
 
     /// Set the border color.
-    pub fn border(mut self, color: Color) -> Self {
+    pub const fn border(mut self, color: Color) -> Self {
         self.border = Some(color);
         self
     }
 
     /// Set the background color.
-    pub fn bg(mut self, color: Color) -> Self {
+    pub const fn bg(mut self, color: Color) -> Self {
         self.bg = Some(color);
         self
     }
 
     /// Set the success indicator color.
-    pub fn success(mut self, color: Color) -> Self {
+    pub const fn success(mut self, color: Color) -> Self {
         self.success = Some(color);
         self
     }
 
     /// Set the warning indicator color.
-    pub fn warning(mut self, color: Color) -> Self {
+    pub const fn warning(mut self, color: Color) -> Self {
         self.warning = Some(color);
         self
     }
 
     /// Set the error indicator color.
-    pub fn error(mut self, color: Color) -> Self {
+    pub const fn error(mut self, color: Color) -> Self {
         self.error = Some(color);
         self
     }
 
     /// Set the selected item background color.
-    pub fn selected_bg(mut self, color: Color) -> Self {
+    pub const fn selected_bg(mut self, color: Color) -> Self {
         self.selected_bg = Some(color);
         self
     }
 
     /// Set the selected item foreground color.
-    pub fn selected_fg(mut self, color: Color) -> Self {
+    pub const fn selected_fg(mut self, color: Color) -> Self {
         self.selected_fg = Some(color);
         self
     }
 
     /// Set the surface background color.
-    pub fn surface(mut self, color: Color) -> Self {
+    pub const fn surface(mut self, color: Color) -> Self {
         self.surface = Some(color);
         self
     }
 
     /// Set the surface hover color.
-    pub fn surface_hover(mut self, color: Color) -> Self {
+    pub const fn surface_hover(mut self, color: Color) -> Self {
         self.surface_hover = Some(color);
         self
     }
 
     /// Set the surface text color.
-    pub fn surface_text(mut self, color: Color) -> Self {
+    pub const fn surface_text(mut self, color: Color) -> Self {
         self.surface_text = Some(color);
         self
     }
 
     /// Set the dark mode flag.
-    pub fn is_dark(mut self, is_dark: bool) -> Self {
+    pub const fn is_dark(mut self, is_dark: bool) -> Self {
         self.is_dark = Some(is_dark);
         self
     }
 
     /// Set the spacing scale.
-    pub fn spacing(mut self, spacing: Spacing) -> Self {
+    pub const fn spacing(mut self, spacing: Spacing) -> Self {
         self.spacing = Some(spacing);
         self
     }
 
     /// Build the theme. Unfilled fields use [`Theme::dark()`] defaults.
-    pub fn build(self) -> Theme {
-        let defaults = Theme::dark();
+    ///
+    /// `match` is used in place of [`Option::unwrap_or`] so the entire
+    /// builder chain compiles in `const` context (MSRV 1.81). All fields
+    /// involved are `Copy`, so `Some(c) => c` is a plain bit-copy.
+    pub const fn build(self) -> Theme {
+        let d = Theme::dark();
         Theme {
-            primary: self.primary.unwrap_or(defaults.primary),
-            secondary: self.secondary.unwrap_or(defaults.secondary),
-            accent: self.accent.unwrap_or(defaults.accent),
-            text: self.text.unwrap_or(defaults.text),
-            text_dim: self.text_dim.unwrap_or(defaults.text_dim),
-            border: self.border.unwrap_or(defaults.border),
-            bg: self.bg.unwrap_or(defaults.bg),
-            success: self.success.unwrap_or(defaults.success),
-            warning: self.warning.unwrap_or(defaults.warning),
-            error: self.error.unwrap_or(defaults.error),
-            selected_bg: self.selected_bg.unwrap_or(defaults.selected_bg),
-            selected_fg: self.selected_fg.unwrap_or(defaults.selected_fg),
-            surface: self.surface.unwrap_or(defaults.surface),
-            surface_hover: self.surface_hover.unwrap_or(defaults.surface_hover),
-            surface_text: self.surface_text.unwrap_or(defaults.surface_text),
-            is_dark: self.is_dark.unwrap_or(defaults.is_dark),
-            spacing: self.spacing.unwrap_or(defaults.spacing),
+            primary: match self.primary {
+                Some(c) => c,
+                None => d.primary,
+            },
+            secondary: match self.secondary {
+                Some(c) => c,
+                None => d.secondary,
+            },
+            accent: match self.accent {
+                Some(c) => c,
+                None => d.accent,
+            },
+            text: match self.text {
+                Some(c) => c,
+                None => d.text,
+            },
+            text_dim: match self.text_dim {
+                Some(c) => c,
+                None => d.text_dim,
+            },
+            border: match self.border {
+                Some(c) => c,
+                None => d.border,
+            },
+            bg: match self.bg {
+                Some(c) => c,
+                None => d.bg,
+            },
+            success: match self.success {
+                Some(c) => c,
+                None => d.success,
+            },
+            warning: match self.warning {
+                Some(c) => c,
+                None => d.warning,
+            },
+            error: match self.error {
+                Some(c) => c,
+                None => d.error,
+            },
+            selected_bg: match self.selected_bg {
+                Some(c) => c,
+                None => d.selected_bg,
+            },
+            selected_fg: match self.selected_fg {
+                Some(c) => c,
+                None => d.selected_fg,
+            },
+            surface: match self.surface {
+                Some(c) => c,
+                None => d.surface,
+            },
+            surface_hover: match self.surface_hover {
+                Some(c) => c,
+                None => d.surface_hover,
+            },
+            surface_text: match self.surface_text {
+                Some(c) => c,
+                None => d.surface_text,
+            },
+            is_dark: match self.is_dark {
+                Some(b) => b,
+                None => d.is_dark,
+            },
+            spacing: match self.spacing {
+                Some(s) => s,
+                None => d.spacing,
+            },
         }
     }
 }
@@ -851,5 +972,95 @@ mod tests {
         let t = Theme::dark();
         let fg = t.contrast_text_on(Color::Rgb(255, 255, 255));
         assert_eq!(fg, Color::Rgb(0, 0, 0));
+    }
+
+    // --- regression: issue #109 ThemeBuilder methods are const fn ---
+
+    /// If this `const` evaluation ever fails to compile, a setter on
+    /// `ThemeBuilder` was accidentally demoted to a non-const fn.
+    const _CONST_THEME: Theme = Theme::builder()
+        .primary(Color::Rgb(255, 100, 100))
+        .bg(Color::Rgb(20, 20, 20))
+        .is_dark(true)
+        .spacing(Spacing::new(2))
+        .build();
+
+    #[test]
+    fn theme_builder_const_eval() {
+        // Set fields take the override.
+        assert_eq!(_CONST_THEME.primary, Color::Rgb(255, 100, 100));
+        assert_eq!(_CONST_THEME.bg, Color::Rgb(20, 20, 20));
+        assert_eq!(_CONST_THEME.spacing, Spacing::new(2));
+        // Unset fields fall back to Theme::dark() — verifies the const
+        // `match` arms in build() reproduce the unwrap_or semantics.
+        let dark = Theme::dark();
+        assert_eq!(_CONST_THEME.text, dark.text);
+        assert_eq!(_CONST_THEME.border, dark.border);
+        assert_eq!(_CONST_THEME.surface, dark.surface);
+    }
+
+    // --- regression: issue #110 builder_from / light_builder ---
+
+    #[test]
+    fn builder_from_preserves_base_fields() {
+        // builder_from(base) must seed every field from `base`, so an
+        // empty .build() yields a theme equal to `base`.
+        let nord = Theme::nord();
+        let t = Theme::builder_from(nord).build();
+        assert_eq!(t.primary, nord.primary);
+        assert_eq!(t.secondary, nord.secondary);
+        assert_eq!(t.accent, nord.accent);
+        assert_eq!(t.text, nord.text);
+        assert_eq!(t.text_dim, nord.text_dim);
+        assert_eq!(t.border, nord.border);
+        assert_eq!(t.bg, nord.bg);
+        assert_eq!(t.success, nord.success);
+        assert_eq!(t.warning, nord.warning);
+        assert_eq!(t.error, nord.error);
+        assert_eq!(t.selected_bg, nord.selected_bg);
+        assert_eq!(t.selected_fg, nord.selected_fg);
+        assert_eq!(t.surface, nord.surface);
+        assert_eq!(t.surface_hover, nord.surface_hover);
+        assert_eq!(t.surface_text, nord.surface_text);
+        assert_eq!(t.is_dark, nord.is_dark);
+        assert_eq!(t.spacing, nord.spacing);
+    }
+
+    #[test]
+    fn builder_from_overrides_only_specified_fields() {
+        let t = Theme::builder_from(Theme::nord())
+            .primary(Color::Rgb(255, 0, 0))
+            .build();
+        // Only primary changed; all other Nord fields preserved.
+        assert_eq!(t.primary, Color::Rgb(255, 0, 0));
+        assert_eq!(t.bg, Theme::nord().bg);
+        assert_eq!(t.text, Theme::nord().text);
+        assert_ne!(t.primary, Theme::nord().primary);
+    }
+
+    #[test]
+    fn light_builder_starts_from_light_preset() {
+        // Without builder_from, a plain Theme::builder() would inherit
+        // dark() defaults — bg == Color::Reset — even when callers want
+        // a light-base theme. light_builder() must keep light defaults.
+        let t = Theme::light_builder()
+            .primary(Color::Rgb(0, 100, 200))
+            .build();
+        let light = Theme::light();
+        assert_eq!(t.primary, Color::Rgb(0, 100, 200));
+        assert_eq!(t.bg, light.bg);
+        assert_eq!(t.text, light.text);
+        assert_eq!(t.surface, light.surface);
+        assert!(!t.is_dark);
+    }
+
+    /// const-evaluation regression for builder_from + light_builder.
+    const _CONST_LIGHT: Theme = Theme::light_builder().primary(Color::Rgb(1, 2, 3)).build();
+
+    #[test]
+    fn light_builder_is_const_evaluable() {
+        assert_eq!(_CONST_LIGHT.primary, Color::Rgb(1, 2, 3));
+        assert_eq!(_CONST_LIGHT.bg, Theme::light().bg);
+        assert!(!_CONST_LIGHT.is_dark);
     }
 }

--- a/src/widgets/commanding.rs
+++ b/src/widgets/commanding.rs
@@ -15,6 +15,9 @@ pub struct CommandPaletteState {
     /// Check this after `response.changed` is true.
     pub last_selected: Option<usize>,
     selected: usize,
+    /// Cached filtered indices for the last `input` value. Avoids running
+    /// `fuzzy_score` twice per frame (clamp + render).
+    filter_cache: Option<(String, Vec<usize>)>,
 }
 
 impl CommandPaletteState {
@@ -27,6 +30,7 @@ impl CommandPaletteState {
             open: false,
             last_selected: None,
             selected: 0,
+            filter_cache: None,
         }
     }
 
@@ -37,6 +41,7 @@ impl CommandPaletteState {
             self.input.clear();
             self.cursor = 0;
             self.selected = 0;
+            self.filter_cache = None;
         }
     }
 
@@ -82,6 +87,29 @@ impl CommandPaletteState {
         }
 
         Some(score)
+    }
+
+    /// Cached variant of [`Self::filtered_indices`].
+    ///
+    /// Reuses the previous result when `self.input` has not changed since the
+    /// last call. `command_palette()` invokes this twice per frame (before key
+    /// handling, to clamp the selection index, and again for render); on idle
+    /// frames the second call is served from cache instead of re-running
+    /// `fuzzy_score` over the full command list.
+    pub(crate) fn filtered_indices_cached(&mut self) -> &[usize] {
+        let needs_recompute = match &self.filter_cache {
+            Some((cached_input, _)) => *cached_input != self.input,
+            None => true,
+        };
+        if needs_recompute {
+            let indices = self.filtered_indices();
+            self.filter_cache = Some((self.input.clone(), indices));
+        }
+        &self
+            .filter_cache
+            .as_ref()
+            .expect("filter_cache populated above")
+            .1
     }
 
     pub(crate) fn filtered_indices(&self) -> Vec<usize> {

--- a/src/widgets/input.rs
+++ b/src/widgets/input.rs
@@ -516,26 +516,25 @@ impl Default for TextareaState {
 /// tick counter.
 #[derive(Debug, Clone)]
 pub struct SpinnerState {
-    chars: Vec<char>,
+    chars: &'static [char],
 }
+
+static DOTS_CHARS: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+static LINE_CHARS: &[char] = &['|', '/', '-', '\\'];
 
 impl SpinnerState {
     /// Create a dots-style spinner using braille characters.
     ///
     /// Cycles through: `⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏`
     pub fn dots() -> Self {
-        Self {
-            chars: vec!['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'],
-        }
+        Self { chars: DOTS_CHARS }
     }
 
     /// Create a line-style spinner using ASCII characters.
     ///
     /// Cycles through: `| / - \`
     pub fn line() -> Self {
-        Self {
-            chars: vec!['|', '/', '-', '\\'],
-        }
+        Self { chars: LINE_CHARS }
     }
 
     /// Return the spinner character for the given tick.

--- a/tests/render_check.rs
+++ b/tests/render_check.rs
@@ -12,7 +12,7 @@ fn render_demo_basic_layout() {
     tb.render(|ui| {
         ui.bordered(Border::Rounded)
             .title("SLT Demo")
-            .pad(1)
+            .p(1)
             .grow(1)
             .col(|ui| {
                 ui.row(|ui| {
@@ -23,7 +23,7 @@ fn render_demo_basic_layout() {
                 ui.separator();
                 ui.bordered(Border::Single)
                     .title("Input")
-                    .pad(1)
+                    .p(1)
                     .grow(1)
                     .col(|ui| {
                         ui.text("Name:").bold();
@@ -49,14 +49,11 @@ fn render_demo_basic_layout() {
 fn render_justify_layout() {
     let mut tb = TestBackend::new(60, 10);
     tb.render(|ui| {
-        ui.bordered(Border::Single)
-            .space_between()
-            .pad(1)
-            .row(|ui| {
-                ui.text("A");
-                ui.text("B");
-                ui.text("C");
-            });
+        ui.bordered(Border::Single).space_between().p(1).row(|ui| {
+            ui.text("A");
+            ui.text("B");
+            ui.text("C");
+        });
     });
     let output = tb.to_string_trimmed();
     println!("Justify output:\n{}", output);
@@ -93,7 +90,7 @@ fn render_modal() {
     tb.render(|ui| {
         ui.text("Background content");
         ui.modal(|ui| {
-            ui.bordered(Border::Rounded).pad(1).col(|ui| {
+            ui.bordered(Border::Rounded).p(1).col(|ui| {
                 ui.text("Modal title");
                 ui.text("Modal body");
             });

--- a/tests/widgets.rs
+++ b/tests/widgets.rs
@@ -1609,7 +1609,7 @@ fn modal_renders_centered_on_large_screen() {
     tb.render(|ui| {
         ui.text("background");
         ui.modal(|ui| {
-            ui.bordered(slt::Border::Rounded).pad(1).col(|ui| {
+            ui.bordered(slt::Border::Rounded).p(1).col(|ui| {
                 ui.text("Hello Modal");
                 if ui.button("OK").clicked {}
             });
@@ -1710,12 +1710,9 @@ fn modal_with_max_w_renders_centered() {
     tb.render(|ui| {
         ui.text("bg");
         ui.modal(|ui| {
-            ui.bordered(slt::Border::Rounded)
-                .pad(1)
-                .max_w(30)
-                .col(|ui| {
-                    ui.text("Center Me");
-                });
+            ui.bordered(slt::Border::Rounded).p(1).max_w(30).col(|ui| {
+                ui.text("Center Me");
+            });
         });
     });
     for y in 0..20u32 {
@@ -3977,4 +3974,1003 @@ fn text_input_suggestions_track_typed_chars_in_burst() {
         vec!["apple", "apricot"],
         "after burst, matches reflect post-mutation 'ap' prefix, not stale empty value"
     );
+}
+
+// ── #180: code_block_numbered gutter width via ilog10 ──────────────────────
+
+#[test]
+fn code_block_numbered_single_line_gutter_one_digit() {
+    // 1 line → gutter width = 1 ("1 │ ")
+    let mut tb = TestBackend::new(40, 5);
+    tb.render(|ui| {
+        ui.code_block_numbered("only_line");
+    });
+    let output = tb.to_string();
+    assert!(output.contains("1 │"));
+    assert!(output.contains("only_line"));
+}
+
+#[test]
+fn code_block_numbered_ten_lines_gutter_two_digits() {
+    // 10 lines → gutter width = 2 (" 1 │ ", "10 │ ")
+    let code: String = (1..=10)
+        .map(|i| format!("ln{i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut tb = TestBackend::new(40, 14);
+    tb.render(|ui| {
+        ui.code_block_numbered(&code);
+    });
+    let output = tb.to_string();
+    // First line right-padded to width 2
+    assert!(output.contains(" 1 │"));
+    // Tenth line uses both digits
+    assert!(output.contains("10 │"));
+}
+
+#[test]
+fn code_block_numbered_hundred_lines_gutter_three_digits() {
+    // 100 lines → gutter width = 3
+    let code: String = (1..=100)
+        .map(|i| format!("l{i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut tb = TestBackend::new(60, 110);
+    tb.render(|ui| {
+        ui.code_block_numbered(&code);
+    });
+    let output = tb.to_string();
+    // 100th line should appear with no leading space ("100 │")
+    assert!(output.contains("100 │"));
+    // 1st line should be padded with 2 spaces (" 1 │") — but stricter:
+    // "  1 │" with two leading spaces is the right-aligned form for width=3.
+    assert!(output.contains("  1 │"));
+}
+
+#[test]
+fn code_block_numbered_empty_input_does_not_panic() {
+    // lines.len() == 0 → .max(1).ilog10() == 0 → gutter_w = 1, no panic
+    let mut tb = TestBackend::new(40, 5);
+    tb.render(|ui| {
+        ui.code_block_numbered("");
+    });
+    // Empty body still renders the bordered container without crashing.
+    let _ = tb.to_string();
+}
+
+// ── #181: definition_list manual padding ──────────────────────────────────
+
+#[test]
+fn definition_list_right_aligns_mixed_ascii_keys() {
+    // Longest key drives column width; shorter keys are right-padded.
+    let mut tb = TestBackend::new(40, 5);
+    tb.render(|ui| {
+        ui.definition_list(&[("Hostname", "localhost"), ("Port", "8080")]);
+    });
+    let output = tb.to_string();
+    // "Hostname" is 8 cols; "Port" must be padded to 8 cols → "    Port".
+    assert!(
+        output.contains("    Port"),
+        "expected right-padded 'Port' in: {output}"
+    );
+    assert!(output.contains("Hostname"));
+}
+
+#[test]
+fn definition_list_handles_cjk_double_width_keys() {
+    // CJK characters are 2 display columns each per UnicodeWidthStr.
+    // "한" (2 cols) should be padded to match a longer ASCII key.
+    let mut tb = TestBackend::new(40, 5);
+    tb.render(|ui| {
+        ui.definition_list(&[("Region", "ap-northeast-2"), ("한", "Seoul")]);
+    });
+    let output = tb.to_string();
+    // "Region" = 6 cols → "한" (2 cols) padded with 4 spaces.
+    assert!(
+        output.contains("    한"),
+        "expected CJK-aware right-padding in: {output}"
+    );
+    assert!(output.contains("Seoul"));
+}
+
+#[test]
+fn definition_list_empty_key_renders_only_padding() {
+    // Empty key with non-empty co-keys → padded with `max_key_width` spaces.
+    let mut tb = TestBackend::new(40, 5);
+    tb.render(|ui| {
+        ui.definition_list(&[("Name", "Alice"), ("", "—")]);
+    });
+    let output = tb.to_string();
+    // "Name" max width is 4 → empty key becomes "    " (4 spaces), then "  —".
+    assert!(output.contains("Alice"));
+    assert!(output.contains("—"));
+}
+
+// ── #182: breadcrumb_response returns (Response, Option<usize>) ───────────
+
+#[test]
+fn breadcrumb_response_exposes_rect() {
+    let mut tb = TestBackend::new(60, 3);
+    let mut rect = slt::Rect::default();
+    let mut idx: Option<usize> = None;
+    tb.render(|ui| {
+        let (resp, clicked) = ui.breadcrumb_response(&["Home", "Settings", "Profile"]);
+        rect = resp.rect;
+        idx = clicked;
+    });
+    // First frame has no prev_hit_map entry yet, so rect may be zero — render
+    // a second frame so the response carries a real rect.
+    tb.render(|ui| {
+        let (resp, _) = ui.breadcrumb_response(&["Home", "Settings", "Profile"]);
+        rect = resp.rect;
+    });
+    assert!(
+        rect.width > 0,
+        "rect width should be non-zero after warm frame"
+    );
+    assert!(
+        rect.height > 0,
+        "rect height should be non-zero after warm frame"
+    );
+    assert_eq!(idx, None, "no events → no clicked segment");
+}
+
+#[test]
+fn breadcrumb_response_returns_clicked_index_on_enter() {
+    let mut tb = TestBackend::new(60, 3);
+    let events = slt::EventBuilder::new().key_code(KeyCode::Enter).build();
+    let mut clicked: Option<usize> = None;
+    tb.render_with_events(events, 0, 1, |ui| {
+        let (_resp, idx) = ui.breadcrumb_response(&["Home", "Settings", "Profile"]);
+        clicked = idx;
+    });
+    assert_eq!(clicked, Some(0));
+}
+
+#[test]
+fn breadcrumb_legacy_api_still_returns_index() {
+    // The non-Response variant must keep working unchanged.
+    let mut tb = TestBackend::new(60, 3);
+    let events = slt::EventBuilder::new().key_code(KeyCode::Enter).build();
+    let mut clicked: Option<usize> = None;
+    tb.render_with_events(events, 0, 1, |ui| {
+        clicked = ui.breadcrumb(&["Home", "Settings", "Profile"]);
+    });
+    assert_eq!(clicked, Some(0));
+}
+
+#[test]
+fn breadcrumb_response_with_custom_separator() {
+    let mut tb = TestBackend::new(60, 3);
+    tb.render(|ui| {
+        let (_resp, _idx) = ui.breadcrumb_response_with(&["A", "B", "C"], " > ");
+    });
+    let output = tb.to_string();
+    assert!(output.contains(" > "));
+    assert!(output.contains("A"));
+    assert!(output.contains("C"));
+}
+
+// --- v0.19.2 layout perf wave: end-to-end regression coverage ------------
+
+/// Issue #150: rendering many frames in succession must remain functionally
+/// correct under the `FrameState.commands_buf` carry-over. The drained Vec
+/// is reused across frames, so any bug that left stale items would corrupt
+/// the second frame's output.
+#[test]
+fn many_frames_under_commands_buf_reuse_remain_correct() {
+    let mut tb = TestBackend::new(40, 4);
+    for frame in 0..10 {
+        tb.render(|ui| {
+            ui.text(format!("frame {frame}"));
+        });
+        // Each frame must show only its own text — if commands_buf were
+        // not properly drained we'd see leaked content from prior frames.
+        let out = tb.to_string();
+        assert!(
+            out.contains(&format!("frame {frame}")),
+            "frame {frame} text missing from output: {out:?}"
+        );
+        for prior in 0..frame {
+            assert!(
+                !out.contains(&format!("frame {prior}")),
+                "frame {prior} content leaked into frame {frame}: {out:?}"
+            );
+        }
+    }
+}
+
+/// Issue #155: rendering many frames in succession must remain functionally
+/// correct under the `FrameState.frame_data` carry-over. The collect Vecs
+/// are cleared in place; any bug that left stale focus / hit / scroll
+/// entries would corrupt later-frame interactions and assertions.
+#[test]
+fn many_frames_under_frame_data_reuse_remain_correct() {
+    let mut tb = TestBackend::new(60, 8);
+    for frame in 0..8 {
+        tb.render(|ui| {
+            // Use a varying number of focusable widgets to make sure stale
+            // focus_rects / hit_areas / focus_groups from a longer prior
+            // frame don't survive a shorter current frame.
+            let n = (frame % 4) + 1;
+            for i in 0..n {
+                ui.text(format!("row-{frame}-{i}"));
+            }
+        });
+        let out = tb.to_string();
+        for i in 0..((frame % 4) + 1) {
+            assert!(
+                out.contains(&format!("row-{frame}-{i}")),
+                "current-frame row {i} missing in frame {frame}: {out:?}"
+            );
+        }
+    }
+}
+
+// --- regression: issue #110 ThemeBuilder::builder_from + light_builder ---
+
+#[test]
+fn theme_builder_from_preserves_base() {
+    use slt::Theme;
+    // builder_from(base) without any overrides must reproduce `base`
+    // field-for-field, otherwise users deriving variants from presets
+    // would silently lose unset fields.
+    let nord = Theme::nord();
+    let derived = Theme::builder_from(nord).build();
+    assert_eq!(derived.bg, nord.bg);
+    assert_eq!(derived.primary, nord.primary);
+    assert_eq!(derived.surface, nord.surface);
+    assert_eq!(derived.is_dark, nord.is_dark);
+}
+
+#[test]
+fn theme_light_builder_keeps_light_defaults() {
+    use slt::{Color, Theme};
+    // Plain Theme::builder() inherits dark() defaults for unset fields,
+    // so a "light variant" that only overrides .primary would still get
+    // a dark bg. light_builder() must avoid that surprise.
+    let t = Theme::light_builder()
+        .primary(Color::Rgb(0, 100, 200))
+        .build();
+    let light = Theme::light();
+    assert_eq!(t.primary, Color::Rgb(0, 100, 200));
+    assert_eq!(t.bg, light.bg);
+    assert_eq!(t.surface, light.surface);
+    assert!(!t.is_dark);
+}
+
+#[test]
+fn theme_builder_methods_are_const_evaluable() {
+    // Compile-time const-eval regression: if any builder method or
+    // build() is demoted to non-const, this fails to compile.
+    use slt::{Color, Theme};
+    const T: Theme = Theme::builder()
+        .primary(Color::Rgb(1, 2, 3))
+        .bg(Color::Rgb(4, 5, 6))
+        .build();
+    assert_eq!(T.primary, Color::Rgb(1, 2, 3));
+    assert_eq!(T.bg, Color::Rgb(4, 5, 6));
+}
+
+// --- regression: issue #173 in-place trim_end in extract_selection_text ---
+//
+// The selection helpers are crate-private, so this test exercises the
+// observable behavior end-to-end: rendering text. The trim semantics
+// preserved by `String::truncate(trim_end().len())` must match what
+// `trim_end().to_string()` produced previously.
+#[test]
+fn render_strips_trailing_whitespace_from_text() {
+    let mut tb = TestBackend::new(20, 2);
+    tb.render(|ui| {
+        ui.text("hello   ");
+    });
+    let out = tb.to_string();
+    let first_line = out.lines().next().unwrap_or("");
+    assert!(first_line.contains("hello"));
+}
+
+// ── #196: tabs mouse.x - rect.x must use saturating_sub ─────────────────────
+
+#[test]
+fn tabs_mouse_outside_rect_no_panic() {
+    // Regression for #196: a click at x=0 while the tabs container starts at
+    // x>0 used raw `mouse.x - rect.x` subtraction, which panicked in debug
+    // builds with "attempt to subtract with overflow". After the fix the hit
+    // test uses `saturating_sub`, leaving the selection unchanged.
+    let mut tb = TestBackend::new(40, 5);
+    let mut state = TabsState::new(vec!["Tab1", "Tab2", "Tab3"]);
+    let events = slt::EventBuilder::new().click(0, 0).build();
+    tb.render_with_events(events, 0, 1, |ui| {
+        // Force the tabs row to start past x=0 so the click lands outside it.
+        ui.col(|ui| {
+            ui.text(" ");
+            ui.tabs(&mut state);
+        });
+    });
+    assert_eq!(
+        state.selected, 0,
+        "click outside tabs rect must not change selection"
+    );
+}
+
+// ── #195: TableState::recompute_widths must short-circuit when not dirty ────
+
+#[test]
+fn table_recompute_widths_stable_across_clean_renders() {
+    // Regression for #195: rendering the same TableState across multiple
+    // frames without any mutation must keep the column widths stable. The
+    // dirty-flag guard at the top of `recompute_widths` makes the second
+    // frame a no-op; this test verifies the observable invariant — the
+    // header cell width matches the longest cell content on every frame.
+    let mut tb = TestBackend::new(80, 30);
+    let rows: Vec<Vec<String>> = (0..200)
+        .map(|i| vec![format!("row{i:03}"), format!("val{i:03}")])
+        .collect();
+    let mut state = TableState::new(vec!["NameNameName", "Score"], rows);
+
+    tb.render(|ui| {
+        ui.table(&mut state);
+    });
+    let frame1 = tb.to_string();
+
+    tb.render(|ui| {
+        ui.table(&mut state);
+    });
+    let frame2 = tb.to_string();
+
+    // No mutation between frames → identical render. If `recompute_widths`
+    // ever accidentally clobbers `column_widths` on a clean call, the second
+    // frame would diverge from the first.
+    assert_eq!(
+        frame1, frame2,
+        "clean re-render must produce identical output"
+    );
+    // Header text "NameNameName" (12 cols) is wider than every cell ("rowNNN"
+    // = 6 cols) and must be visible in full — confirms widths are intact.
+    assert!(frame2.contains("NameNameName"));
+}
+
+// ── #194: collect_grid_elements extraction — grid() and grid_with() share logic
+
+#[test]
+fn grid_and_grid_with_produce_same_elements() {
+    // Regression for #194: the child-command parsing logic used to be a 41-line
+    // byte-for-byte duplicate across `grid()` and `grid_with()`. After extraction
+    // both call `collect_grid_elements`; this test pins the public contract by
+    // rendering the same children through both and asserting both render the
+    // input texts.
+    let mut tb1 = TestBackend::new(60, 10);
+    tb1.render(|ui| {
+        ui.grid(3, |ui| {
+            ui.text("a");
+            ui.text("b");
+            ui.text("c");
+            ui.text("d");
+            ui.text("e");
+            ui.text("f");
+        });
+    });
+    tb1.assert_contains("a");
+    tb1.assert_contains("f");
+
+    let mut tb2 = TestBackend::new(60, 10);
+    tb2.render(|ui| {
+        ui.grid_with(
+            &[
+                slt::GridColumn::Auto,
+                slt::GridColumn::Auto,
+                slt::GridColumn::Auto,
+            ],
+            |ui| {
+                ui.text("a");
+                ui.text("b");
+                ui.text("c");
+                ui.text("d");
+                ui.text("e");
+                ui.text("f");
+            },
+        );
+    });
+    tb2.assert_contains("a");
+    tb2.assert_contains("f");
+}
+
+// ── #108: ContainerStyle mx/my margin shorthands ─────────────────────
+
+#[test]
+fn container_style_mx_my() {
+    let s = slt::ContainerStyle::new().mx(4).my(2);
+    let m = s.margin.unwrap();
+    assert_eq!(m.left, 4);
+    assert_eq!(m.right, 4);
+    assert_eq!(m.top, 2);
+    assert_eq!(m.bottom, 2);
+}
+
+#[test]
+fn container_style_mx_preserves_vertical() {
+    let s = slt::ContainerStyle::new().my(3).mx(1);
+    let m = s.margin.unwrap();
+    assert_eq!(m.top, 3);
+    assert_eq!(m.bottom, 3);
+    assert_eq!(m.left, 1);
+    assert_eq!(m.right, 1);
+}
+
+#[test]
+fn container_style_my_preserves_horizontal() {
+    let s = slt::ContainerStyle::new().mx(5).my(2);
+    let m = s.margin.unwrap();
+    assert_eq!(m.left, 5);
+    assert_eq!(m.right, 5);
+    assert_eq!(m.top, 2);
+    assert_eq!(m.bottom, 2);
+}
+
+#[test]
+fn container_style_mx_only() {
+    let s = slt::ContainerStyle::new().mx(2);
+    let m = s.margin.unwrap();
+    assert_eq!(m.left, 2);
+    assert_eq!(m.right, 2);
+    assert_eq!(m.top, 0);
+    assert_eq!(m.bottom, 0);
+}
+
+#[test]
+fn container_style_my_only() {
+    let s = slt::ContainerStyle::new().my(3);
+    let m = s.margin.unwrap();
+    assert_eq!(m.top, 3);
+    assert_eq!(m.bottom, 3);
+    assert_eq!(m.left, 0);
+    assert_eq!(m.right, 0);
+}
+
+// ── #111: Modifiers::remove ──────────────────────────────────────────
+
+#[test]
+fn modifiers_remove() {
+    let mut m = slt::Modifiers::BOLD | slt::Modifiers::ITALIC | slt::Modifiers::UNDERLINE;
+    m.remove(slt::Modifiers::ITALIC);
+    assert!(m.contains(slt::Modifiers::BOLD));
+    assert!(!m.contains(slt::Modifiers::ITALIC));
+    assert!(m.contains(slt::Modifiers::UNDERLINE));
+}
+
+#[test]
+fn modifiers_remove_none_is_noop() {
+    let mut m = slt::Modifiers::BOLD;
+    m.remove(slt::Modifiers::NONE);
+    assert!(m.contains(slt::Modifiers::BOLD));
+}
+
+#[test]
+fn modifiers_remove_all() {
+    let mut m = slt::Modifiers::BOLD | slt::Modifiers::DIM;
+    m.remove(slt::Modifiers::BOLD | slt::Modifiers::DIM);
+    assert!(m.is_empty());
+}
+
+#[test]
+fn modifiers_remove_unset_is_noop() {
+    let mut m = slt::Modifiers::BOLD;
+    m.remove(slt::Modifiers::ITALIC);
+    assert!(m.contains(slt::Modifiers::BOLD));
+    assert!(!m.contains(slt::Modifiers::ITALIC));
+}
+
+// ── #183: separator() still works after move to widgets_display ──────
+
+#[test]
+fn separator_still_callable_after_move() {
+    let mut tb = TestBackend::new(40, 5);
+    tb.render(|ui| {
+        ui.text("above");
+        ui.separator();
+        ui.text("below");
+    });
+    tb.assert_contains("above");
+    tb.assert_contains("below");
+    tb.assert_contains("─");
+}
+
+#[test]
+fn separator_colored_still_callable_after_move() {
+    let mut tb = TestBackend::new(40, 5);
+    tb.render(|ui| {
+        ui.separator_colored(slt::Color::Red);
+    });
+    tb.assert_contains("─");
+}
+
+// ── #133: use_memo single-downcast cache-hit path ──────────────────────────
+
+#[test]
+fn use_memo_cache_hit_returns_consistent_value() {
+    let mut tb = TestBackend::new(20, 5);
+    tb.render(|ui| {
+        let v1 = *ui.use_memo(&42i32, |x| x * 2);
+        // Different compute closure on a different slot: hook cursor must
+        // advance correctly even when the cache-hit path returns directly
+        // from a single downcast. If the cursor or downcast logic regresses,
+        // these reads will conflict.
+        let v2 = *ui.use_memo(&10i32, |x| x * 3);
+        assert_eq!(v1, 84);
+        assert_eq!(v2, 30);
+    });
+}
+
+#[test]
+fn use_memo_cache_hit_does_not_recompute() {
+    let mut tb = TestBackend::new(20, 5);
+    let calls = std::rc::Rc::new(std::cell::Cell::new(0));
+
+    let c1 = calls.clone();
+    tb.render(|ui| {
+        let v = *ui.use_memo(&7i32, |d| {
+            c1.set(c1.get() + 1);
+            d * 4
+        });
+        assert_eq!(v, 28);
+    });
+
+    let c2 = calls.clone();
+    tb.render(|ui| {
+        // Same deps — must hit cache and return the stored value via the
+        // single-downcast path without invoking `compute`.
+        let v = *ui.use_memo(&7i32, |d| {
+            c2.set(c2.get() + 1);
+            d * 99 // would corrupt result if recomputed
+        });
+        assert_eq!(v, 28);
+    });
+
+    assert_eq!(calls.get(), 1, "compute must run only on first frame");
+}
+
+// ── #135: SmallVec activation-key consume ──────────────────────────────────
+
+#[test]
+fn button_activates_on_enter_through_smallvec_path() {
+    // Exercises the SmallVec-backed activation-key consumer through the
+    // public button widget — Enter on the focused button must trigger a
+    // click response, going through `consume_activation_keys` which now
+    // collects matched events into a `SmallVec<[usize; 8]>` with no heap
+    // allocation in the typical case.
+    let mut tb = TestBackend::new(20, 5);
+    let events = slt::EventBuilder::new()
+        .key_code(slt::KeyCode::Enter)
+        .build();
+    let mut clicked = false;
+    tb.render_with_events(events, 0, 1, |ui| {
+        if ui.button("OK").clicked {
+            clicked = true;
+        }
+    });
+    assert!(
+        clicked,
+        "Enter on focused button must activate via SmallVec path"
+    );
+}
+
+#[test]
+fn button_does_not_activate_without_key_event() {
+    // Empty event list — SmallVec stays empty (`is_empty == true`) and the
+    // early `activated = false` branch fires. Activation must not occur.
+    let mut tb = TestBackend::new(20, 5);
+    let mut clicked = false;
+    tb.render(|ui| {
+        if ui.button("OK").clicked {
+            clicked = true;
+        }
+    });
+    assert!(!clicked, "no key events ⇒ no activation");
+}
+
+// ── #148: deprecated long-form aliases still compile and behave the same ───
+
+#[test]
+#[allow(deprecated)]
+fn deprecated_long_form_aliases_still_function() {
+    let mut tb = TestBackend::new(40, 10);
+    // Old long-forms must still produce identical layouts to the short forms.
+    tb.render(|ui| {
+        ui.container()
+            .p(1)
+            .min_w(10)
+            .max_w(30)
+            .min_h(2)
+            .max_h(8)
+            .col(|ui| {
+                ui.text("legacy api");
+            });
+    });
+    tb.assert_contains("legacy api");
+}
+
+// ── #123: candlestick_hd half-block body precision ─────────────────────────
+
+#[test]
+fn candlestick_hd_uses_half_block_body() {
+    // Tall canvas + a doji (open == close) plus narrow-bodied candles forces
+    // the body to land on a single half-cell, requiring ▀ or ▄ rendering.
+    let mut tb = TestBackend::new(20, 8);
+    let candles = vec![
+        slt::Candle {
+            open: 50.0,
+            high: 100.0,
+            low: 0.0,
+            close: 50.0,
+        },
+        slt::Candle {
+            open: 30.0,
+            high: 100.0,
+            low: 0.0,
+            close: 70.0,
+        },
+        slt::Candle {
+            open: 35.0,
+            high: 100.0,
+            low: 0.0,
+            close: 65.0,
+        },
+    ];
+    tb.render(|ui| {
+        ui.candlestick_hd(
+            &candles,
+            slt::Color::Rgb(38, 166, 91),
+            slt::Color::Rgb(234, 57, 67),
+        );
+    });
+    let output = tb.to_string();
+    assert!(
+        output.contains('▀') || output.contains('▄'),
+        "candlestick_hd should render at least one half-block (▀ or ▄) for sub-cell body edges; output:\n{output}"
+    );
+    assert!(
+        output.contains('┃'),
+        "candlestick_hd should still draw heavy wick ┃; output:\n{output}"
+    );
+}
+
+#[test]
+fn candlestick_hd_full_block_when_body_spans_full_cells() {
+    // A wide-bodied candle (open near low, close near high) covers many full
+    // cells, so at least one █ must appear.
+    let mut tb = TestBackend::new(12, 10);
+    let candles = vec![slt::Candle {
+        open: 10.0,
+        high: 100.0,
+        low: 0.0,
+        close: 90.0,
+    }];
+    tb.render(|ui| {
+        ui.candlestick_hd(&candles, slt::Color::Green, slt::Color::Red);
+    });
+    let output = tb.to_string();
+    assert!(
+        output.contains('█'),
+        "wide-bodied candle should still include full █ blocks; output:\n{output}"
+    );
+}
+
+// ── #121: treemap sort uses total_cmp; tolerates NaN ───────────────────────
+
+#[test]
+fn treemap_total_cmp_handles_nan_without_panic() {
+    let mut tb = TestBackend::new(30, 10);
+    tb.render(|ui| {
+        let _ = ui.treemap(&[
+            slt::TreemapItem::new("A", 50.0, slt::Color::Red),
+            slt::TreemapItem::new("B", f64::NAN, slt::Color::Blue),
+            slt::TreemapItem::new("C", 30.0, slt::Color::Green),
+        ]);
+    });
+    // Survives NaN input without panic; total_cmp gives a deterministic order.
+}
+
+// ── #115: squarify_recursive incremental ratio path (no Vec::clone) ────────
+
+#[test]
+fn treemap_many_items_renders_without_panic() {
+    // Stress the squarify inner loop with 100+ items — exercises the
+    // incremental sum/max/min tracking that replaces the per-iteration
+    // candidate Vec::clone.
+    let mut tb = TestBackend::new(80, 30);
+    let items: Vec<slt::TreemapItem> = (0..120)
+        .map(|i| {
+            let value = ((i % 17) + 1) as f64 * 1.5;
+            slt::TreemapItem::new(format!("item-{i}"), value, slt::Color::Cyan)
+        })
+        .collect();
+    tb.render(|ui| {
+        let _ = ui.treemap(&items);
+    });
+    let output = tb.to_string();
+    assert!(
+        !output.is_empty(),
+        "treemap with 120 items should render some cells"
+    );
+}
+
+// ── v0.19.2 fix wave: regressions for #99, #101, #117, #122, #191 ────────────
+
+#[test]
+fn rich_log_bounded_default() {
+    // a-191: RichLogState::new() must default to Some(DEFAULT_MAX_ENTRIES) so
+    // long-running apps cannot accumulate state without bound.
+    let mut state = RichLogState::new();
+    assert!(
+        state.max_entries.is_some(),
+        "new() must apply default cap, got max_entries=None"
+    );
+    for i in 0..(RichLogState::DEFAULT_MAX_ENTRIES + 10) {
+        state.push_plain(format!("line {i}"));
+    }
+    assert!(
+        state.entries.len() <= RichLogState::DEFAULT_MAX_ENTRIES,
+        "entries.len() = {}, should be <= {}",
+        state.entries.len(),
+        RichLogState::DEFAULT_MAX_ENTRIES
+    );
+}
+
+#[test]
+fn rich_log_unbounded_new() {
+    // a-191: explicit opt-in via new_unbounded() must skip the trim guard.
+    let state = RichLogState::new_unbounded();
+    assert!(state.max_entries.is_none());
+}
+
+#[test]
+fn spinner_state_frame_is_stable_across_clones() {
+    // a-099: SpinnerState now stores frames as &'static [char], so cloning is
+    // cheap and the frame sequence must be byte-identical to the heap-Vec
+    // implementation.
+    let s = slt::SpinnerState::dots();
+    let s2 = s.clone();
+    for tick in 0..32u64 {
+        assert_eq!(
+            s.frame(tick),
+            s2.frame(tick),
+            "clone must yield identical frame at tick {tick}"
+        );
+    }
+    let dots: Vec<char> = (0..10).map(|t| s.frame(t)).collect();
+    assert_eq!(dots, vec!['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']);
+    assert_eq!(s.frame(10), '⠋', "tick 10 wraps back to first frame");
+
+    let line = slt::SpinnerState::line();
+    let line_seq: Vec<char> = (0..4).map(|t| line.frame(t)).collect();
+    assert_eq!(line_seq, vec!['|', '/', '-', '\\']);
+    assert_eq!(line.frame(4), '|');
+}
+
+#[test]
+fn command_palette_render_uses_filter_cache() {
+    // a-101: command_palette() previously called fuzzy_score twice per frame.
+    // Now it routes through filtered_indices_cached(), but the rendered output
+    // must remain unchanged.
+    let cmds = vec![
+        slt::PaletteCommand::new("open file", ""),
+        slt::PaletteCommand::new("save file", ""),
+        slt::PaletteCommand::new("quit", ""),
+    ];
+    let mut state = CommandPaletteState::new(cmds);
+    state.toggle();
+    state.input.push_str("file");
+
+    let mut tb = TestBackend::new(80, 24);
+    tb.render(|ui| {
+        ui.command_palette(&mut state);
+    });
+    let out = tb.to_string();
+    assert!(out.contains("open file"), "expected 'open file' in:\n{out}");
+    assert!(out.contains("save file"), "expected 'save file' in:\n{out}");
+}
+
+#[test]
+fn chart_flat_buffer_renders_line() {
+    // a-117: chart's plot_chars/plot_styles are now flat Vec<T> instead of
+    // Vec<Vec<T>>. Verify a line chart renders without panics and produces
+    // non-empty output.
+    let mut tb = TestBackend::new(80, 24);
+    tb.render(|ui| {
+        ui.chart(
+            |c| {
+                c.line(&[(0.0, 0.0), (1.0, 1.0), (2.0, 2.0), (3.0, 1.5)])
+                    .label("S1")
+                    .color(slt::Color::Cyan);
+            },
+            70,
+            20,
+        );
+    });
+    let out = tb.to_string();
+    assert!(!out.trim().is_empty(), "chart output must not be blank");
+    assert!(out.contains("S1"), "legend label must render");
+}
+
+#[test]
+fn chart_bar_dataset_renders_with_flat_buffer() {
+    // a-117: bar dataset path through draw_bar_dataset on flat buffer.
+    let mut tb = TestBackend::new(80, 24);
+    tb.render(|ui| {
+        ui.chart(
+            |c| {
+                c.bar(&[(0.0, 1.0), (1.0, 2.0), (2.0, 3.0)])
+                    .label("B")
+                    .color(slt::Color::Cyan);
+            },
+            70,
+            20,
+        );
+    });
+    let out = tb.to_string();
+    assert!(out.contains('█'), "bar chart should render block glyph");
+}
+
+#[test]
+fn sixel_image_renders_with_stack_register_array() {
+    // a-122: row_registers() now uses [bool; 216] on the stack. Verify the
+    // sixel encode path still produces output for a small multi-color image.
+    let mut rgba = Vec::with_capacity(4 * 6 * 4);
+    let cols = [
+        [255u8, 0, 0, 255],
+        [0, 255, 0, 255],
+        [0, 0, 255, 255],
+        [128, 128, 128, 255],
+    ];
+    for _ in 0..6 {
+        for c in &cols {
+            rgba.extend_from_slice(c);
+        }
+    }
+    let mut tb = TestBackend::new(20, 8);
+    tb.render(|ui| {
+        let _ = ui.sixel_image(&rgba, 4, 6, 20, 4);
+    });
+    // Smoke: rendering must not panic with the stack-array implementation.
+}
+
+// ===== v0.19.2 — issue #103 / #176 regression tests =====
+
+#[test]
+fn textarea_kill_line_truncates_to_cursor() {
+    // Issue #103: Ctrl+K from middle of line truncates to cursor.
+    let mut tb = TestBackend::new(40, 10);
+    let mut state = TextareaState::new();
+    state.set_value("hello world");
+    state.cursor_row = 0;
+    state.cursor_col = 5;
+    let events = slt::EventBuilder::new()
+        .key_with(KeyCode::Char('k'), KeyModifiers::CONTROL)
+        .build();
+    tb.render_with_events(events, 0, 1, |ui| {
+        ui.textarea(&mut state, 5);
+    });
+    assert_eq!(state.lines, vec!["hello".to_string()]);
+    assert_eq!(state.cursor_col, 5);
+}
+
+#[test]
+fn textarea_kill_line_preserves_following_lines() {
+    // Issue #103: Ctrl+K does NOT remove the line break — only truncates
+    // the current line at the cursor column.
+    let mut tb = TestBackend::new(40, 10);
+    let mut state = TextareaState::new();
+    state.set_value("foo bar\nnext");
+    state.cursor_row = 0;
+    state.cursor_col = 3;
+    let events = slt::EventBuilder::new()
+        .key_with(KeyCode::Char('k'), KeyModifiers::CONTROL)
+        .build();
+    tb.render_with_events(events, 0, 1, |ui| {
+        ui.textarea(&mut state, 5);
+    });
+    assert_eq!(state.lines, vec!["foo".to_string(), "next".to_string()]);
+}
+
+#[test]
+fn textarea_word_jump_forward() {
+    // Issue #103: Ctrl+Right from cursor=0 on "foo bar baz" must jump
+    // past the end of the next word ("foo") to char 3.
+    let mut tb = TestBackend::new(40, 10);
+    let mut state = TextareaState::new();
+    state.set_value("foo bar baz");
+    state.cursor_row = 0;
+    state.cursor_col = 0;
+    let events = slt::EventBuilder::new()
+        .key_with(KeyCode::Right, KeyModifiers::CONTROL)
+        .build();
+    tb.render_with_events(events, 0, 1, |ui| {
+        ui.textarea(&mut state, 5);
+    });
+    assert_eq!(state.cursor_col, 3);
+}
+
+#[test]
+fn textarea_word_jump_backward() {
+    // Issue #103: Ctrl+Left from cursor=7 on "foo bar baz" must jump back
+    // to the start of "bar" at char 4.
+    let mut tb = TestBackend::new(40, 10);
+    let mut state = TextareaState::new();
+    state.set_value("foo bar baz");
+    state.cursor_row = 0;
+    state.cursor_col = 7;
+    let events = slt::EventBuilder::new()
+        .key_with(KeyCode::Left, KeyModifiers::CONTROL)
+        .build();
+    tb.render_with_events(events, 0, 1, |ui| {
+        ui.textarea(&mut state, 5);
+    });
+    assert_eq!(state.cursor_col, 4);
+}
+
+#[test]
+fn textarea_word_jump_alt_modifier() {
+    // Issue #103: Alt+Left/Right are equivalent to Ctrl+Left/Right
+    // (matches macOS readline conventions).
+    let mut tb = TestBackend::new(40, 10);
+    let mut state = TextareaState::new();
+    state.set_value("alpha beta gamma");
+    state.cursor_row = 0;
+    state.cursor_col = 0;
+    let events = slt::EventBuilder::new()
+        .key_with(KeyCode::Right, KeyModifiers::ALT)
+        .build();
+    tb.render_with_events(events, 0, 1, |ui| {
+        ui.textarea(&mut state, 5);
+    });
+    assert_eq!(state.cursor_col, 5);
+}
+
+#[test]
+fn markdown_byte_index_handles_cjk_bold() {
+    // Issue #176: byte-index scan of `**굵은**` must NOT split the
+    // multi-byte Korean characters (each is 3 bytes in UTF-8).
+    let mut tb = TestBackend::new(40, 5);
+    tb.render(|ui| {
+        ui.markdown("**굵은**");
+    });
+    tb.assert_contains("굵은");
+}
+
+#[test]
+fn markdown_byte_index_handles_interleaved_cjk_markers() {
+    // Issue #176: arbitrary order of bold/italic/code with multi-byte text.
+    let mut tb = TestBackend::new(80, 5);
+    tb.render(|ui| {
+        ui.markdown("**굵은** `코드` *이탤릭*");
+    });
+    let out = tb.to_string_trimmed();
+    assert!(out.contains("굵은"), "bold CJK segment lost: {out:?}");
+    assert!(out.contains("코드"), "code CJK segment lost: {out:?}");
+    assert!(out.contains("이탤릭"), "italic CJK segment lost: {out:?}");
+    // The marker characters themselves must be stripped.
+    assert!(!out.contains("**"), "** marker must be stripped: {out:?}");
+    assert!(!out.contains('`'), "code marker must be stripped: {out:?}");
+}
+
+#[test]
+fn markdown_byte_index_unclosed_marker_falls_through() {
+    // Issue #176: unclosed `**` must render as plain text, not panic.
+    let mut tb = TestBackend::new(40, 5);
+    tb.render(|ui| {
+        ui.markdown("**unclosed");
+    });
+    // The literal `**unclosed` must appear since the marker never closes.
+    tb.assert_contains("**unclosed");
+}
+
+#[test]
+fn markdown_byte_index_empty_bold_marker() {
+    // Issue #176: `****` is a valid empty bold span — must not produce
+    // garbage or panic on byte indices.
+    let mut tb = TestBackend::new(40, 5);
+    tb.render(|ui| {
+        ui.markdown("a****b");
+    });
+    tb.assert_contains("ab");
 }


### PR DESCRIPTION
## Summary

Patch release covering **34 v0.19.x patch-safe issues** plus **two long-standing visual regressions** caught during demo validation.

### Visual regressions fixed

- **Border title overdraws horizontal bar with spaces** — regression introduced in v0.19.1 (#160). ASCII titles like `cargo-slt` lost the surrounding `──` and rendered as `╭─cargo-slt           ╮`. Now back to `╭─cargo-slt──────╮`. CJK truncation correctness (the original purpose of #160) preserved.
- **`text_input()` claims all available vertical space in its parent column** — regression dating to v0.17. `.grow(1)` was always applied to the bordered container, so a single-line input inside `bordered("Packages").p(1).grow(1).col(...)` would expand and push siblings off-screen. Removed the implicit grow.

### Highlights (34 issues)

**Perf**: chart 2D→flat (#117), squarify alloc-free (#115), candlestick half-cell (#123), use_memo single downcast (#133), SmallVec activation keys (#135), parse_inline_segments byte-scan (#176), CommandPalette filter cache (#101), recompute_widths dirty-flag (#195), streaming_text borrow not clone (#178), scrollbar static glyphs (#179), code_block_numbered ilog10 (#180), definition_list manual padding (#181), trim_end allocation (#173), grid_elements extract (#194), table_visible_len local binding (#140), SpinnerState static frames (#99), blend_color extracted (#119), treemap total_cmp (#121).

**Bug**: sixel false-positive on `xterm-256color` (#116), sixel row_registers stack (#122), separator overflow (#177), RichLogState bounded default (#191), tabs underflow (#196).

**Feat**: ContainerStyle mx/my (#108), Modifiers::remove (#111), Theme::builder_from + light_builder + const fn (#109/#110), breadcrumb_response (#182), textarea kill-line + word-jump (#103).

**Refactor / Docs / Tests**: separator move to display facade (#183), Buffer::diff alloc note (#170), Align::Start CSS-stretch doc (#165), Cell size compile-time assert (#167), candlestick_hd doc (#120).

### New demo

`examples/demo_cjk.rs` — interactive CJK demo with:
- Korean/Chinese/Japanese title clamp + body wrap
- 4 narrow-clamp title cards (`설정창`, `管理设置`, `設定パネル`, `Mixed 한中日 abc`) — hover brightens border, click increments per-card counter
- Live mouse coords + last-clicked card label in status bar
- "초기화 / Reset" + "포커스 / Focus next" buttons
- Two CJK-placeholder text inputs

Pins both regressions above and serves as a manual visual gate for future title-clamp / wrap changes.

### Deferred to v0.19.3

- **#102** textarea undo/redo — patch-safe constraint (`TextareaState` had all-`pub` fields in v0.19.1; new private fields break struct-literal construction). Same constraint as v0.19.1's #94 deferral. Will re-architect under `use_state_named` in v0.19.3 or land in v0.20.0.
- **#171** line-hash flush skip — issue body's own bench gate (`< 50µs → NO-GO`) was not met; a regression test caught a row-skip case where the dirty-flag interaction lost a changed row.
- **#150 / #152 / #153 / #155 / #157 / #162** layout perf — reverted while triaging the title-clamp regression. Will re-apply on top of the title fix in v0.19.3.
- **#146 / #147 / #148** container — same triage cycle.

### Stats

- 48 files changed, 2,343 insertions(+), 519 deletions(-)
- 808 tests passing (0 fail, 16 ignored, 91 doc)
- 0 breaking changes (`cargo semver-checks` clean)

### Closes (verified by source diff)

closes #99 closes #101 closes #103 closes #108 closes #109 closes #110 closes #111 closes #115 closes #116 closes #117 closes #118 closes #119 closes #120 closes #121 closes #122 closes #123 closes #125 closes #132 closes #133 closes #135 closes #136 closes #138 closes #140 closes #165 closes #167 closes #170 closes #173 closes #176 closes #177 closes #178 closes #179 closes #180 closes #181 closes #182 closes #183 closes #191 closes #194 closes #195 closes #196

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo check --all-features`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --all-features` (808 passed)
- [x] `cargo check --examples --all-features`
- [x] `cargo check -p superlighttui --no-default-features`
- [x] `cargo check -p slt-wasm --target wasm32-unknown-unknown`
- [x] `typos`
- [x] `cargo hack check --each-feature --no-dev-deps` (26/26)
- [x] `cargo audit` (1 dev-only allowed warning, identical to v0.19.1)
- [x] `cargo deny check`
- [x] `cargo semver-checks check-release --baseline-rev v0.19.1` — 196 pass, 0 fail
- [x] Manual: `demo`, `demo_dashboard`, `demo_cli`, `demo_infoviz`, `cookbook_login`, `cookbook_table`, `demo_cjk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)