### PR TITLE
docs: fix context borrowing examples and audit gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Context injection examples** (#281) — shared-context examples now take an
+  owned snapshot before subsequent mutable UI calls, avoiding overlapping
+  `&Context` / `&mut Context` borrows.
+
+### Docs
+
+- **Rustdoc audit follow-up** (#244) — completed the remaining status-widget
+  examples, gauge-family links, animation links, state-access panic contracts,
+  and defensive consuming-builder documentation.
+
 ## [0.22.3] - 2026-07-31
 
 Patch release preventing mixed terminal frames during screen navigation,

--- a/docs/AI_GUIDE.md
+++ b/docs/AI_GUIDE.md
@@ -124,6 +124,7 @@ When a value is *read* by many nested render functions (theme, current tick, cur
 // `provide` boxes the value as `dyn Any`, so the type must satisfy `T: 'static`.
 // `Theme` is `Copy`, so deref-copy from `ui.theme()`. Use `&'static str` for
 // string literals; switch to `String` if the value comes from runtime input.
+#[derive(Clone, Copy)]
 struct AppCtx {
     theme: slt::Theme,
     tick: u64,
@@ -139,10 +140,15 @@ slt::run(|ui: &mut slt::Context| {
 });
 
 fn render_card(ui: &mut slt::Context) {
-    let ctx = ui.use_context::<AppCtx>();
+    // End the immutable borrow before the next `&mut ui` widget call.
+    let ctx = *ui.use_context::<AppCtx>();
     ui.text(format!("hi {} (tick {})", ctx.user, ctx.tick));
 }
 ```
+
+`use_context` and `try_use_context` return references tied to `ui`. Never keep
+one across a widget call: copy or clone the whole value (or just the fields the
+component needs) first.
 
 Reserve explicit parameters for **writes** (e.g. `&mut MyDocState`) — those should still be passed in, not read out of the context bag. See [PATTERNS.md](PATTERNS.md) for the full pattern.
 

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -641,6 +641,7 @@ use slt::{Border, Color, Context, KeyCode, Theme};
 // `provide` boxes the value as `dyn Any`, requiring `T: 'static`. `Theme` is
 // `Copy`, so deref-copy from `ui.theme()`. `&'static str` works for string
 // literals; switch to `String` for runtime values.
+#[derive(Clone, Copy)]
 struct AppCtx {
     theme: Theme,
     tick: u64,
@@ -674,14 +675,14 @@ fn main() -> std::io::Result<()> {
 }
 
 fn render_header(ui: &mut Context) {
-    let ctx = ui.use_context::<AppCtx>();
+    let ctx = *ui.use_context::<AppCtx>();
     ui.text(format!("hi, {}", ctx.user)).bold().fg(Color::Cyan);
     ui.text(format!("tick {}", ctx.tick)).dim();
 }
 
 fn render_card(ui: &mut Context) {
     // Optional read — never panics if no provider is on the stack.
-    if let Some(ctx) = ui.try_use_context::<AppCtx>() {
+    if let Some(ctx) = ui.try_use_context::<AppCtx>().copied() {
         ui.text(format!("theme bg: {:?}", ctx.theme.bg));
     } else {
         ui.text("no app context").dim();
@@ -694,6 +695,8 @@ fn render_card(ui: &mut Context) {
 - `provide` is scoped to the closure body. Once that body returns, the value pops off the context stack.
 - `use_context::<T>()` finds the nearest provided `T` by type. Two providers of the same type stack — the inner one wins inside its body.
 - Use `try_use_context` in helpers that should also work outside the provider (e.g. unit tests, isolated demos).
+- `use_context` returns a reference tied to `ui`. Copy or clone the required
+  value before calling a widget method that needs `&mut ui`.
 
 ---
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -253,6 +253,7 @@ Some values want to propagate through a deep tree without being passed to every 
 ```rust
 use slt::{Color, Context};
 
+#[derive(Clone)]
 struct AppContext {
     username: String,
     show_debug: bool,
@@ -271,7 +272,9 @@ fn main() -> std::io::Result<()> {
 }
 
 fn render_home(ui: &mut Context) {
-    let app = ui.use_context::<AppContext>();
+    // `use_context` returns `&T`, which borrows `ui`. Take an owned snapshot
+    // before calling methods that need `&mut ui`.
+    let app = ui.use_context::<AppContext>().clone();
     ui.text(format!("Hello, {}", app.username));
     if app.show_debug {
         ui.text("debug mode on").dim();
@@ -284,10 +287,13 @@ How it behaves:
 - **Scoped.** The value is alive only inside the body closure passed to `provide`. Outside that closure, `use_context::<AppContext>()` panics — there is no value.
 - **Shadowing.** Nested `provide` calls of the same type shadow the outer one for the duration of the inner closure. Think of it as a LIFO stack, one stack per `TypeId`.
 - **Optional reads.** `try_use_context::<T>() -> Option<&T>` returns `None` instead of panicking. Use it when a component should work both inside and outside the provider.
+- **Snapshot before rendering.** A context reference borrows `ui`. Copy or clone
+  only the fields a component needs before the next `ui.*` call; do not hold
+  `&T` across calls that mutably borrow `ui`.
 
 ```rust
 fn render_footer(ui: &mut Context) {
-    if let Some(app) = ui.try_use_context::<AppContext>() {
+    if let Some(app) = ui.try_use_context::<AppContext>().cloned() {
         ui.text(format!("logged in as {}", app.username)).dim();
     } else {
         ui.text("anonymous").dim();

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -1046,6 +1046,8 @@ impl Context {
     /// - [`animate_value`](Self::animate_value) — the underlying primitive this
     ///   delegates to; use it for a custom duration or a non-binary target.
     /// - [`Tween`](crate::Tween) — full control over easing and lifecycle.
+    /// - [`Spring`](crate::Spring) — physics-based motion that reacts smoothly
+    ///   when its target changes.
     pub fn animate_bool(&mut self, id: &'static str, value: bool) -> f64 {
         let target = if value { 1.0 } else { 0.0 };
         self.animate_value(id, target, crate::anim::DEFAULT_ANIMATE_TICKS)
@@ -1092,6 +1094,8 @@ impl Context {
     /// - [`animate_bool`](Self::animate_bool) — boolean-driven shorthand that
     ///   tweens between `0.0` and `1.0`.
     /// - [`Tween`](crate::Tween) — explicit easing and lifecycle control.
+    /// - [`Spring`](crate::Spring) — physics-based motion for frequently
+    ///   changing targets.
     pub fn animate_value(&mut self, id: &'static str, target: f64, duration_ticks: u64) -> f64 {
         let tick = self.tick;
         let entry = self
@@ -1548,6 +1552,26 @@ impl Context {
     ///
     /// Panics if no value of type `T` is currently provided. Use
     /// [`try_use_context`](Self::try_use_context) for a non-panicking variant.
+    ///
+    /// # Example
+    ///
+    /// Take an owned snapshot before calling methods that need `&mut Context`:
+    ///
+    /// ```no_run
+    /// #[derive(Clone)]
+    /// struct AppContext {
+    ///     username: String,
+    ///     show_debug: bool,
+    /// }
+    ///
+    /// fn render_home(ui: &mut slt::Context) {
+    ///     let app = ui.use_context::<AppContext>().clone();
+    ///     ui.text(format!("Hello, {}", app.username));
+    ///     if app.show_debug {
+    ///         ui.text("debug mode on").dim();
+    ///     }
+    /// }
+    /// ```
     pub fn use_context<T: 'static>(&self) -> &T {
         self.try_use_context::<T>().unwrap_or_else(|| {
             panic!(

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -79,6 +79,14 @@ impl<T: 'static> State<T> {
     }
 
     /// Read the current value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this handle's slot or id contains a different concrete type,
+    /// which means positional hooks changed order or the same named/keyed id
+    /// was reused with another `T`. Named and keyed handles also panic if their
+    /// backing entry was removed before access. The message identifies the
+    /// hook index or id and the expected type.
     pub fn get<'a>(&self, ui: &'a Context) -> &'a T {
         match &self.key {
             StateKey::Indexed(idx) => downcast_or_panic::<T>(
@@ -107,6 +115,11 @@ impl<T: 'static> State<T> {
     }
 
     /// Mutably access the current value.
+    ///
+    /// # Panics
+    ///
+    /// Panics under the same slot, id, and type-mismatch conditions as
+    /// [`get`](Self::get).
     pub fn get_mut<'a>(&self, ui: &'a mut Context) -> &'a mut T {
         match &self.key {
             StateKey::Indexed(idx) => downcast_or_panic_mut::<T>(

--- a/src/context/widgets_display/gauge.rs
+++ b/src/context/widgets_display/gauge.rs
@@ -87,6 +87,11 @@ impl Context {
 /// `Drop` is intentional: `ui.gauge(0.5).label("CPU");` is the idiomatic form
 /// when the response isn't needed, mirroring egui's `ui.add(...)`. Use
 /// [`Self::show`] when you need the response.
+///
+/// # Family
+///
+/// Use [`LineGauge`] for a compact single-line bar with a trailing label, or
+/// [`Context::progress_bar`] / [`Context::progress`] for an unlabeled bar.
 pub struct Gauge<'a> {
     ctx: Option<&'a mut Context>,
     ratio: f64,
@@ -135,8 +140,11 @@ impl<'a> Gauge<'a> {
 
     /// Render now and return the [`GaugeResponse`].
     pub fn show(mut self) -> GaugeResponse {
-        // SAFETY: ctx is Some until Drop runs; show consumes self before Drop.
-        let ctx = self.ctx.take().expect("Gauge::show called twice");
+        let Some(ctx) = self.ctx.take() else {
+            // `show` consumes the builder, so safe code cannot reach this
+            // branch. Stay defensive if the internal invariant changes.
+            return GaugeResponse::default();
+        };
         render_gauge(
             ctx,
             self.ratio,
@@ -169,6 +177,11 @@ impl Drop for Gauge<'_> {
 ///
 /// `Drop` is intentional: `ui.line_gauge(0.5).filled('━');` is the idiomatic
 /// form when the response isn't needed.
+///
+/// # Family
+///
+/// Use [`Gauge`] for a block-fill bar with a centered label, or
+/// [`Context::progress_bar`] / [`Context::progress`] for an unlabeled bar.
 pub struct LineGauge<'a> {
     ctx: Option<&'a mut Context>,
     ratio: f64,
@@ -225,7 +238,11 @@ impl<'a> LineGauge<'a> {
 
     /// Render now and return the [`GaugeResponse`].
     pub fn show(mut self) -> GaugeResponse {
-        let ctx = self.ctx.take().expect("LineGauge::show called twice");
+        let Some(ctx) = self.ctx.take() else {
+            // `show` consumes the builder, so safe code cannot reach this
+            // branch. Stay defensive if the internal invariant changes.
+            return GaugeResponse::default();
+        };
         render_line_gauge(
             ctx,
             self.ratio,

--- a/src/context/widgets_display/status.rs
+++ b/src/context/widgets_display/status.rs
@@ -215,6 +215,17 @@ impl Context {
     }
 
     /// Collapsible section that toggles on click, Enter, or Space.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # let mut open = true;
+    /// # slt::run(|ui: &mut slt::Context| {
+    /// ui.accordion("Advanced", &mut open, |ui| {
+    ///     ui.text("Expert settings");
+    /// });
+    /// # });
+    /// ```
     pub fn accordion(
         &mut self,
         title: &str,
@@ -609,18 +620,42 @@ impl Context {
     }
 
     /// Render a code block with language-aware syntax highlighting.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # slt::run(|ui: &mut slt::Context| {
+    /// ui.code_block("fn main() {}").lang("rust");
+    /// # });
+    /// ```
     #[deprecated(since = "0.21.0", note = "use `code_block(code).lang(lang)`")]
     pub fn code_block_lang(&mut self, code: &str, lang: &str) -> Response {
         render_code_block(self, code, lang, false)
     }
 
     /// Render a code block with line numbers and keyword highlighting.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # slt::run(|ui: &mut slt::Context| {
+    /// ui.code_block("let first = 1;\nlet second = 2;").numbered();
+    /// # });
+    /// ```
     #[deprecated(since = "0.21.0", note = "use `code_block(code).numbered()`")]
     pub fn code_block_numbered(&mut self, code: &str) -> Response {
         render_code_block(self, code, "", true)
     }
 
     /// Render a code block with line numbers and language-aware highlighting.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # slt::run(|ui: &mut slt::Context| {
+    /// ui.code_block("fn main() {}").lang("rust").numbered();
+    /// # });
+    /// ```
     #[deprecated(
         since = "0.21.0",
         note = "use `code_block(code).lang(lang).numbered()`"
@@ -783,7 +818,11 @@ impl<'a> Breadcrumb<'a> {
 
     /// Render now and return the [`BreadcrumbResponse`].
     pub fn show(mut self) -> BreadcrumbResponse {
-        let ctx = self.ctx.take().expect("Breadcrumb::show called twice");
+        let Some(ctx) = self.ctx.take() else {
+            // `show` consumes the builder, so safe code cannot reach this
+            // branch. Stay defensive if the internal invariant changes.
+            return BreadcrumbResponse::default();
+        };
         render_breadcrumb(ctx, self.segments, self.separator, self.color)
     }
 }


### PR DESCRIPTION
## Summary

- teach an owned-snapshot pattern for `use_context` / `try_use_context` before mutable widget calls
- add a compiling rustdoc regression for the borrow-checker failure reported in #281
- finish the remaining status-widget examples and gauge-family links from the v0.20 docs audit
- document the real `State::get` / `get_mut` panic boundary and link animation helpers to both `Tween` and `Spring`
- make consuming gauge/breadcrumb builders defensive instead of carrying unreachable `expect` branches

## Notes

The positional/named/keyed state constructor methods no longer downcast directly; their handles do. The panic contract is therefore documented on `State::get` and `State::get_mut`, rather than claiming that non-panicking constructors panic.

## Validation

- full local Core Gate
- full local Extended Gate
- 306 rustdoc tests passed (30 ignored)
- RustSec: 0 vulnerabilities
- cargo-hack: 29 feature combinations passed

Closes #281
Closes #244