### PR TITLE
fix: update crossbeam-epoch for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

- update the locked crossbeam-epoch version from 0.9.18 to 0.9.20
- resolve RUSTSEC-2026-0204 in the criterion and rayon development dependency path
- keep the change limited to Cargo.lock

## Verification

- cargo fmt -- --check
- cargo check --all-features
- cargo clippy --all-features -- -D warnings
- cargo test --all-features
- cargo check --examples --all-features
- typos
- cargo check -p superlighttui --no-default-features
- cargo check -p slt-wasm --all-features --target wasm32-unknown-unknown
- cargo hack check -p superlighttui --each-feature --no-dev-deps
- cargo audit
- cargo deny check