### PR TITLE
feat: v0.22.3 — screen navigation and security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.22.3] - 2026-07-31
+
+Patch release preventing mixed terminal frames during screen navigation,
+correcting the documented navigation API, and resolving two RustSec findings.
+
+### Fixed
+
+- **Single-view screen transitions** (#307) — `push_screen`, `pop_screen`, and
+  `reset_screen` still update `ScreenState` when the active closure returns,
+  but the transition frame now finishes rendering only its source screen. The
+  destination starts on the next frame, so both views cannot be composed into
+  one terminal buffer.
+- **Nested screen navigation isolation** (#307) — deferred navigation is scoped
+  to the exact active `screen(...)` closure, preventing an inner screen from
+  draining or applying an outer screen's request to the wrong `ScreenState`.
+- **Invalid navigation diagnostics** (#307) — calling screen-navigation helpers
+  outside an active `screen(...)` closure now fails immediately with guidance
+  to mutate `ScreenState` directly instead of silently targeting a later screen.
+- **RustSec dependency findings** (#305, #306) — updated `crossbeam-epoch` for
+  RUSTSEC-2026-0204 and `anyhow` for RUSTSEC-2026-0190.
+
+### Docs
+
+- **Screen navigation patterns** (#283, #307) — examples now use
+  `ui.push_screen(...)`, `ui.pop_screen()`, and `ui.reset_screen()`, and document
+  the source-frame/destination-frame transition contract.
+
 ## [0.22.2] - 2026-06-28
 
 Patch release preparation focused on terminal safety, browser backend lifecycle,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,7 +1203,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slt-wasm"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "js-sys",
  "superlighttui",
@@ -1232,7 +1232,7 @@ checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "superlighttui"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "compact_str",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ private_intra_doc_links = "warn"
 
 [package]
 name = "superlighttui"
-version = "0.22.2"
+version = "0.22.3"
 edition = "2024"
 description = "Super Light TUI - A lightweight, ergonomic terminal UI library"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The same closure runs across several entry points. Pick one based on UI shape, n
 
 ```toml
 [dependencies]
-superlighttui = { version = "0.22.2", features = ["async", "image"] }
+superlighttui = { version = "0.22.3", features = ["async", "image"] }
 ```
 
 | Feature | What it adds |

--- a/crates/slt-wasm/Cargo.toml
+++ b/crates/slt-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slt-wasm"
-version = "0.22.2"
+version = "0.22.3"
 edition = "2024"
 rust-version = "1.88"
 description = "WASM/browser backend for SuperLightTUI"
@@ -10,7 +10,7 @@ homepage = "https://github.com/subinium/SuperLightTUI"
 documentation = "https://docs.rs/slt-wasm"
 
 [dependencies]
-superlighttui = { version = "0.22.2", path = "../..", default-features = false }
+superlighttui = { version = "0.22.3", path = "../..", default-features = false }
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = [
     "CssStyleDeclaration",


### PR DESCRIPTION
## v0.22.3

Patch release preventing mixed terminal frames during screen navigation,
correcting the documented navigation API, and resolving two RustSec findings.

### Fixed

- **Single-view screen transitions** (#307) — screen navigation updates state when the active closure returns while keeping the transition frame on its source screen; the destination starts on the next frame.
- **Nested screen navigation isolation** (#307) — inner and outer screen closures now apply deferred navigation to their own `ScreenState` values.
- **Invalid navigation diagnostics** (#307) — helpers called outside an active screen closure fail immediately with direct-`ScreenState` guidance.
- **RustSec dependency findings** (#305, #306) — update `crossbeam-epoch` for RUSTSEC-2026-0204 and `anyhow` for RUSTSEC-2026-0190.

### Docs

- **Screen navigation patterns** (#283, #307) — examples use the `Context` navigation helpers and document the one-view-per-frame transition contract.

### Version coordination

- bump `superlighttui` and `slt-wasm` to 0.22.3
- update the `slt-wasm -> superlighttui` requirement and lockfile
- update the README installation snippet and changelog

### Local release gate

- `cargo fmt -- --check`
- `cargo check --all-features`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo check --examples --all-features`
- `typos`
- `cargo check -p superlighttui --no-default-features`
- `cargo check -p slt-wasm --target wasm32-unknown-unknown`
- `cargo hack check -p superlighttui --each-feature --no-dev-deps`
- `cargo audit`
- `cargo deny check`
- packaged and rebuilt the `superlighttui 0.22.3` crate archive

The tag-triggered release workflow repeats the full gate, verifies all three version values against the tag, publishes `superlighttui`, waits for its crates.io index entry, publishes `slt-wasm`, and creates the GitHub release from `CHANGELOG.md`.
