### PR TITLE
chore: Update PATTERNS.md: change screens.push + pop to be used via Context

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -448,13 +448,13 @@ Use manual `push()` / `pop()` logic on `ScreenState` when you need explicit navi
 ```rust
 ui.screen("home", &mut screens, |ui| {
     if ui.button("Settings").clicked {
-        screens.push("settings");
+        ui.push_screen("settings");
     }
 });
 
 ui.screen("settings", &mut screens, |ui| {
     if ui.button("Back").clicked {
-        screens.pop();
+        ui.pop_screen();
     }
 });
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -440,8 +440,8 @@ ui.screen("settings", &mut screens, |ui| {
 });
 ```
 
-Use `screen(name, &mut screens, ...)` when you want declarative rendering that only runs for the active screen. Each screen gets isolated hook state and focus.
-Use manual `push()` / `pop()` logic on `ScreenState` when you need explicit navigation transitions.
+Use `screen(name, &mut screens, ...)` when you want declarative rendering that only runs for the active screen. Each screen gets isolated hook state and focus. Navigate from **inside** a `screen(...)` closure with `push_screen(name)`,
+`pop_screen()`, or `reset_screen()` when you need explicit navigation transitions.
 
 ## Modal, overlay, and screen composition
 


### PR DESCRIPTION
## What

Complement the changes that fixed issue: https://github.com/subinium/SuperLightTUI/issues/279

Updating PATTERNS.md doc to make use of the `ui.push_screen()` + `ui.pop_screen()` in the example where `ui.screen()` is being used as well.

## Why

To make sure the sample code shown in the docs compile without errors.

## Checklist

### Required

- [ ] `cargo fmt -- --check` passes
- [ ] `cargo check --all-features` passes
- [ ] `cargo clippy --all-features -- -D warnings` passes
- [ ] `cargo test --all-features` passes
- [ ] `cargo check --examples --all-features` passes

### Public API Changes

- [ ] New public items have doc comments (`///`)
- [ ] Widget follows the [Response pattern](DESIGN_PRINCIPLES.md#3-widget-contract)
- [ ] State struct in `widgets.rs`, impl on `Context`, re-export in `lib.rs`
- [ ] Breaking change? Update CHANGELOG.md and note it here

### If Adding a Widget

- [ ] Calls `register_focusable()` if interactive
- [ ] Consumes handled key events
- [ ] Uses `self.theme.*` for default colors
- [ ] Example added or existing example updated

### If Applicable

- [ ] Tests added
- [ ] Animation uses build-time pre-sort (not per-frame)
- [ ] No `unwrap()` in Result-returning functions
