### PR TITLE
fix: harden terminal probes across platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,19 @@ jobs:
       # cross-test contamination was fixed at the source.
       - run: cargo test --all-features
 
+  platform-test:
+    name: Test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test -p superlighttui --all-features
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-features
 
+  platform-test:
+    name: Test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test -p superlighttui --all-features
+
   examples:
     name: Examples
     runs-on: ubuntu-latest
@@ -207,6 +222,7 @@ jobs:
       - check-stable
       - clippy
       - test
+      - platform-test
       - examples
       - msrv
       - typos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 - **Context injection examples** (#281) — shared-context examples now take an
   owned snapshot before subsequent mutable UI calls, avoiding overlapping
   `&Context` / `&mut Context` borrows.
+- **Terminal query safety** — automatic capability probes now skip generic PTY
+  wrappers, `TERM=dumb`, and tmux/screen by default, preventing control-sequence
+  leaks and a race that could consume the first byte of user input. Kitty
+  keyboard setup and cleanup now also emit portable protocol bytes on Windows,
+  and optional mode teardown can no longer abort core terminal restoration.
+
+### Changed
+
+- **Native platform CI** — macOS and Windows now run the full
+  `superlighttui --all-features` test suite for pull requests and releases.
 
 ### Docs
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -47,6 +47,18 @@ What still remains:
 
 That makes SLT usable as a rendering core for non-terminal environments.
 
+## Terminal query safety
+
+The built-in runtime probes capabilities only when both stdin and stdout are
+TTYs and the environment identifies a direct terminal emulator. It skips
+generic PTY wrappers, `TERM=dumb`, and tmux/screen sessions by default so a
+silent host cannot leak query bytes or race the first user keystroke.
+
+- Set `SLT_DISABLE_TERMINAL_QUERIES=1` to disable all terminal queries.
+- Set `SLT_FORCE_TERMINAL_QUERIES=1` to opt in on an otherwise skipped host.
+- Image-protocol force flags (`SLT_FORCE_KITTY`, `SLT_FORCE_SIXEL`, and
+  `SLT_FORCE_ITERM`) remain independent.
+
 ## Recommended combos
 
 | Goal | Suggested dependency |

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -328,7 +328,7 @@ pub(crate) fn cell_pixel_size() -> (u32, u32) {
 }
 
 fn detect_cell_pixel_size() -> Option<(u32, u32)> {
-    if !terminal_queries_allowed() {
+    if !automatic_terminal_queries_allowed() {
         return None;
     }
 
@@ -516,15 +516,20 @@ impl Capabilities {
 /// Return the process-global negotiated [`Capabilities`], probing the terminal
 /// exactly once on first call and caching the result.
 ///
-/// The probe issues DA1 (`CSI c`), DA2 (`CSI > c`), and XTGETTCAP for the
-/// truecolor capname, reading replies through the existing OSC round-trip
-/// infrastructure with a bounded total timeout (≤150ms). On no reply every
-/// field falls back to a conservative default. Repeated calls are free.
+/// On an identified direct terminal, the probe issues DA1 (`CSI c`), DA2
+/// (`CSI > c`), and XTGETTCAP for the truecolor capname, reading replies
+/// through the existing OSC round-trip infrastructure with a bounded total
+/// timeout (≤180ms). Generic PTY wrappers, `TERM=dumb`, and tmux/screen skip
+/// automatic queries to avoid leaking control bytes or racing user input;
+/// environment-based fallbacks remain available. Set
+/// `SLT_FORCE_TERMINAL_QUERIES=1` to opt in or
+/// `SLT_DISABLE_TERMINAL_QUERIES=1` to disable all terminal queries. Repeated
+/// calls are free.
 #[cfg(feature = "crossterm")]
 #[cfg_attr(docsrs, doc(cfg(feature = "crossterm")))]
 pub fn capabilities() -> Capabilities {
     use std::sync::OnceLock;
-    if !terminal_queries_allowed() {
+    if !io::stdout().is_terminal() {
         return Capabilities::default();
     }
     static CACHED: OnceLock<Capabilities> = OnceLock::new();
@@ -539,64 +544,54 @@ pub fn capabilities() -> Capabilities {
 #[cfg(feature = "crossterm")]
 fn probe_capabilities() -> Capabilities {
     let mut caps = Capabilities::default();
-    if !terminal_queries_allowed() {
-        return caps;
-    }
+    if automatic_terminal_queries_allowed() {
+        // Total stdin wait is bounded to ≤180ms (90 + 30 + 30 + 30) so a
+        // silent terminal cannot stall startup beyond a small multiple of the
+        // existing OSC-11 budget. A responsive terminal replies in well under
+        // 10ms per query, so the common path adds negligible latency.
+        let mut out = io::stdout();
+        // DA1 then DA2 in one write — both terminate with `c`, so a single
+        // DA-aware read drains both replies (in order) when supported.
+        if write!(out, "\x1b[c\x1b[>c").is_ok()
+            && out.flush().is_ok()
+            && let Some(resp) = read_da_response(Duration::from_millis(90))
+        {
+            parse_da1(&resp, &mut caps);
+            parse_da2(&resp, &mut caps);
+        }
 
-    // Total stdin wait is bounded to ≤180ms (90 + 30 + 30 + 30) so a silent
-    // terminal cannot stall startup beyond a small multiple of the existing
-    // OSC-11 budget. A responsive terminal replies in well under 10ms per
-    // query, so the common path adds negligible latency.
-    let mut out = io::stdout();
-    // DA1 then DA2 in one write — both terminate with `c`, so a single
-    // DA-aware read drains both replies (in order) when supported.
-    if write!(out, "\x1b[c\x1b[>c").is_ok()
-        && out.flush().is_ok()
-        && let Some(resp) = read_da_response(Duration::from_millis(90))
-    {
-        parse_da1(&resp, &mut caps);
-        parse_da2(&resp, &mut caps);
-    }
+        // Kitty graphics query: APC G a=q (query) with a 1×1 RGB direct
+        // payload. Base64 of three zero bytes = "AAAA".
+        if write!(out, "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\").is_ok()
+            && out.flush().is_ok()
+            && let Some(resp) = read_osc_response(Duration::from_millis(30))
+        {
+            parse_kitty_graphics_ack(&resp, &mut caps);
+        }
 
-    // Kitty graphics query: APC G a=q (query) with a 1×1 RGB direct payload.
-    // Supporting terminals ack with `APC G i=31;OK ST`; others stay silent so
-    // the bounded read just times out. Base64 of three zero bytes = "AAAA".
-    if write!(out, "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\").is_ok()
-        && out.flush().is_ok()
-        && let Some(resp) = read_osc_response(Duration::from_millis(30))
-    {
-        parse_kitty_graphics_ack(&resp, &mut caps);
-    }
+        // XTGETTCAP for the `Tc` (truecolor) capname: `Tc` -> hex "5463".
+        if write!(out, "\x1bP+q5463\x1b\\").is_ok()
+            && out.flush().is_ok()
+            && let Some(resp) = read_osc_response(Duration::from_millis(30))
+        {
+            parse_xtgettcap_truecolor(&resp, &mut caps);
+        }
 
-    // XTGETTCAP for the `Tc` (truecolor) capname: DCS + q <hex> ST.
-    // `Tc` -> hex "5463".
-    if write!(out, "\x1bP+q5463\x1b\\").is_ok()
-        && out.flush().is_ok()
-        && let Some(resp) = read_osc_response(Duration::from_millis(30))
-    {
-        parse_xtgettcap_truecolor(&resp, &mut caps);
-    }
-
-    // DECRQM for synchronized output (mode ?2026): CSI ? 2026 $ p. A supporting
-    // terminal replies CSI ? 2026 ; <Ps> $ y, where Ps ∈ {1,2} (set / reset)
-    // both mean *recognized*; Ps = 0 means the mode is not recognized. The
-    // reply terminates with `y` rather than BEL / ST, so it needs the
-    // DECRPM-aware reader. A silent terminal leaves the resolution `Unknown`,
-    // which the flush gate treats as "keep emitting" — preserving the historic
-    // always-emit behavior on headless / non-answering hosts.
-    if write!(out, "\x1b[?2026$p").is_ok()
-        && out.flush().is_ok()
-        && let Some(resp) = read_decrpm_response(Duration::from_millis(30))
-    {
-        match parse_decrpm_sync_output(&resp) {
-            Some(true) => {
-                caps.sync_output = true;
-                let _ = SYNC_OUTPUT_RESOLUTION.set(SyncOutputResolution::Supported);
+        // DECRQM for synchronized output (mode ?2026): CSI ? 2026 $ p.
+        if write!(out, "\x1b[?2026$p").is_ok()
+            && out.flush().is_ok()
+            && let Some(resp) = read_decrpm_response(Duration::from_millis(30))
+        {
+            match parse_decrpm_sync_output(&resp) {
+                Some(true) => {
+                    caps.sync_output = true;
+                    let _ = SYNC_OUTPUT_RESOLUTION.set(SyncOutputResolution::Supported);
+                }
+                Some(false) => {
+                    let _ = SYNC_OUTPUT_RESOLUTION.set(SyncOutputResolution::Unsupported);
+                }
+                None => {}
             }
-            Some(false) => {
-                let _ = SYNC_OUTPUT_RESOLUTION.set(SyncOutputResolution::Unsupported);
-            }
-            None => {}
         }
     }
 
@@ -757,11 +752,70 @@ fn truthy_env_value(value: &str) -> bool {
 
 #[cfg(feature = "crossterm")]
 fn terminal_queries_allowed() -> bool {
-    terminal_query_allowed(io::stdout().is_terminal(), io::stdin().is_terminal())
+    let term = std::env::var("TERM").unwrap_or_default();
+    terminal_query_allowed(
+        io::stdout().is_terminal(),
+        io::stdin().is_terminal(),
+        &term,
+        terminal_is_multiplexed(),
+        force_env_enabled("SLT_FORCE_TERMINAL_QUERIES"),
+        force_env_enabled("SLT_DISABLE_TERMINAL_QUERIES"),
+    )
 }
 
-fn terminal_query_allowed(stdout_is_terminal: bool, stdin_is_terminal: bool) -> bool {
-    stdout_is_terminal && stdin_is_terminal
+#[cfg(feature = "crossterm")]
+fn automatic_terminal_queries_allowed() -> bool {
+    if !terminal_queries_allowed() {
+        return false;
+    }
+    force_env_enabled("SLT_FORCE_TERMINAL_QUERIES") || terminal_query_host_is_identified()
+}
+
+#[cfg(feature = "crossterm")]
+fn terminal_query_host_is_identified() -> bool {
+    const IDENTITY_VARS: &[&str] = &[
+        "TERM_PROGRAM",
+        "WT_SESSION",
+        "VTE_VERSION",
+        "KONSOLE_VERSION",
+        "KITTY_WINDOW_ID",
+    ];
+    if IDENTITY_VARS
+        .iter()
+        .any(|name| std::env::var_os(name).is_some_and(|value| !value.is_empty()))
+    {
+        return true;
+    }
+
+    let term = std::env::var("TERM")
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    terminal_query_host_is_identified_env(&term, false)
+}
+
+fn terminal_query_host_is_identified_env(term: &str, has_identity_var: bool) -> bool {
+    has_identity_var
+        || matches!(
+            term.to_ascii_lowercase().as_str(),
+            "alacritty" | "foot" | "foot-extra" | "mlterm" | "wezterm" | "xterm-kitty"
+        )
+}
+
+fn terminal_query_allowed(
+    stdout_is_terminal: bool,
+    stdin_is_terminal: bool,
+    term: &str,
+    multiplexed: bool,
+    forced: bool,
+    disabled: bool,
+) -> bool {
+    if !stdout_is_terminal || !stdin_is_terminal || disabled {
+        return false;
+    }
+    if forced {
+        return true;
+    }
+    !multiplexed && !term.is_empty() && !term.eq_ignore_ascii_case("dumb")
 }
 
 /// Process-wide pump that owns the only blocking `stdin` read used for
@@ -2858,11 +2912,7 @@ fn write_session_enter(stdout: &mut impl Write, session: &TerminalSessionGuard) 
         execute!(stdout, EnableMouseCapture)?;
     }
     if session.kitty_keyboard {
-        use crossterm::event::PushKeyboardEnhancementFlags;
-        let _ = execute!(
-            stdout,
-            PushKeyboardEnhancementFlags(kitty_flags(session.report_all_keys))
-        );
+        let _ = write_kitty_keyboard_push(stdout, session.report_all_keys);
     }
 
     Ok(())
@@ -2885,6 +2935,17 @@ fn kitty_flags(report_all_keys: bool) -> crossterm::event::KeyboardEnhancementFl
         flags |= KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES;
     }
     flags
+}
+
+/// Write Kitty keyboard protocol commands directly instead of routing them
+/// through crossterm's legacy Windows API, where these commands are reported
+/// as unsupported even when the terminal host accepts ANSI sequences.
+fn write_kitty_keyboard_push(stdout: &mut impl Write, report_all_keys: bool) -> io::Result<()> {
+    write!(stdout, "\x1b[>{}u", kitty_flags(report_all_keys).bits())
+}
+
+fn write_kitty_keyboard_pop(stdout: &mut impl Write) -> io::Result<()> {
+    stdout.write_all(b"\x1b[<1u")
 }
 
 fn write_session_cleanup(
@@ -2930,13 +2991,16 @@ fn write_session_exit(
     kitty_keyboard: bool,
 ) -> io::Result<()> {
     if kitty_keyboard {
-        use crossterm::event::PopKeyboardEnhancementFlags;
-        execute!(stdout, PopKeyboardEnhancementFlags)?;
+        write_kitty_keyboard_pop(stdout)?;
     }
     if mouse_enabled {
-        execute!(stdout, DisableMouseCapture)?;
+        // On Windows this uses crossterm's process-global console mode state,
+        // which may not have been initialized when panic cleanup runs. Mouse
+        // restoration is best-effort so it cannot prevent the core cursor,
+        // paste, and screen cleanup below.
+        let _ = execute!(stdout, DisableMouseCapture);
     }
-    execute!(stdout, DisableFocusChange)?;
+    let _ = execute!(stdout, DisableFocusChange);
     write_session_cleanup(stdout, mode, inline_reserved)
 }
 
@@ -3282,6 +3346,22 @@ mod tests {
     }
 
     #[test]
+    fn session_enter_writes_kitty_keyboard_flags_portably() {
+        let session = TerminalSessionGuard {
+            mode: TerminalSessionMode::Fullscreen,
+            mouse_enabled: false,
+            kitty_keyboard: true,
+            report_all_keys: true,
+            harness: false,
+        };
+        let mut out = Vec::new();
+        write_session_enter(&mut out, &session).unwrap();
+        let output = String::from_utf8(out).unwrap();
+        let expected = format!("\u{1b}[>{}u", kitty_flags(true).bits());
+        assert!(output.contains(&expected));
+    }
+
+    #[test]
     fn fullscreen_session_cleanup_leaves_alt_screen() {
         let mut out = Vec::new();
         write_session_cleanup(&mut out, TerminalSessionMode::Fullscreen, false).unwrap();
@@ -3307,7 +3387,11 @@ mod tests {
         let mut out = Vec::new();
         write_session_exit(&mut out, TerminalSessionMode::Fullscreen, false, true, true).unwrap();
         let output = String::from_utf8(out).unwrap();
+        // Crossterm manages mouse/focus through the Windows console API rather
+        // than writing those escape sequences to the supplied writer.
+        #[cfg(not(windows))]
         assert!(output.contains("\u{1b}[?1004l"), "disables focus reporting");
+        #[cfg(not(windows))]
         assert!(output.contains("\u{1b}[?1006l"), "disables SGR mouse mode");
         assert!(output.contains("\u{1b}[<1u"), "pops Kitty keyboard flags");
         assert!(output.contains("\u{1b}[?1049l"), "leaves alt screen");
@@ -3318,6 +3402,7 @@ mod tests {
         let mut out = Vec::new();
         write_panic_cleanup(&mut out).unwrap();
         let output = String::from_utf8(out).unwrap();
+        #[cfg(not(windows))]
         assert!(output.contains("\u{1b}[?1004l"), "disables focus reporting");
         assert!(output.contains("\u{1b}[<1u"), "pops Kitty keyboard flags");
         assert!(output.contains("\u{1b}[?1049l"), "leaves alt screen");
@@ -3838,11 +3923,72 @@ mod tests {
     }
 
     #[test]
-    fn terminal_query_guard_requires_stdin_and_stdout_tty() {
-        assert!(terminal_query_allowed(true, true));
-        assert!(!terminal_query_allowed(true, false));
-        assert!(!terminal_query_allowed(false, true));
-        assert!(!terminal_query_allowed(false, false));
+    fn terminal_query_guard_rejects_unsafe_hosts() {
+        assert!(terminal_query_allowed(
+            true,
+            true,
+            "xterm-256color",
+            false,
+            false,
+            false
+        ));
+        assert!(!terminal_query_allowed(
+            true,
+            false,
+            "xterm-256color",
+            false,
+            false,
+            false
+        ));
+        assert!(!terminal_query_allowed(
+            false,
+            true,
+            "xterm-256color",
+            false,
+            false,
+            false
+        ));
+        assert!(!terminal_query_allowed(
+            true, true, "dumb", false, false, false
+        ));
+        assert!(!terminal_query_allowed(
+            true,
+            true,
+            "screen-256color",
+            true,
+            false,
+            false
+        ));
+        assert!(!terminal_query_allowed(true, true, "", false, false, false));
+    }
+
+    #[test]
+    fn terminal_query_guard_honors_force_and_disable_precedence() {
+        assert!(terminal_query_allowed(
+            true, true, "dumb", true, true, false
+        ));
+        assert!(!terminal_query_allowed(
+            true,
+            true,
+            "xterm-kitty",
+            false,
+            true,
+            true
+        ));
+    }
+
+    #[test]
+    fn automatic_query_hosts_require_a_real_terminal_identity() {
+        assert!(!terminal_query_host_is_identified_env(
+            "xterm-256color",
+            false
+        ));
+        assert!(terminal_query_host_is_identified_env(
+            "xterm-256color",
+            true
+        ));
+        assert!(terminal_query_host_is_identified_env("xterm-kitty", false));
+        assert!(terminal_query_host_is_identified_env("foot", false));
     }
 
     #[test]

--- a/tests/run_static.rs
+++ b/tests/run_static.rs
@@ -1,12 +1,10 @@
 #[test]
 fn run_static_signature_compiles() {
-    let mut output = slt::StaticOutput::new();
-    output.println("Preparing...");
-
-    let result = slt::run_static(&mut output, 3, |ui| {
-        ui.text("dynamic");
-        ui.quit();
-    });
-
-    assert!(result.is_ok());
+    let _signature_check = || -> std::io::Result<()> {
+        let mut output = slt::StaticOutput::new();
+        slt::run_static(&mut output, 3, |ui| {
+            ui.text("dynamic");
+            ui.quit();
+        })
+    };
 }


### PR DESCRIPTION
## Summary

- restrict automatic terminal capability probes to identified direct terminal emulators
- skip query traffic for non-TTY streams, `TERM=dumb`, and tmux/screen unless explicitly forced
- add `SLT_FORCE_TERMINAL_QUERIES` and `SLT_DISABLE_TERMINAL_QUERIES` overrides
- emit Kitty keyboard push/pop sequences directly so crossterm's legacy Windows API cannot abort terminal cleanup
- make optional Windows console-mode teardown best-effort so cursor, paste, and alternate-screen restoration always continues
- make the `run_static` signature regression test compile-only so it never opens a live terminal under a PTY test runner
- add blocking macOS and Windows test jobs to both pull-request CI and the release gate
- document the query policy and record the changes under Unreleased

## Why

A real-PTY run exposed two compatibility hazards: a compile-signature test could emit terminal query sequences, and a silent or generic PTY host could leave the reply pump racing the first byte of user input. Automatic probing now requires a direct-terminal identity, while environment fallbacks remain available without terminal I/O.

The first Windows CI run exposed a separate cleanup bug: crossterm 0.28 reports Kitty keyboard commands as unsupported through its legacy Windows API. The next run exposed that mouse cleanup can also report `Initial console modes not set` when panic cleanup has no initialized session. Either error previously returned before focus, bracketed paste, cursor, and alternate-screen cleanup ran. SLT now writes the standard Kitty ANSI protocol bytes directly and treats optional console-mode teardown as best-effort while preserving core restoration.

## Validation

- `cargo fmt -- --check`
- `cargo check --all-features`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features` (847 core unit tests plus integration and doctests)
- `cargo check --examples --all-features`
- `typos`
- `cargo check -p superlighttui --no-default-features`
- `cargo check -p slt-wasm --target wasm32-unknown-unknown`
- `cargo hack check -p superlighttui --each-feature --no-dev-deps` (29 combinations)
- `cargo audit` (1,174 advisories loaded, no vulnerabilities)
- `cargo deny check`
- `cargo check -p superlighttui --features full,pty-test --target x86_64-pc-windows-gnu`
- real PTY smoke tests for `TERM=dumb` and an unidentified generic `xterm-256color` host; no query/control bytes were emitted
- workflow YAML parsed successfully

## Release note

This is an Unreleased post-v0.22.3 hardening change. It does not retag or mutate the published v0.22.3 artifact.
