### PR TITLE
fix: isolate screen navigation transitions

### DIFF
--- a/docs/COMPLETE_REFERENCE.md
+++ b/docs/COMPLETE_REFERENCE.md
@@ -282,7 +282,7 @@ Legend: `Response = { clicked, hovered, changed, focused, rect }`. `&mut Self` m
 | `ui.tooltip(text)` | `()` | Shown near cursor on hover. |
 | `ui.group(name)` | `ContainerBuilder` | Named group for shared hover/focus styling. |
 | `ui.screen(name, &mut screens, |ui|{...})` | `()` | Render only when `screens.current() == name`. Isolates hook state and focus per screen. |
-| `ui.push_screen(name)` / `ui.pop_screen()` / `ui.reset_screen()` | `()` | Navigate from **inside** a `screen(...)` closure. Deferred and applied when the closure returns (issue #279). |
+| `ui.push_screen(name)` / `ui.pop_screen()` / `ui.reset_screen()` | `()` | Navigate from **inside** a `screen(...)` closure. State updates when the closure returns; the destination renders next frame (issue #279). |
 | `ui.form(&mut form_state, |ui|{...})` | `&mut Self` | Form container. |
 | `ui.form_field(&mut field)` | `&mut Self` | One field (label + input + error). |
 | `ui.form_submit(label)` | `Response` | Submit button. |
@@ -523,6 +523,10 @@ that is applied to your `ScreenState` the moment the closure returns — calling
 `screen(...)` already holds a `&mut ScreenState` borrow for the duration of the
 closure (issue #279). Outside any `screen(...)` closure you can still mutate the
 `ScreenState` directly (`screens.push("x")`, `screens.pop()`).
+
+The transition frame finishes rendering only the source screen. The destination
+starts on the next frame, preventing both views from being composed into one
+terminal buffer.
 
 ### 6.6 Multi-mode app
 ```rust

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -440,8 +440,8 @@ ui.screen("settings", &mut screens, |ui| {
 });
 ```
 
-Use `screen(name, &mut screens, ...)` when you want declarative rendering that only runs for the active screen. Each screen gets isolated hook state and focus. Navigate from **inside** a `screen(...)` closure with `push_screen(name)`,
-`pop_screen()`, or `reset_screen()` when you need explicit navigation transitions.
+Use `screen(name, &mut screens, ...)` when you want declarative rendering that only runs for the active screen. Each screen gets isolated hook state and focus. Navigate from **inside** a `screen(...)` closure with `ui.push_screen(name)`,
+`ui.pop_screen()`, or `ui.reset_screen()` when you need explicit navigation transitions. The state changes when the active closure returns, but the destination renders on the next frame so source and destination content never share one terminal buffer.
 
 ## Modal, overlay, and screen composition
 

--- a/src/context/core.rs
+++ b/src/context/core.rs
@@ -96,6 +96,16 @@ pub struct Context {
     /// closure returns. Deferring the mutation here lets app code navigate from
     /// within the closure without a double mutable borrow of its `ScreenState`.
     pub(crate) pending_screen_nav: Vec<ScreenNav>,
+    /// Number of currently active `screen` closures. Each `screen` keeps its
+    /// own pending-navigation start index on the call stack; this depth lets
+    /// navigation helpers reject calls made outside any screen without a
+    /// per-frame heap allocation.
+    pub(crate) screen_nav_depth: usize,
+    /// Original active screen for each `ScreenState` that navigated this frame.
+    /// Later `screen` declarations keep rendering this origin until the next
+    /// frame, preventing source and destination screens from being composed in
+    /// the same terminal buffer. Keys are per-frame `ScreenState` addresses.
+    pub(crate) screen_nav_render_origins: std::collections::HashMap<usize, String>,
     pub(crate) hovered_groups: std::collections::HashSet<std::sync::Arc<str>>,
     /// Issue #273: version keys recorded by [`Context::cached`] regions on the
     /// PREVIOUS frame, moved in from `FrameState::region_versions`. Indexed by
@@ -219,6 +229,8 @@ pub(super) struct ContextCheckpoint {
     /// panicking subtree inside an `error_boundary`, so a rolled-back screen
     /// closure does not leave a phantom push/pop queued for its `ScreenState`.
     pending_screen_nav_len: usize,
+    /// Drop navigation scopes opened by a panicking nested `screen` call.
+    screen_nav_depth: usize,
     /// Issue #273: `cached` region keys recorded so far, so a panicking
     /// `cached` region inside an `error_boundary` rolls back its key entry
     /// (and any nested ones) — keeping the recorded keys consistent with the
@@ -236,6 +248,7 @@ impl ContextCheckpoint {
             context_stack_len: ctx.context_stack.len(),
             pending_tooltips_len: ctx.pending_tooltips.len(),
             pending_screen_nav_len: ctx.pending_screen_nav.len(),
+            screen_nav_depth: ctx.screen_nav_depth,
             region_versions_cur_len: ctx.region_versions_cur.len(),
             rollback: ctx.rollback.clone(),
         }
@@ -253,6 +266,7 @@ impl ContextCheckpoint {
         // Issue #279: drop screen-navigation requests queued by the panicking
         // subtree but keep any recorded before the error boundary was entered.
         ctx.pending_screen_nav.truncate(self.pending_screen_nav_len);
+        ctx.screen_nav_depth = self.screen_nav_depth;
         // Issue #273: drop `cached` keys recorded by the panicking subtree.
         ctx.region_versions_cur
             .truncate(self.region_versions_cur_len);

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -227,6 +227,8 @@ impl Context {
             },
             pending_tooltips,
             pending_screen_nav: Vec::new(),
+            screen_nav_depth: 0,
+            screen_nav_render_origins: std::collections::HashMap::new(),
             hovered_groups,
             region_versions_prev,
             region_versions_cur,

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -21,6 +21,8 @@ struct SnapshotShape {
     deferred_draws_len: usize,
     notification_queue_len: usize,
     pending_tooltips_len: usize,
+    pending_screen_nav_len: usize,
+    screen_nav_scope_depth: usize,
     text_color_stack_len: usize,
 }
 
@@ -43,6 +45,8 @@ fn snapshot_shape(ctx: &Context) -> SnapshotShape {
         deferred_draws_len: ctx.deferred_draws.len(),
         notification_queue_len: ctx.rollback.notification_queue.len(),
         pending_tooltips_len: ctx.pending_tooltips.len(),
+        pending_screen_nav_len: ctx.pending_screen_nav.len(),
+        screen_nav_scope_depth: ctx.screen_nav_depth,
         text_color_stack_len: ctx.rollback.text_color_stack.len(),
     }
 }
@@ -288,6 +292,8 @@ fn error_boundary_restores_snapshot_state_after_panic() {
                 anchor_rect: crate::rect::Rect::new(1, 1, 1, 1),
                 lines: vec!["drop".into()],
             });
+            ui.pending_screen_nav.push(ScreenNav::Pop);
+            ui.screen_nav_depth += 1;
             ui.rollback.text_color_stack.push(Some(Color::Red));
             panic!("boom");
         },
@@ -431,7 +437,7 @@ fn screen_helper_renders_only_current_screen() {
 // === Issue #279: navigate from inside a `ui.screen` closure ===
 
 #[test]
-fn push_screen_inside_closure_navigates() {
+fn push_screen_inside_closure_navigates_without_blending_frames() {
     let mut backend = TestBackend::new(24, 3);
     let mut screens = ScreenState::new("home");
 
@@ -439,6 +445,7 @@ fn push_screen_inside_closure_navigates() {
     // closure returns — so it does not double-borrow `screens` (issue #279).
     backend.render(|ui| {
         ui.screen("home", &mut screens, |ui| {
+            ui.text("Home Screen");
             ui.push_screen("settings");
         });
         ui.screen("settings", &mut screens, |ui| {
@@ -447,24 +454,83 @@ fn push_screen_inside_closure_navigates() {
     });
 
     assert_eq!(screens.current(), "settings");
-    // The push is applied mid-frame, so the settings screen renders the same
-    // frame the navigation happened.
-    assert!(backend.to_string().contains("Settings Screen"));
+    let transition = backend.to_string();
+    assert!(transition.contains("Home Screen"));
+    assert!(!transition.contains("Settings Screen"));
+
+    backend.render(|ui| {
+        ui.screen("home", &mut screens, |ui| {
+            ui.text("Home Screen");
+        });
+        ui.screen("settings", &mut screens, |ui| {
+            ui.text("Settings Screen");
+        });
+    });
+    let settled = backend.to_string();
+    assert!(!settled.contains("Home Screen"));
+    assert!(settled.contains("Settings Screen"));
 }
 
 #[test]
-fn pop_screen_inside_closure_navigates() {
+fn pop_screen_inside_closure_navigates_without_blank_frame() {
     let mut backend = TestBackend::new(24, 3);
     let mut screens = ScreenState::new("home");
     screens.push("settings");
 
     backend.render(|ui| {
+        ui.screen("home", &mut screens, |ui| {
+            ui.text("Home Screen");
+        });
         ui.screen("settings", &mut screens, |ui| {
+            ui.text("Settings Screen");
             ui.pop_screen();
         });
     });
 
     assert_eq!(screens.current(), "home");
+    let transition = backend.to_string();
+    assert!(!transition.contains("Home Screen"));
+    assert!(transition.contains("Settings Screen"));
+
+    backend.render(|ui| {
+        ui.screen("home", &mut screens, |ui| {
+            ui.text("Home Screen");
+        });
+        ui.screen("settings", &mut screens, |ui| {
+            ui.text("Settings Screen");
+        });
+    });
+    let settled = backend.to_string();
+    assert!(settled.contains("Home Screen"));
+    assert!(!settled.contains("Settings Screen"));
+}
+
+#[test]
+fn nested_screen_navigation_stays_in_its_own_scope() {
+    let mut backend = TestBackend::new(24, 3);
+    let mut outer = ScreenState::new("outer-home");
+    let mut inner = ScreenState::new("inner-home");
+
+    backend.render(|ui| {
+        ui.screen("outer-home", &mut outer, |ui| {
+            ui.push_screen("outer-settings");
+            ui.screen("inner-home", &mut inner, |ui| {
+                ui.push_screen("inner-details");
+            });
+        });
+    });
+
+    assert_eq!(outer.current(), "outer-settings");
+    assert_eq!(outer.depth(), 2);
+    assert_eq!(inner.current(), "inner-details");
+    assert_eq!(inner.depth(), 2);
+}
+
+#[test]
+#[should_panic(expected = "screen navigation helpers can only be called inside")]
+fn screen_navigation_outside_screen_panics_with_guidance() {
+    let mut backend = TestBackend::new(24, 3);
+    backend.render(|ui| ui.push_screen("settings"));
 }
 
 #[test]

--- a/src/context/widgets_display/layout.rs
+++ b/src/context/widgets_display/layout.rs
@@ -230,6 +230,10 @@ impl Context {
     /// even when you switch between screens across frames.
     ///
     /// Focus state is saved and restored per screen automatically.
+    /// Navigation requested inside a screen mutates `ScreenState` when that
+    /// closure returns, while the frame finishes rendering the screen that was
+    /// active at its start. The destination renders on the next frame, so
+    /// source and destination content are never composed together.
     ///
     /// # Example
     ///
@@ -256,7 +260,11 @@ impl Context {
             v
         };
 
-        let is_active = screens.current() == name;
+        let screen_key = screens as *mut ScreenState as usize;
+        let is_active = self
+            .screen_nav_render_origins
+            .get(&screen_key)
+            .map_or_else(|| screens.current() == name, |origin| origin == name);
 
         if is_active {
             // Save outer focus, restore this screen's focus
@@ -268,8 +276,18 @@ impl Context {
             self.rollback.hook_cursor = seg_start;
             let focus_count_before = self.rollback.focus_count;
 
+            // Scope deferred navigation to this exact screen closure. Nested
+            // screens get their own range and cannot drain an outer request.
+            let nav_scope_start = self.pending_screen_nav.len();
+            self.screen_nav_depth += 1;
+
             // Execute the screen's closure
             f(self);
+
+            self.screen_nav_depth = self
+                .screen_nav_depth
+                .checked_sub(1)
+                .expect("active screen must own a navigation scope");
 
             // Record the hook count for this screen.
             //
@@ -297,9 +315,15 @@ impl Context {
             // hold `&mut screens` here, so there is no double mutable borrow —
             // app code can call `ui.push_screen(...)` / `ui.pop_screen()` from
             // within the closure without the borrow conflict from the issue.
-            if !self.pending_screen_nav.is_empty() {
-                let navs = std::mem::take(&mut self.pending_screen_nav);
-                for nav in navs {
+            if self.pending_screen_nav.len() > nav_scope_start {
+                // Preserve the screen that rendered at the start of this
+                // transition. ScreenState changes immediately, but later
+                // declarations wait until the next frame to render the new
+                // destination, avoiding a one-frame source/destination blend.
+                self.screen_nav_render_origins
+                    .entry(screen_key)
+                    .or_insert_with(|| screens.current().to_owned());
+                for nav in self.pending_screen_nav.drain(nav_scope_start..) {
                     screens.apply_nav(nav);
                 }
             }
@@ -316,7 +340,9 @@ impl Context {
     /// Call this from inside a [`Context::screen`] closure to navigate forward.
     /// The push is deferred and applied to your `ScreenState` the moment the
     /// closure returns, so it does not conflict with the `&mut ScreenState`
-    /// already borrowed by `screen(...)` (issue #279).
+    /// already borrowed by `screen(...)` (issue #279). Rendering stays on the
+    /// source screen for that transition frame; the destination appears on the
+    /// next frame.
     ///
     /// # Example
     ///
@@ -330,7 +356,14 @@ impl Context {
     /// });
     /// # });
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics when called outside an active [`Context::screen`] closure. Use
+    /// [`ScreenState::push`] directly when navigating outside a screen.
+    #[track_caller]
     pub fn push_screen(&mut self, name: impl Into<String>) {
+        self.assert_screen_nav_scope();
         self.pending_screen_nav.push(ScreenNav::Push(name.into()));
     }
 
@@ -339,7 +372,14 @@ impl Context {
     ///
     /// Like [`Self::push_screen`], the pop is deferred and applied when the
     /// enclosing [`Context::screen`] closure returns (issue #279).
+    ///
+    /// # Panics
+    ///
+    /// Panics when called outside an active [`Context::screen`] closure. Use
+    /// [`ScreenState::pop`] directly when navigating outside a screen.
+    #[track_caller]
     pub fn pop_screen(&mut self) {
+        self.assert_screen_nav_scope();
         self.pending_screen_nav.push(ScreenNav::Pop);
     }
 
@@ -348,8 +388,23 @@ impl Context {
     ///
     /// Deferred and applied when the enclosing [`Context::screen`] closure
     /// returns (issue #279).
+    ///
+    /// # Panics
+    ///
+    /// Panics when called outside an active [`Context::screen`] closure. Use
+    /// [`ScreenState::reset`] directly when navigating outside a screen.
+    #[track_caller]
     pub fn reset_screen(&mut self) {
+        self.assert_screen_nav_scope();
         self.pending_screen_nav.push(ScreenNav::Reset);
+    }
+
+    #[track_caller]
+    fn assert_screen_nav_scope(&self) {
+        assert!(
+            self.screen_nav_depth > 0,
+            "screen navigation helpers can only be called inside an active Context::screen closure; mutate ScreenState directly outside a screen"
+        );
     }
 
     /// Remove retained hook/focus state for an inactive screen.

--- a/tests/pty_ansi.rs
+++ b/tests/pty_ansi.rs
@@ -13,7 +13,7 @@
 //! Gated behind the dev-only `pty-test` feature: `cargo test --features pty-test`.
 #![cfg(feature = "pty-test")]
 
-use slt::{Color, ColorDepth, PtyBackend};
+use slt::{Color, ColorDepth, PtyBackend, ScreenState};
 use std::sync::Mutex;
 
 static ENV_GUARD: Mutex<()> = Mutex::new(());
@@ -218,6 +218,40 @@ fn frames_raw_accumulates_each_render() {
         ui.text("b");
     });
     assert_eq!(pb.frames_raw().count(), 2);
+}
+
+/// Screen navigation changes state immediately without flushing source and
+/// destination views into the same terminal frame.
+#[test]
+fn screen_navigation_emits_one_view_per_frame() {
+    let mut pb = PtyBackend::new(24, 2);
+    let mut screens = ScreenState::new("home");
+
+    pb.render(|ui| {
+        ui.screen("home", &mut screens, |ui| {
+            ui.text("Home Screen");
+            ui.push_screen("settings");
+        });
+        ui.screen("settings", &mut screens, |ui| {
+            ui.text("Settings Screen");
+        });
+    });
+
+    assert_eq!(screens.current(), "settings");
+    pb.assert_emits("Home Screen");
+    pb.assert_not_emits("Settings Screen");
+
+    pb.render(|ui| {
+        ui.screen("home", &mut screens, |ui| {
+            ui.text("Home Screen");
+        });
+        ui.screen("settings", &mut screens, |ui| {
+            ui.text("Settings Screen");
+        });
+    });
+
+    pb.assert_emits("Settings Screen");
+    pb.assert_not_emits("Home Screen");
 }
 
 /// `assert_not_emits` passes when the needle is genuinely absent.


### PR DESCRIPTION
## Summary

- keep rendering on the source screen for the rest of a navigation frame while applying the `ScreenState` mutation immediately after the active closure returns
- scope deferred navigation per nested `screen` call so an inner screen cannot drain or misapply an outer screen's requests
- reject navigation helpers outside an active `screen` closure with actionable guidance instead of silently routing them to a later screen
- document the frame boundary and direct `ScreenState` mutation outside screen closures

This is a functional follow-up to #283. The documented API compiled correctly, but exercising it end to end exposed a one-frame source/destination blend in terminal output.

## Regression coverage

- push transition with source declared before destination
- pop transition with destination declared before source
- nested screens backed by independent `ScreenState` values
- invalid navigation outside a screen closure
- PTY/ANSI flush output proving one view per frame

## Validation

- `cargo fmt -- --check`
- `cargo check --all-features`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo check --examples --all-features`
- `typos`
- `cargo check -p superlighttui --no-default-features`
- `cargo check -p slt-wasm --target wasm32-unknown-unknown`
- `cargo hack check -p superlighttui --each-feature --no-dev-deps`
- `cargo audit`
- `cargo deny check`
- Rust 1.88 check and Clippy
- WASM-target Clippy
- rustdoc with `-D warnings`
